### PR TITLE
Add test for ENOENT for omap

### DIFF
--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -979,3 +979,22 @@ func TestLocking(t *testing.T) {
 	pool.Destroy()
 	conn.Shutdown()
 }
+
+func TestOmapOnNonexistentObjectError(t *testing.T) {
+	conn, _ := rados.NewConn()
+	conn.ReadDefaultConfigFile()
+	conn.Connect()
+
+	pool_name := GetUUID()
+	err := conn.MakePool(pool_name)
+	assert.NoError(t, err)
+
+	pool, err := conn.OpenIOContext(pool_name)
+	assert.NoError(t, err)
+
+	//This object does not exist
+	objname := GetUUID()
+
+	_, err = pool.GetAllOmapValues(objname, "", "", 100)
+	assert.Equal(t, err, rados.RadosErrorNotFound)
+}


### PR DESCRIPTION
As requested in #32 this adds a test that fails at present.

We attempt to get omap values on an object that does not exist. We would like to get RadosErrorNotFound but instead we get IO Error.