### PR TITLE
Improve namespace support

### DIFF
--- a/rados/rados.go
+++ b/rados/rados.go
@@ -17,6 +17,8 @@ func (e RadosError) Error() string {
 	return fmt.Sprintf("rados: %s", C.GoString(C.strerror(C.int(-e))))
 }
 
+var RadosAllNamespaces = "\x01"
+
 var RadosErrorNotFound = RadosError(-C.ENOENT)
 var RadosErrorPermissionDenied = RadosError(-C.EPERM)
 


### PR DESCRIPTION
RADOS supports listing and iterating over all of the objects in a pool (across namespaces) but at present the go bindings don't explicitly support that. Under the covers this is achieved by passing a magic constant to `rados_ioctx_set_namespace()` so we define that constant for people to use.

Additionally, we can extend the iterator to support returning the namespace of objects if you are iterating across all namespace without breaking the API, so I did that. We unfortunately cannot extend ListObjects without changing the signature, so I omitted that. Anyone needing that info can simply use the iterator interface instead.

I extended the tests of both ListObjects and Iter to check that behavior is correct within and across namespaces.