### PR TITLE
Fix bogus duration handling in IOContext.Lock*

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -649,7 +649,7 @@ func (ioctx *IOContext) LockExclusive(oid, name, cookie, desc string, duration t
 
 	var c_duration C.struct_timeval
 	if duration != 0 {
-		tv := syscall.NsecToTimeval(time.Now().Add(duration).UnixNano())
+		tv := syscall.NsecToTimeval(duration.Nanoseconds())
 		c_duration = C.struct_timeval{tv_sec: C.__time_t(tv.Sec), tv_usec: C.__suseconds_t(tv.Usec)}
 	}
 
@@ -698,7 +698,7 @@ func (ioctx *IOContext) LockShared(oid, name, cookie, tag, desc string, duration
 
 	var c_duration C.struct_timeval
 	if duration != 0 {
-		tv := syscall.NsecToTimeval(time.Now().Add(duration).UnixNano())
+		tv := syscall.NsecToTimeval(duration.Nanoseconds())
 		c_duration = C.struct_timeval{tv_sec: C.__time_t(tv.Sec), tv_usec: C.__suseconds_t(tv.Usec)}
 	}
 

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -976,6 +976,28 @@ func TestLocking(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(info.Clients))
 
+	// lock sh with duration
+	res, err = pool.LockShared("obj", "myLock", "myCookie", "", "a description", time.Millisecond, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, res)
+
+	// verify lock sh expired
+	time.Sleep(time.Second)
+	info, err = pool.ListLockers("obj", "myLock")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(info.Clients))
+
+	// lock sh with duration
+	res, err = pool.LockExclusive("obj", "myLock", "myCookie", "a description", time.Millisecond, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, res)
+
+	// verify lock sh expired
+	time.Sleep(time.Second)
+	info, err = pool.ListLockers("obj", "myLock")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(info.Clients))
+
 	pool.Destroy()
 	conn.Shutdown()
 }


### PR DESCRIPTION
The current code generate locks that expires more than 47 years from now...