### PR TITLE
Namespace support for Pools.

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -51,6 +51,17 @@ func (ioctx *IOContext) Pointer() uintptr {
 	return uintptr(ioctx.ioctx)
 }
 
+// SetNamespace sets the namespace for objects within this IO context (pool).
+// Setting namespace to a empty or zero length string sets the pool to the default namespace.
+func (ioctx *IOContext) SetNamespace(namespace string) {
+	var c_ns *C.char
+	if len(namespace) > 0 {
+		c_ns = C.CString(namespace)
+		defer C.free(unsafe.Pointer(c_ns))
+	}
+	C.rados_ioctx_set_namespace(ioctx.ioctx, c_ns)
+}
+
 // Write writes len(data) bytes to the object with key oid starting at byte
 // offset offset. It returns an error, if any.
 func (ioctx *IOContext) Write(oid string, data []byte, offset uint64) error {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -773,3 +773,44 @@ func TestReadFilterOmap(t *testing.T) {
 
 	pool.Destroy()
 }
+
+func TestSetNamespace(t *testing.T) {
+	conn, _ := rados.NewConn()
+	conn.ReadDefaultConfigFile()
+	conn.Connect()
+
+	pool_name := GetUUID()
+	err := conn.MakePool(pool_name)
+	assert.NoError(t, err)
+
+	pool, err := conn.OpenIOContext(pool_name)
+	assert.NoError(t, err)
+
+	bytes_in := []byte("input data")
+	err = pool.Write("obj", bytes_in, 0)
+	assert.NoError(t, err)
+
+	stat, err := pool.Stat("obj")
+	assert.Equal(t, uint64(len(bytes_in)), stat.Size)
+	assert.NotNil(t, stat.ModTime)
+
+	pool.SetNamespace("space1")
+	stat, err = pool.Stat("obj")
+	assert.Equal(t, err, rados.RadosErrorNotFound)
+
+	bytes_in = []byte("input data")
+	err = pool.Write("obj2", bytes_in, 0)
+	assert.NoError(t, err)
+
+	pool.SetNamespace("")
+
+	stat, err = pool.Stat("obj2")
+	assert.Equal(t, err, rados.RadosErrorNotFound)
+
+	stat, err = pool.Stat("obj")
+	assert.Equal(t, uint64(len(bytes_in)), stat.Size)
+	assert.NotNil(t, stat.ModTime)
+
+	pool.Destroy()
+	conn.Shutdown()
+}


### PR DESCRIPTION
This commit simply adds a SetNamespace() method to IOContext, allowing users to
perform pool operations in the context of a specific namespace.