### PR TITLE
cephfs: add unmount, release, chmod, chown, etc 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ before_install: |
     exit 1
   fi
 
+# cephfs (fuse) requires: --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined
 script:
-  - docker run --rm -it -v ${PWD}:/go/src/github.com/ceph/go-ceph:z ceph-golang-ci
+  - docker run --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --rm -it -v ${PWD}:/go/src/github.com/ceph/go-ceph:z ceph-golang-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN apt-get update && apt-get install -y \
   librbd-dev \
   golang-1.10-go
 
+# add user account to test permissions
+RUN groupadd -g 1010 bob
+RUN useradd -u 1010 -g bob -M bob
+
 ENV GOPATH /go
 WORKDIR /go/src/github.com/ceph/go-ceph
 VOLUME /go/src/github.com/ceph/go-ceph

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 	go test -v ./...
 
 test-docker: .build-docker
-	docker run --rm -it -v $(CURDIR):/go/src/github.com/ceph/go-ceph $(DOCKER_CI_IMAGE)
+	docker run --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --rm -it -v $(CURDIR):/go/src/github.com/ceph/go-ceph $(DOCKER_CI_IMAGE)
 
 .build-docker:
 	docker build -t $(DOCKER_CI_IMAGE) .

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
 
 The native RADOS library and development headers are expected to be installed.
 
+On debian systems (apt):
+```sh
+libcephfs-dev librbd-dev librados-dev
+```
+
+On rpm based systems (dnf, yum, etc):
+```sh
+libcephfs-devel librbd-devel librados-devel
+```
+
 ## Documentation
 
 Detailed documentation is available at
@@ -92,10 +102,11 @@ conn.DeletePool("new_pool")
 # Development
 
 ```
-docker run --rm -it --net=host
-  -v ${PWD}:/go/src/github.com/ceph/go-ceph:z
-  -v /home/nwatkins/src/ceph/build:/home/nwatkins/src/ceph/build:z
-  -e CEPH_CONF=/home/nwatkins/src/ceph/build/ceph.conf
+docker run --rm -it --net=host \
+  --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined \
+  -v ${PWD}:/go/src/github.com/ceph/go-ceph:z \
+  -v /home/nwatkins/src/ceph/build:/home/nwatkins/src/ceph/build:z \
+  -e CEPH_CONF=/home/nwatkins/src/ceph/build/ceph.conf \
   ceph-golang
 ```
 
@@ -122,4 +133,3 @@ Contributions are welcome & greatly appreciated, every little bit helps. Make co
 ```
 make test-docker
 ```
-

--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -7,17 +7,26 @@ package cephfs
 #include <cephfs/libcephfs.h>
 */
 import "C"
-import "fmt"
-import "unsafe"
 
-//
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"math"
+	"syscall"
+	"unsafe"
+)
+
 type CephError int
 
 func (e CephError) Error() string {
-	return fmt.Sprintf("cephfs: ret=%d", e)
+	if e == 0 {
+		return fmt.Sprintf("")
+	} else {
+		err := syscall.Errno(uint(math.Abs(float64(e))))
+		return fmt.Sprintf("cephfs: ret=(%d) %v", e, err)
+	}
 }
 
-//
 type MountInfo struct {
 	mount *C.struct_ceph_mount_info
 }
@@ -28,7 +37,41 @@ func CreateMount() (*MountInfo, error) {
 	if ret == 0 {
 		return mount, nil
 	} else {
+		log.Errorf("CreateMount: Failed to create mount")
 		return nil, CephError(ret)
+	}
+}
+
+func (mount *MountInfo) RemoveDir(path string) error {
+	c_path := C.CString(path)
+	defer C.free(unsafe.Pointer(c_path))
+
+	ret := C.ceph_rmdir(mount.mount, c_path)
+	if ret == 0 {
+		return nil
+	} else {
+		log.Errorf("RemoveDir: Failed to remove directory")
+		return CephError(ret)
+	}
+}
+
+func (mount *MountInfo) Unmount() error {
+	ret := C.ceph_unmount(mount.mount)
+	if ret == 0 {
+		return nil
+	} else {
+		log.Errorf("Unmount: Failed to unmount")
+		return CephError(ret)
+	}
+}
+
+func (mount *MountInfo) Release() error {
+	ret := C.ceph_release(mount.mount)
+	if ret == 0 {
+		return nil
+	} else {
+		log.Errorf("Release: Failed to release mount")
+		return CephError(ret)
 	}
 }
 
@@ -37,6 +80,7 @@ func (mount *MountInfo) ReadDefaultConfigFile() error {
 	if ret == 0 {
 		return nil
 	} else {
+		log.Errorf("ReadDefaultConfigFile: Failed to read ceph config")
 		return CephError(ret)
 	}
 }
@@ -46,6 +90,7 @@ func (mount *MountInfo) Mount() error {
 	if ret == 0 {
 		return nil
 	} else {
+		log.Errorf("Mount: Failed to mount")
 		return CephError(ret)
 	}
 }
@@ -55,6 +100,7 @@ func (mount *MountInfo) SyncFs() error {
 	if ret == 0 {
 		return nil
 	} else {
+		log.Errorf("Mount: Failed to sync filesystem")
 		return CephError(ret)
 	}
 }
@@ -72,6 +118,7 @@ func (mount *MountInfo) ChangeDir(path string) error {
 	if ret == 0 {
 		return nil
 	} else {
+		log.Errorf("ChangeDir: Failed to change directory")
 		return CephError(ret)
 	}
 }
@@ -84,6 +131,46 @@ func (mount *MountInfo) MakeDir(path string, mode uint32) error {
 	if ret == 0 {
 		return nil
 	} else {
+		log.Errorf("MakeDir: Failed to make directory %s", path)
 		return CephError(ret)
 	}
+}
+
+func (mount *MountInfo) Chmod(path string, mode uint32) error {
+	c_path := C.CString(path)
+	defer C.free(unsafe.Pointer(c_path))
+
+	ret := C.ceph_chmod(mount.mount, c_path, C.mode_t(mode))
+	if ret == 0 {
+		return nil
+	} else {
+		log.Errorf("Chmod: Failed to chmod :%s", path)
+		return CephError(ret)
+	}
+}
+
+func (mount *MountInfo) Chown(path string, user uint32, group uint32) error {
+	c_path := C.CString(path)
+	defer C.free(unsafe.Pointer(c_path))
+
+	ret := C.ceph_chown(mount.mount, c_path, C.int(user), C.int(group))
+	if ret == 0 {
+		return nil
+	} else {
+		log.Errorf("Chown: Failed to chown :%s", path)
+		return CephError(ret)
+	}
+}
+
+/*
+ * Helper functions
+ */
+
+func (mount *MountInfo) IsMounted() bool {
+	ret := C.ceph_is_mounted(mount.mount)
+	return ret == 0
+}
+
+func (mount *MountInfo) GetMount() *C.struct_ceph_mount_info {
+	return mount.mount
 }

--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -16,9 +16,9 @@ import (
 	"unsafe"
 )
 
-type CephError int
+type cephError int
 
-func (e CephError) Error() string {
+func (e cephError) Error() string {
 	if e == 0 {
 		return fmt.Sprintf("cephfs: no error given")
 	}
@@ -26,135 +26,144 @@ func (e CephError) Error() string {
 	return fmt.Sprintf("cephfs: ret=(%d) %v", e, err)
 }
 
+// MountInfo exports ceph's ceph_mount_info from libcephfs.cc
 type MountInfo struct {
 	mount *C.struct_ceph_mount_info
 }
 
+// CreateMount creates a mount handle for interacting with Ceph.
 func CreateMount() (*MountInfo, error) {
 	mount := &MountInfo{}
 	ret := C.ceph_create(&mount.mount, nil)
-	if ret == 0 {
-		return mount, nil
+	if ret != 0 {
+		log.Errorf("CreateMount: Failed to create mount")
+		return nil, cephError(ret)
 	}
-	log.Errorf("CreateMount: Failed to create mount")
-	return nil, CephError(ret)
+	return mount, nil
 }
 
+// ReadDefaultConfigFile loads the ceph configuration from the specified config file.
 func (mount *MountInfo) ReadDefaultConfigFile() error {
 	ret := C.ceph_conf_read_file(mount.mount, nil)
-	if ret == 0 {
-		return nil
+	if ret != 0 {
+		log.Errorf("ReadDefaultConfigFile: Failed to read ceph config")
+		return cephError(ret)
 	}
-	log.Errorf("ReadDefaultConfigFile: Failed to read ceph config")
-	return CephError(ret)
+	return nil
 }
 
+// Mount mounts the mount handle.
 func (mount *MountInfo) Mount() error {
 	ret := C.ceph_mount(mount.mount, nil)
-	if ret == 0 {
-		return nil
+	if ret != 0 {
+		log.Errorf("Mount: Failed to mount")
+		return cephError(ret)
 	}
-	log.Errorf("Mount: Failed to mount")
-	return CephError(ret)
+	return nil
 }
 
+// Unmount unmounts the mount handle.
 func (mount *MountInfo) Unmount() error {
 	ret := C.ceph_unmount(mount.mount)
-	if ret == 0 {
-		return nil
+	if ret != 0 {
+		log.Errorf("Unmount: Failed to unmount")
+		return cephError(ret)
 	}
-	log.Errorf("Unmount: Failed to unmount")
-	return CephError(ret)
+	return nil
 }
 
+// Release destroys the mount handle.
 func (mount *MountInfo) Release() error {
 	ret := C.ceph_release(mount.mount)
-	if ret == 0 {
-		return nil
-	} else {
+	if ret != 0 {
 		log.Errorf("Release: Failed to release mount")
-		return CephError(ret)
+		return cephError(ret)
 	}
+	return nil
 }
 
+// SyncFs synchronizes all filesystem data to persistent media.
 func (mount *MountInfo) SyncFs() error {
 	ret := C.ceph_sync_fs(mount.mount)
-	if ret == 0 {
-		return nil
+	if ret != 0 {
+		log.Errorf("Mount: Failed to sync filesystem")
+		return cephError(ret)
 	}
-	log.Errorf("Mount: Failed to sync filesystem")
-	return CephError(ret)
+	return nil
 }
 
+// CurrentDir gets the current working directory.
 func (mount *MountInfo) CurrentDir() string {
-	c_dir := C.ceph_getcwd(mount.mount)
-	return C.GoString(c_dir)
+	cDir := C.ceph_getcwd(mount.mount)
+	return C.GoString(cDir)
 }
 
+// ChangeDir changes the current working directory.
 func (mount *MountInfo) ChangeDir(path string) error {
-	c_path := C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_chdir(mount.mount, c_path)
-	if ret == 0 {
-		return nil
+	ret := C.ceph_chdir(mount.mount, cPath)
+	if ret != 0 {
+		log.Errorf("ChangeDir: Failed to change directory")
+		return cephError(ret)
 	}
-	log.Errorf("ChangeDir: Failed to change directory")
-	return CephError(ret)
+	return nil
 }
 
+// MakeDir creates a directory.
 func (mount *MountInfo) MakeDir(path string, mode uint32) error {
-	c_path := C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_mkdir(mount.mount, c_path, C.mode_t(mode))
-	if ret == 0 {
-		return nil
+	ret := C.ceph_mkdir(mount.mount, cPath, C.mode_t(mode))
+	if ret != 0 {
+		log.Errorf("MakeDir: Failed to make directory %s", path)
+		return cephError(ret)
 	}
-	log.Errorf("MakeDir: Failed to make directory %s", path)
-	return CephError(ret)
+	return nil
 }
 
+// RemoveDir removes a directory.
 func (mount *MountInfo) RemoveDir(path string) error {
-	c_path := C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_rmdir(mount.mount, c_path)
-	if ret == 0 {
-		return nil
+	ret := C.ceph_rmdir(mount.mount, cPath)
+	if ret != 0 {
+		log.Errorf("RemoveDir: Failed to remove directory")
+		return cephError(ret)
 	}
-	log.Errorf("RemoveDir: Failed to remove directory")
-	return CephError(ret)
+	return nil
 }
 
+// Chmod changes the mode bits (permissions) of a file/directory.
 func (mount *MountInfo) Chmod(path string, mode uint32) error {
-	c_path := C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_chmod(mount.mount, c_path, C.mode_t(mode))
-	if ret == 0 {
-		return nil
+	ret := C.ceph_chmod(mount.mount, cPath, C.mode_t(mode))
+	if ret != 0 {
+		log.Errorf("Chmod: Failed to chmod :%s", path)
+		return cephError(ret)
 	}
-	log.Errorf("Chmod: Failed to chmod :%s", path)
-	return CephError(ret)
+	return nil
 }
 
+// Chown changes the ownership of a file/directory.
 func (mount *MountInfo) Chown(path string, user uint32, group uint32) error {
-	c_path := C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_chown(mount.mount, c_path, C.int(user), C.int(group))
-	if ret == 0 {
-		return nil
+	ret := C.ceph_chown(mount.mount, cPath, C.int(user), C.int(group))
+	if ret != 0 {
+		log.Errorf("Chown: Failed to chown :%s", path)
+		return cephError(ret)
 	}
-	log.Errorf("Chown: Failed to chown :%s", path)
-	return CephError(ret)
+	return nil
 }
 
-/*
- * Helper functions
- */
-
+// IsMounted checks mount status.
 func (mount *MountInfo) IsMounted() bool {
 	ret := C.ceph_is_mounted(mount.mount)
 	return ret == 1

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -1,19 +1,26 @@
 package cephfs_test
 
-import "testing"
-import "github.com/ceph/go-ceph/cephfs"
-import "github.com/stretchr/testify/assert"
+import (
+	"fmt"
+	"github.com/ceph/go-ceph/cephfs"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
+)
 
 func TestCreateMount(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
+	assert.True(t, mount.IsMounted())
 }
 
 func TestMountRoot(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
+	assert.True(t, mount.IsMounted())
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
@@ -26,6 +33,7 @@ func TestSyncFs(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
+	assert.True(t, mount.IsMounted())
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
@@ -41,6 +49,7 @@ func TestChangeDir(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
+	assert.True(t, mount.IsMounted())
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
@@ -63,4 +72,64 @@ func TestChangeDir(t *testing.T) {
 	assert.NotEqual(t, dir1, dir2)
 	assert.Equal(t, dir1, "/")
 	assert.Equal(t, dir2, "/asdf")
+}
+
+func TestRemoveDir(t *testing.T) {
+	dirname := "/one"
+	mount, err := cephfs.CreateMount()
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+	assert.True(t, mount.IsMounted())
+
+	err = mount.ReadDefaultConfigFile()
+	assert.NoError(t, err)
+
+	err = mount.Mount()
+	assert.NoError(t, err)
+
+	dir1 := mount.CurrentDir()
+	assert.NotNil(t, dir1)
+
+	fmt.Printf("path: %v\n", dir1)
+
+	err = mount.MakeDir(dirname, 0755)
+	assert.NoError(t, err)
+
+	err = mount.SyncFs()
+	assert.NoError(t, err)
+
+	files, _ := ioutil.ReadDir("./")
+	for _, f := range files {
+		fmt.Println(f.Name())
+	}
+
+	_, err = os.Stat(dirname)
+	assert.NoError(t, err)
+
+	err = mount.RemoveDir(dirname)
+	assert.NoError(t, err)
+	_, err = os.Stat(dirname)
+	assert.EqualError(t, err, fmt.Sprintf("stat %s: no such file or directory", dirname))
+}
+
+func TestUnmountMount(t *testing.T) {
+	mount, err := cephfs.CreateMount()
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+	assert.True(t, mount.IsMounted())
+
+	err = mount.Unmount()
+	assert.NoError(t, err)
+	assert.False(t, mount.IsMounted())
+}
+
+func TestReleaseMount(t *testing.T) {
+	mount, err := cephfs.CreateMount()
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+	assert.True(t, mount.IsMounted())
+
+	err = mount.Release()
+	assert.NoError(t, err)
+	assert.Nil(t, mount.GetMount())
 }

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -4,23 +4,25 @@ import (
 	"fmt"
 	"github.com/ceph/go-ceph/cephfs"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"os"
+	"syscall"
 	"testing"
+)
+
+var (
+	CephMountTest string = "/tmp/ceph/mds/mnt/"
 )
 
 func TestCreateMount(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
-	assert.True(t, mount.IsMounted())
 }
 
 func TestMountRoot(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
-	assert.True(t, mount.IsMounted())
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
@@ -33,7 +35,6 @@ func TestSyncFs(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
-	assert.True(t, mount.IsMounted())
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
@@ -49,7 +50,6 @@ func TestChangeDir(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
-	assert.True(t, mount.IsMounted())
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
@@ -75,11 +75,10 @@ func TestChangeDir(t *testing.T) {
 }
 
 func TestRemoveDir(t *testing.T) {
-	dirname := "/one"
+	dirname := "one"
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
-	assert.True(t, mount.IsMounted())
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
@@ -87,35 +86,35 @@ func TestRemoveDir(t *testing.T) {
 	err = mount.Mount()
 	assert.NoError(t, err)
 
-	dir1 := mount.CurrentDir()
-	assert.NotNil(t, dir1)
-
-	fmt.Printf("path: %v\n", dir1)
-
 	err = mount.MakeDir(dirname, 0755)
 	assert.NoError(t, err)
 
 	err = mount.SyncFs()
 	assert.NoError(t, err)
 
-	files, _ := ioutil.ReadDir("./")
-	for _, f := range files {
-		fmt.Println(f.Name())
-	}
-
-	_, err = os.Stat(dirname)
+	// os.Stat the actual mounted location to verify Makedir/RemoveDir
+	_, err = os.Stat(CephMountTest + dirname)
 	assert.NoError(t, err)
 
 	err = mount.RemoveDir(dirname)
 	assert.NoError(t, err)
-	_, err = os.Stat(dirname)
-	assert.EqualError(t, err, fmt.Sprintf("stat %s: no such file or directory", dirname))
+
+	_, err = os.Stat(CephMountTest + dirname)
+	assert.EqualError(t, err,
+		fmt.Sprintf("stat %s: no such file or directory", CephMountTest+dirname))
 }
 
 func TestUnmountMount(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
+	fmt.Printf("%#v\n", mount.IsMounted())
+
+	err = mount.ReadDefaultConfigFile()
+	assert.NoError(t, err)
+
+	err = mount.Mount()
+	assert.NoError(t, err)
 	assert.True(t, mount.IsMounted())
 
 	err = mount.Unmount()
@@ -127,9 +126,80 @@ func TestReleaseMount(t *testing.T) {
 	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
-	assert.True(t, mount.IsMounted())
 
 	err = mount.Release()
 	assert.NoError(t, err)
-	assert.Nil(t, mount.GetMount())
+}
+
+func TestChmodDir(t *testing.T) {
+	dirname := "two"
+	var stats_before uint32 = 0755
+	var stats_after uint32 = 0700
+	mount, err := cephfs.CreateMount()
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+
+	err = mount.ReadDefaultConfigFile()
+	assert.NoError(t, err)
+
+	err = mount.Mount()
+	assert.NoError(t, err)
+
+	err = mount.MakeDir(dirname, stats_before)
+	assert.NoError(t, err)
+
+	err = mount.SyncFs()
+	assert.NoError(t, err)
+
+	// os.Stat the actual mounted location to verify Makedir/RemoveDir
+	stats, err := os.Stat(CephMountTest + dirname)
+	assert.NoError(t, err)
+
+	assert.Equal(t, uint32(stats.Mode().Perm()), stats_before)
+
+	err = mount.Chmod(dirname, stats_after)
+	assert.NoError(t, err)
+
+	stats, err = os.Stat(CephMountTest + dirname)
+	assert.Equal(t, uint32(stats.Mode().Perm()), stats_after)
+}
+
+// Not cross-platform, go's os does not specifiy Sys return type
+func TestChown(t *testing.T) {
+	dirname := "three"
+	// dockerfile creates bob user account
+	var bob uint32 = 1010
+	var root uint32 = 0
+
+	mount, err := cephfs.CreateMount()
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+
+	err = mount.ReadDefaultConfigFile()
+	assert.NoError(t, err)
+
+	err = mount.Mount()
+	assert.NoError(t, err)
+
+	err = mount.MakeDir(dirname, 0755)
+	assert.NoError(t, err)
+
+	err = mount.SyncFs()
+	assert.NoError(t, err)
+
+	// os.Stat the actual mounted location to verify Makedir/RemoveDir
+	stats, err := os.Stat(CephMountTest + dirname)
+	assert.NoError(t, err)
+
+	assert.Equal(t, uint32(stats.Sys().(*syscall.Stat_t).Uid), root)
+	assert.Equal(t, uint32(stats.Sys().(*syscall.Stat_t).Gid), root)
+
+	err = mount.Chown(dirname, bob, bob)
+	assert.NoError(t, err)
+
+	stats, err = os.Stat(CephMountTest + dirname)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(stats.Sys().(*syscall.Stat_t).Uid), bob)
+	assert.Equal(t, uint32(stats.Sys().(*syscall.Stat_t).Gid), bob)
+
 }


### PR DESCRIPTION
This commit adds the following cephfs functions:

* Unmount // Unmounting is necessary to cleanup mounts
* Release // Release destroys the cmount ~ end of transaction
* RemoveDir // inverse of MakeDir
* Chown // change ownership of file or directory
* Chmod // change permissions of file or directory

Tests are included for each function.

In addition to these changes modifications to:

.travis.yml, Dockerfile, and Makefile

were made to accomodate tests to mount the ceph volume.  Tests use
fuse to mount the volume which requires adding:

--device /dev/fuse --cap-add SYS_ADMIN --security-opt \
apparmor:unconfined

to the docker container (alternatively --privileged works but adds
additional permissions).

Changes to README add the above docker changes as well as point
users to the necessary ceph development libraries.