### PR TITLE
Pool iterator: Implement Iter() interface to allow incremental listing of Pools.

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -536,3 +536,77 @@ func (ioctx *IOContext) CleanOmap(oid string) error {
 
 	return GetRadosError(ret)
 }
+
+type Iter struct {
+	ctx   C.rados_list_ctx_t
+	err   error
+	entry string
+}
+
+type IterToken uint32
+
+// Return a Iterator object that can be used to list the object names in the current pool
+func (ioctx *IOContext) Iter() (*Iter, error) {
+	iter := Iter{}
+	if cerr := C.rados_objects_list_open(ioctx.ioctx, &iter.ctx); cerr < 0 {
+		return nil, GetRadosError(cerr)
+	}
+	return &iter, nil
+}
+
+// Returns a token marking the current position of the iterator. To be used in combination with Iter.Seek()
+func (iter *Iter) Token() IterToken {
+	return IterToken(C.rados_objects_list_get_pg_hash_position(iter.ctx))
+}
+
+func (iter *Iter) Seek(token IterToken) {
+	C.rados_objects_list_seek(iter.ctx, C.uint32_t(token))
+}
+
+// Next retrieves the next object name in the pool/namespace iterator.
+// Upon a successful invocation (return value of true), the Value method should
+// be used to obtain the name of the retrieved object name. When the iterator is
+// exhausted, Next returns false. The Err method should used to verify whether the
+// end of the iterator was reached, or the iterator received an error.
+//
+// Example:
+//	iter := pool.Iter()
+//	defer iter.Close()
+//	for iter.Next() {
+//		fmt.Printf("%v\n", iter.Value())
+//	}
+//	return iter.Err()
+//
+func (iter *Iter) Next() bool {
+	centry := (*C.char)(C.calloc(1, 1024))
+	defer C.free(unsafe.Pointer(centry))
+
+	if cerr := C.rados_objects_list_next(iter.ctx, &centry, nil); cerr < 0 {
+		iter.err = GetRadosError(cerr)
+		return false
+	}
+	iter.entry = C.GoString(centry)
+	return true
+}
+
+// Returns the current value of the iterator (object name), after a successful call to Next.
+func (iter *Iter) Value() string {
+	if iter.err != nil {
+		return ""
+	}
+	return iter.entry
+}
+
+// Checks whether the iterator has encountered an error.
+func (iter *Iter) Err() error {
+	if iter.err == RadosErrorNotFound {
+		return nil
+	}
+	return iter.err
+}
+
+// Closes the iterator cursor on the server. Be aware that iterators are not closed automatically
+// at the end of iteration.
+func (iter *Iter) Close() {
+	C.rados_objects_list_close(iter.ctx)
+}

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -578,14 +578,12 @@ func (iter *Iter) Seek(token IterToken) {
 //	return iter.Err()
 //
 func (iter *Iter) Next() bool {
-	centry := (*C.char)(C.calloc(1, 1024))
-	defer C.free(unsafe.Pointer(centry))
-
-	if cerr := C.rados_objects_list_next(iter.ctx, &centry, nil); cerr < 0 {
+	var c_entry *C.char
+	if cerr := C.rados_objects_list_next(iter.ctx, &c_entry, nil); cerr < 0 {
 		iter.err = GetRadosError(cerr)
 		return false
 	}
-	iter.entry = C.GoString(centry)
+	iter.entry = C.GoString(c_entry)
 	return true
 }
 


### PR DESCRIPTION
The current IOContext struct has a ListObjects() method that works well for
pools with a reasonable number of objects. However, for very large pools, having
finer control over the iteration may be desirable.

This commit adds a new Iter() interface for pools. It allows callers to stop
iterating at any time by issuing a iter.Close(). It also allows callers to
"Seek" into the pool list using a token object.