### PR TITLE
continue after -ERANGE in retval of rbd_list_children

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -461,7 +461,10 @@ func (image *Image) ListChildren() (pools []string, images []string, err error) 
 	ret := C.rbd_list_children(image.image,
 		nil, &c_pools_len,
 		nil, &c_images_len)
-	if ret < 0 {
+	if ret == 0 {
+		return nil, nil, nil
+	}
+	if ret < 0 && ret != -C.ERANGE {
 		return nil, nil, RBDError(int(ret))
 	}
 


### PR DESCRIPTION
Adds check for `ERANGE`. Fixes https://github.com/ceph/go-ceph/issues/16

Thanks to @neurodrone for tracking down the behavior in librbd.