### PR TITLE
Update Dockerfile to Go 1.7.1 and Ceph Jewel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM golang:1.6-wheezy
+FROM golang:1.7.1
 MAINTAINER Abhishek Lekshmanan "abhishek.lekshmanan@gmail.com"
 
-ENV CEPH_VERSION hammer
+ENV CEPH_VERSION jewel
 
-RUN echo deb http://ceph.com/debian-$CEPH_VERSION/ wheezy main | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list
+RUN echo deb http://download.ceph.com/debian-$CEPH_VERSION/ jessie main | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list
 
 # Running wget with no certificate checks, alternatively ssl-cert package should be installed
 RUN wget --no-check-certificate -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add - \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ceph ceph-mds librados-dev librbd-dev libcephfs-dev \
+    && apt-get install -y --no-install-recommends \
+        ceph \
+        ceph-mds \
+        librados-dev \
+        librbd-dev \
+        libcephfs-dev \
+        uuid-runtime \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
This moves Go to 1.7.1, using Debian Jessie
Uses Ceph Jewel instead of Hammer
Uses download.ceph.com

Debian Jessie does not have `uuidgen` command by default, so
also needed to install uuid-runtime.

Signed-off-by: Travis Rhoden <trhoden@gmail.com>