### PR TITLE
Convert RBD feature flags to constants with iota

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -5,6 +5,7 @@ package rbd
 // #include <stdlib.h>
 // #include <rados/librados.h>
 // #include <rbd/librbd.h>
+// #include <rbd/features.h>
 import "C"
 
 import (
@@ -18,44 +19,29 @@ import (
 
 const (
 	// RBD features.
-	RbdFeatureLayering uint64 = 1 << iota
-	RbdFeatureStripingV2
-	RbdFeatureExclusiveLock
-	RbdFeatureObjectMap
-	RbdFeatureFastDiff
-	RbdFeatureDeepFlatten
-	RbdFeatureJournaling
-	RbdFeatureDataPool
-	RbdFeatureOperations
-	RbdFeatureMigrating
+	RbdFeatureLayering      = C.RBD_FEATURE_LAYERING
+	RbdFeatureStripingV2    = C.RBD_FEATURE_STRIPINGV2
+	RbdFeatureExclusiveLock = C.RBD_FEATURE_EXCLUSIVE_LOCK
+	RbdFeatureObjectMap     = C.RBD_FEATURE_OBJECT_MAP
+	RbdFeatureFastDiff      = C.RBD_FEATURE_FAST_DIFF
+	RbdFeatureDeepFlatten   = C.RBD_FEATURE_DEEP_FLATTEN
+	RbdFeatureJournaling    = C.RBD_FEATURE_JOURNALING
+	RbdFeatureDataPool      = C.RBD_FEATURE_DATA_POOL
+
+	RbdFeaturesDefault = C.RBD_FEATURES_DEFAULT
 
 	// Features that make an image inaccessible for read or write by clients that don't understand
 	// them.
-	RbdFeaturesIncompatible = RbdFeatureLayering |
-		RbdFeatureStripingV2 |
-		RbdFeatureDataPool
+	RbdFeaturesIncompatible = C.RBD_FEATURES_INCOMPATIBLE
 
 	// Features that make an image unwritable by clients that don't understand them.
-	RbdFeaturesRwIncompatible = RbdFeaturesIncompatible |
-		RbdFeatureExclusiveLock |
-		RbdFeatureObjectMap |
-		RbdFeatureFastDiff |
-		RbdFeatureDeepFlatten |
-		RbdFeatureJournaling |
-		RbdFeatureOperations |
-		RbdFeatureMigrating
+	RbdFeaturesRwIncompatible = C.RBD_FEATURES_RW_INCOMPATIBLE
 
 	// Features that may be dynamically enabled or disabled.
-	RbdFeaturesMutable = RbdFeatureExclusiveLock |
-		RbdFeatureObjectMap |
-		RbdFeatureFastDiff |
-		RbdFeatureJournaling
+	RbdFeaturesMutable = C.RBD_FEATURES_MUTABLE
 
 	// Features that only work when used with a single client using the image for writes.
-	RbdFeaturesSingleClient = RbdFeatureExclusiveLock |
-		RbdFeatureObjectMap |
-		RbdFeatureFastDiff |
-		RbdFeatureJournaling
+	RbdFeaturesSingleClient = C.RBD_FEATURES_SINGLE_CLIENT
 )
 
 //

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	// RBD features
+	// RBD features.
 	RbdFeatureLayering uint64 = 1 << iota
 	RbdFeatureStripingV2
 	RbdFeatureExclusiveLock
@@ -28,6 +28,34 @@ const (
 	RbdFeatureDataPool
 	RbdFeatureOperations
 	RbdFeatureMigrating
+
+	// Features that make an image inaccessible for read or write by clients that don't understand
+	// them.
+	RbdFeaturesIncompatible = RbdFeatureLayering |
+		RbdFeatureStripingV2 |
+		RbdFeatureDataPool
+
+	// Features that make an image unwritable by clients that don't understand them.
+	RbdFeaturesRwIncompatible = RbdFeaturesIncompatible |
+		RbdFeatureExclusiveLock |
+		RbdFeatureObjectMap |
+		RbdFeatureFastDiff |
+		RbdFeatureDeepFlatten |
+		RbdFeatureJournaling |
+		RbdFeatureOperations |
+		RbdFeatureMigrating
+
+	// Features that may be dynamically enabled or disabled.
+	RbdFeaturesMutable = RbdFeatureExclusiveLock |
+		RbdFeatureObjectMap |
+		RbdFeatureFastDiff |
+		RbdFeatureJournaling
+
+	// Features that only work when used with a single client using the image for writes.
+	RbdFeaturesSingleClient = RbdFeatureExclusiveLock |
+		RbdFeatureObjectMap |
+		RbdFeatureFastDiff |
+		RbdFeatureJournaling
 )
 
 //

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -16,15 +16,27 @@ import (
 	"unsafe"
 )
 
+const (
+	// RBD features
+	RbdFeatureLayering uint64 = 1 << iota
+	RbdFeatureStripingV2
+	RbdFeatureExclusiveLock
+	RbdFeatureObjectMap
+	RbdFeatureFastDiff
+	RbdFeatureDeepFlatten
+	RbdFeatureJournaling
+	RbdFeatureDataPool
+	RbdFeatureOperations
+	RbdFeatureMigrating
+)
+
 //
 type RBDError int
 
-var RbdErrorImageNotOpen = errors.New("RBD image not open")
-var RbdErrorNotFound = errors.New("RBD image not found")
-
-//Rdb feature
-var RbdFeatureLayering = uint64(1 << 0)
-var RbdFeatureStripingV2 = uint64(1 << 1)
+var (
+	RbdErrorImageNotOpen = errors.New("RBD image not open")
+	RbdErrorNotFound     = errors.New("RBD image not found")
+)
 
 //
 type ImageInfo struct {


### PR DESCRIPTION
This simply converts the RBD feature flags to constants (as they should be), and uses Go's iota helper for enum-like constants.