### PR TITLE
add param 'order' to Create() and Image.Clone()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.3-wheezy
 MAINTAINER Abhishek Lekshmanan "abhishek.lekshmanan@gmail.com"
 
-ENV CEPH_VERSION giant
+ENV CEPH_VERSION hammer
 
 RUN echo deb http://ceph.com/debian-$CEPH_VERSION/ wheezy main | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list
 

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -144,10 +144,10 @@ func GetImage(ioctx *rados.IOContext, name string) *Image {
 // int rbd_create3(rados_ioctx_t io, const char *name, uint64_t size,
 //        uint64_t features, int *order,
 //        uint64_t stripe_unit, uint64_t stripe_count);
-func Create(ioctx *rados.IOContext, name string, size uint64,
+func Create(ioctx *rados.IOContext, name string, size uint64, order int,
 	args ...uint64) (image *Image, err error) {
 	var ret C.int
-	var c_order C.int
+	var c_order C.int = C.int(order)
 	var c_name *C.char = C.CString(name)
 	defer C.free(unsafe.Pointer(c_name))
 
@@ -185,8 +185,8 @@ func Create(ioctx *rados.IOContext, name string, size uint64,
 //            const char *p_snapname, rados_ioctx_t c_ioctx,
 //            const char *c_name, uint64_t features, int *c_order,
 //            uint64_t stripe_unit, int stripe_count);
-func (image *Image) Clone(snapname string, c_ioctx *rados.IOContext, c_name string, features uint64) (*Image, error) {
-	var c_order C.int
+func (image *Image) Clone(snapname string, c_ioctx *rados.IOContext, c_name string, features uint64, order int) (*Image, error) {
+	var c_order C.int = C.int(order)
 	var c_p_name *C.char = C.CString(image.name)
 	var c_p_snapname *C.char = C.CString(snapname)
 	var c_c_name *C.char = C.CString(c_name)

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -38,7 +38,7 @@ func TestGetImageNames(t *testing.T) {
 	createdList := []string{}
 	for i := 0; i < 10; i++ {
 		name := GetUUID()
-		_, err := rbd.Create(ioctx, name, 1<<22)
+		_, err := rbd.Create(ioctx, name, 1<<22, 22)
 		assert.NoError(t, err)
 		createdList = append(createdList, name)
 	}
@@ -74,7 +74,7 @@ func TestIOReaderWriter(t *testing.T) {
 	assert.NoError(t, err)
 
 	name := GetUUID()
-	img, err := rbd.Create(ioctx, name, 1<<22)
+	img, err := rbd.Create(ioctx, name, 1<<22, 22)
 	assert.NoError(t, err)
 
 	err = img.Open()
@@ -136,7 +136,7 @@ func TestCreateSnapshot(t *testing.T) {
 	assert.NoError(t, err)
 
 	name := GetUUID()
-	img, err := rbd.Create(ioctx, name, 1<<22)
+	img, err := rbd.Create(ioctx, name, 1<<22, 22)
 	assert.NoError(t, err)
 
 	err = img.Open()
@@ -176,7 +176,7 @@ func TestParentInfo(t *testing.T) {
 	assert.NoError(t, err)
 
 	name := "parent"
-	img, err := rbd.Create(ioctx, name, 1<<22, 1)
+	img, err := rbd.Create(ioctx, name, 1<<22, 22, 1)
 	assert.NoError(t, err)
 
 	err = img.Open()
@@ -188,7 +188,7 @@ func TestParentInfo(t *testing.T) {
 	err = snapshot.Protect()
 	assert.NoError(t, err)
 
-	imgNew, err := img.Clone("mysnap", ioctx, "child", 1)
+	imgNew, err := img.Clone("mysnap", ioctx, "child", 1, 22)
 	assert.NoError(t, err)
 
 	err = imgNew.Open()


### PR DESCRIPTION
add param 'order' to `Create() ` and `Image.Clone()`. `giant` ceph version can on longer be installed through package,  upgrade ci ceph version to `hammer`. Reference to #6 

Signed-off-by: Crazykev <crazykev@zju.edu.cn>