### PR TITLE
FEA: Add more api support for CephFS

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -48,6 +48,15 @@ const (
 	CephStatxAllStats   = C.CEPH_STATX_ALL_STATS
 
 	CephStatxMask = (CephStatxUid | CephStatxGid | CephStatxSize | CephStatxBlocks | CephStatxAtime | CephStatxMtime)
+
+	CephSetAttrMode  = C.CEPH_SETATTR_MODE
+	CephSetAttrUid   = C.CEPH_SETATTR_UID
+	CephSetAttrGid   = C.CEPH_SETATTR_GID
+	CephSetAttrMtime = C.CEPH_SETATTR_MTIME
+	CephSetAttrAtime = C.CEPH_SETATTR_ATIME
+	CephSetAttrSize  = C.CEPH_SETATTR_SIZE
+	CephSetAttrCtime = C.CEPH_SETATTR_CTIME
+	CephSetAttrBtime = C.CEPH_SETATTR_BTIME
 )
 
 type CephStat struct {

--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -74,6 +74,94 @@ type CephStat struct {
 	IsSymlink bool // S_ISLNK
 }
 
+func (stat *CephStat) StrMode() string {
+	mode := make([]byte, 10)
+	// type
+	switch stat.Mode & C.S_IFMT {
+	case C.S_IFDIR:
+		mode[0] = 'd'
+	case C.S_IFCHR:
+		mode[0] = 'c'
+	case C.S_IFBLK:
+		mode[0] = 'b'
+	case C.S_IFREG:
+		mode[0] = '-'
+	case C.S_IFLNK:
+		mode[0] = 'l'
+	case C.S_IFSOCK:
+		mode[0] = 's'
+	default:
+		mode[0] = '?'
+	}
+
+	// user
+	if (stat.Mode & C.S_IRUSR) != 0 {
+		mode[1] = 'r'
+	} else {
+		mode[1] = '-'
+	}
+	if (stat.Mode & C.S_IWUSR) != 0 {
+		mode[2] = 'w'
+	} else {
+		mode[2] = '-'
+	}
+	switch stat.Mode & (C.S_IXUSR | C.S_ISUID) {
+	case 0:
+		mode[3] = '-'
+	case C.S_IXUSR:
+		mode[3] = 'x'
+	case C.S_ISUID:
+		mode[3] = 'S'
+	case C.S_IXUSR | C.S_ISUID:
+		mode[3] = 's'
+	}
+
+	// group
+	if (stat.Mode & C.S_IRGRP) != 0 {
+		mode[4] = 'r'
+	} else {
+		mode[4] = '-'
+	}
+	if (stat.Mode & C.S_IWGRP) != 0 {
+		mode[5] = 'w'
+	} else {
+		mode[5] = '-'
+	}
+	switch stat.Mode & (C.S_IXGRP | C.S_ISUID) {
+	case 0:
+		mode[6] = '-'
+	case C.S_IXGRP:
+		mode[6] = 'x'
+	case C.S_ISUID:
+		mode[6] = 'S'
+	case C.S_IXGRP | C.S_ISUID:
+		mode[6] = 's'
+	}
+
+	// other
+	if (stat.Mode & C.S_IROTH) != 0 {
+		mode[7] = 'r'
+	} else {
+		mode[7] = '-'
+	}
+	if (stat.Mode & C.S_IWOTH) != 0 {
+		mode[8] = 'w'
+	} else {
+		mode[8] = '-'
+	}
+	switch stat.Mode & (C.S_IXOTH | C.S_ISVTX) {
+	case 0:
+		mode[9] = '-'
+	case C.S_IXOTH:
+		mode[9] = 'x'
+	case C.S_ISVTX:
+		mode[9] = 'T'
+	case C.S_IXOTH | C.S_ISVTX:
+		mode[9] = 't'
+	}
+	return string(mode)
+}
+
 // MountInfo exports ceph's ceph_mount_info from libcephfs.cc
 type MountInfo struct {
 	mount *C.struct_ceph_mount_info

--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -373,7 +373,6 @@ func (mount *MountInfo) ListDir(path string) ([]string, error) {
 		for bufpos < int(ret) {
 			ptr := unsafe.Pointer((uintptr(buf) + uintptr(bufpos)))
 			ent = C.GoString((*C.char)(ptr))
-			log.Info(ent)
 			if strings.Compare(ent, ".") != 0 && strings.Compare(ent, "..") != 0 {
 				dirs = append(dirs, ent)
 			}
@@ -426,6 +425,7 @@ func (mount *MountInfo) fillCephStat(stx Statx) CephStat {
 	} else {
 		stat.IsSymlink = false
 	}
+
 	return stat
 }
 

--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -4,6 +4,9 @@ package cephfs
 #cgo LDFLAGS: -lcephfs
 #cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
 #include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/stat.h>
 #include <cephfs/libcephfs.h>
 */
 import "C"
@@ -12,6 +15,8 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"math"
+	//"os"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -26,15 +31,51 @@ func (e cephError) Error() string {
 	return fmt.Sprintf("cephfs: ret=(%d) %v", e, err)
 }
 
+const (
+	CephStatMask = (C.CEPH_STATX_UID | C.CEPH_STATX_GID | C.CEPH_STATX_SIZE | C.CEPH_STATX_BLOCKS | C.CEPH_STATX_MTIME | C.CEPH_STATX_ATIME)
+)
+
+type CephStat struct {
+	Mode       uint16
+	Uid        uint
+	Gid        uint
+	Size       uint64
+	BlkSize    uint
+	Blocks     uint64
+	AppendTime int64
+	ModifyTime int64
+
+	IsFile    bool // S_ISREG
+	IsDir     bool // S_ISDIR
+	IsSymlink bool // S_ISLNK
+}
+
 // MountInfo exports ceph's ceph_mount_info from libcephfs.cc
 type MountInfo struct {
 	mount *C.struct_ceph_mount_info
 }
 
+type DirResult struct {
+	dirp *C.struct_ceph_dir_result
+}
+
+type Statx struct {
+	stx C.struct_ceph_statx
+}
+
 // CreateMount creates a mount handle for interacting with Ceph.
-func CreateMount() (*MountInfo, error) {
+func CreateMount(id string) (*MountInfo, error) {
 	mount := &MountInfo{}
-	ret := C.ceph_create(&mount.mount, nil)
+
+	var cId *C.char
+	if strings.Compare(id, "") == 0 {
+		cId = nil
+	} else {
+		cId = C.CString(id)
+		defer C.free(unsafe.Pointer(cId))
+	}
+
+	ret := C.ceph_create(&mount.mount, cId)
 	if ret != 0 {
 		log.Errorf("CreateMount: Failed to create mount")
 		return nil, cephError(ret)
@@ -52,9 +93,65 @@ func (mount *MountInfo) ReadDefaultConfigFile() error {
 	return nil
 }
 
+// ReadConfigFile loads the ceph configuration from the specified config file.
+func (mount *MountInfo) ReadConfigFile(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.ceph_conf_read_file(mount.mount, cPath)
+	if ret != 0 {
+		log.Errorf("ReadConfigFile: Failed to read ceph config")
+		return cephError(ret)
+	}
+	return nil
+}
+
+// SetConf sets a configuration value from a string
+func (mount *MountInfo) SetConf(option, value string) error {
+	cOption := C.CString(option)
+	defer C.free(unsafe.Pointer(cOption))
+	cValue := C.CString(value)
+	defer C.free(unsafe.Pointer(cValue))
+
+	ret := C.ceph_conf_set(mount.mount, cOption, cValue)
+	if ret != 0 {
+		log.Errorf("SetConf: Failed to set ceph config")
+		return cephError(ret)
+	}
+	return nil
+}
+
+// GetConf gets a configuration value as a string
+func (mount *MountInfo) GetConf(option string) (string, error) {
+	cOption := C.CString(option)
+	defer C.free(unsafe.Pointer(cOption))
+
+	bufLen := 128
+	buf := C.malloc(C.sizeof_char * C.size_t(bufLen))
+	defer C.free(unsafe.Pointer(buf))
+
+	for {
+		ret := C.ceph_conf_get(mount.mount, cOption, (*C.char)(buf), C.size_t(bufLen))
+		if ret == -C.ENAMETOOLONG {
+			bufLen *= 2
+			buf = C.malloc(C.sizeof_char * C.size_t(bufLen))
+			continue
+		} else if ret < 0 {
+			log.Errorf("GetConf: Failed to get ceph config")
+			return "", cephError(ret)
+		}
+		value := C.GoString((*C.char)(buf))
+		return value, nil
+	}
+
+}
+
 // Mount mounts the mount handle.
-func (mount *MountInfo) Mount() error {
-	ret := C.ceph_mount(mount.mount, nil)
+func (mount *MountInfo) Mount(rootPath string) error {
+	cPath := C.CString(rootPath)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.ceph_mount(mount.mount, cPath)
 	if ret != 0 {
 		log.Errorf("Mount: Failed to mount")
 		return cephError(ret)
@@ -150,6 +247,16 @@ func (mount *MountInfo) Chmod(path string, mode uint32) error {
 	return nil
 }
 
+// Fchmod changes the mode bits (permissions) of an open file
+func (mount *MountInfo) Fchmod(fd int, mode uint32) error {
+	ret := C.ceph_fchmod(mount.mount, C.int(fd), C.mode_t(mode))
+	if ret != 0 {
+		log.Errorf("Fchmod: Failed to fchmod")
+		return cephError(ret)
+	}
+	return nil
+}
+
 // Chown changes the ownership of a file/directory.
 func (mount *MountInfo) Chown(path string, user uint32, group uint32) error {
 	cPath := C.CString(path)
@@ -167,4 +274,301 @@ func (mount *MountInfo) Chown(path string, user uint32, group uint32) error {
 func (mount *MountInfo) IsMounted() bool {
 	ret := C.ceph_is_mounted(mount.mount)
 	return ret == 1
+}
+
+// Create and/or open a file
+func (mount *MountInfo) Open(path string, flags int, mode uint32) (int, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.ceph_open(mount.mount, cPath, C.int(flags), C.mode_t(mode))
+	if ret < 0 {
+		log.Errorf("Open: Failed to open: %s", path)
+		return int(ret), cephError(ret)
+	}
+	return int(ret), nil
+}
+
+// Close the open file
+func (mount *MountInfo) Close(fd int) error {
+	ret := C.ceph_close(mount.mount, C.int(fd))
+	if ret < 0 {
+		log.Errorf("Close: Failed to close")
+		return cephError(ret)
+	}
+	return nil
+}
+
+// Lseek seek to a position in a file
+func (mount *MountInfo) Lseek(fd int, offset int64, whence int) error {
+	ret := C.ceph_lseek(mount.mount, C.int(fd), C.int64_t(offset), C.int(whence))
+	if ret < 0 {
+		log.Errorf("Lseek: Failed to lseek")
+		return cephError(ret)
+	}
+	return nil
+}
+
+// Read read data from the file
+func (mount *MountInfo) Read(fd int, size uint64, offset uint64) ([]byte, error) {
+	buf := C.malloc(C.sizeof_char * C.uint64_t(size))
+	defer C.free(unsafe.Pointer(buf))
+
+	ret := C.ceph_read(mount.mount, C.int(fd), (*C.char)(unsafe.Pointer(buf)), C.int64_t(size), C.int64_t(offset))
+	if ret < 0 {
+		log.Errorf("Read: Failed to read")
+		return nil, cephError(ret)
+	}
+
+	b := C.GoBytes(buf, ret)
+	return b, nil
+}
+
+// Write write data to a file
+func (mount *MountInfo) Write(fd int, data []byte, size uint64, offset uint64) (int, error) {
+	buf := C.CBytes(data)
+	defer C.free(unsafe.Pointer(buf))
+
+	ret := C.ceph_write(mount.mount, C.int(fd), (*C.char)(buf), C.int64_t(size), C.int64_t(offset))
+	if ret < 0 {
+		log.Errorf("Write: Failed to write")
+		return int(ret), cephError(ret)
+	}
+	return int(ret), nil
+}
+
+// ListDir list the contents of a directory
+func (mount *MountInfo) ListDir(path string) ([]string, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	dir := &DirResult{}
+
+	ret := C.ceph_opendir(mount.mount, cPath, (**C.struct_ceph_dir_result)(&dir.dirp))
+	if ret != 0 {
+		log.Errorf("ListDir: Failed to open dir: %s", path)
+		return nil, cephError(ret)
+	}
+
+	var dirs []string
+
+	bufLen := 256
+	buf := C.malloc(C.sizeof_char * C.size_t(bufLen))
+	defer C.free(unsafe.Pointer(buf))
+
+	for {
+		ret = C.ceph_getdnames(mount.mount, dir.dirp, (*C.char)(buf), C.int(bufLen))
+		if ret == -C.ERANGE {
+			C.free(unsafe.Pointer(buf))
+			bufLen *= 2
+			buf = C.malloc(C.sizeof_char * C.size_t(bufLen))
+			continue
+		}
+		if ret <= 0 {
+			break
+		}
+
+		bufpos := 0
+		ent := ""
+		for bufpos < int(ret) {
+			ptr := unsafe.Pointer((uintptr(buf) + uintptr(bufpos)))
+			ent = C.GoString((*C.char)(ptr))
+			log.Info(ent)
+			if strings.Compare(ent, ".") != 0 && strings.Compare(ent, "..") != 0 {
+				dirs = append(dirs, ent)
+			}
+			bufpos += len(ent) + 1
+		}
+	}
+
+	ret = C.ceph_closedir(mount.mount, dir.dirp)
+	if ret != 0 {
+		log.Errorf("ListDir: Failed to close dir: %s", path)
+		return nil, cephError(ret)
+	}
+
+	return dirs, nil
+}
+
+func (mount *MountInfo) fillCephStat(stx Statx) CephStat {
+	var stat CephStat
+	stat.Mode = uint16(stx.stx.stx_mode)
+	stat.Uid = uint(stx.stx.stx_uid)
+	stat.Gid = uint(stx.stx.stx_gid)
+	stat.Size = uint64(stx.stx.stx_size)
+	stat.BlkSize = uint(stx.stx.stx_blksize)
+	stat.Blocks = uint64(stx.stx.stx_blocks)
+
+	time := stx.stx.stx_atime.tv_sec
+	time *= 1000
+	time += stx.stx.stx_atime.tv_nsec / 1000000
+	stat.AppendTime = int64(time)
+
+	time = stx.stx.stx_mtime.tv_sec
+	time *= 1000
+	time += stx.stx.stx_mtime.tv_nsec / 1000000
+	stat.ModifyTime = int64(time)
+
+	if (stx.stx.stx_mode & C.S_IFMT) == C.S_IFREG {
+		stat.IsFile = true
+	} else {
+		stat.IsFile = false
+	}
+
+	if (stx.stx.stx_mode & C.S_IFMT) == C.S_IFDIR {
+		stat.IsDir = true
+	} else {
+		stat.IsDir = false
+	}
+
+	if (stx.stx.stx_mode & C.S_IFMT) == C.S_IFLNK {
+		stat.IsSymlink = true
+	} else {
+		stat.IsSymlink = false
+	}
+	return stat
+}
+
+// Stat get file status from a given path
+func (mount *MountInfo) Stat(path string) (CephStat, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	stx := Statx{}
+	ret := C.ceph_statx(mount.mount, cPath, &stx.stx, CephStatMask, 0)
+	// ret := C.ceph_statx(mount.mount, cPath, &stx.stx, C.CEPH_STATX_UID, 0)
+	if ret != 0 {
+		log.Errorf("Stat: Failed to get file status: %s", path)
+		return CephStat{}, cephError(ret)
+	}
+
+	stat := mount.fillCephStat(stx)
+	return stat, nil
+}
+
+// FStat get file status from a file descriptor
+func (mount *MountInfo) FStat(fd int) (CephStat, error) {
+	stx := Statx{}
+	ret := C.ceph_fstatx(mount.mount, C.int(fd), &stx.stx, CephStatMask, 0)
+	if ret != 0 {
+		log.Errorf("Stat: Failed to get file status")
+		return CephStat{}, cephError(ret)
+	}
+
+	stat := mount.fillCephStat(stx)
+	return stat, nil
+}
+
+// LStat get file status, without following symlinks
+func (mount *MountInfo) LStat(path string) (CephStat, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	stx := Statx{}
+	ret := C.ceph_statx(mount.mount, cPath, &stx.stx, CephStatMask, C.AT_SYMLINK_NOFOLLOW)
+	if ret != 0 {
+		log.Errorf("Stat: Failed to get file status: %s", path)
+		return CephStat{}, cephError(ret)
+	}
+
+	stat := mount.fillCephStat(stx)
+	return stat, nil
+}
+
+/*
+// SetAttr set file attributes
+func (mount *MountInfo) SetAttr(path string, stat CephStat, mask int) {
+
+}
+*/
+// Truncate truncate a file to a specified length
+func (mount *MountInfo) Truncate(path string, size int64) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.ceph_truncate(mount.mount, cPath, C.int64_t(size))
+	if ret != 0 {
+		log.Errorf("Truncate: Failed to truncate file: %s", path)
+		return cephError(ret)
+	}
+	return nil
+}
+
+// FTruncate truncate a file to a specified length
+func (mount *MountInfo) FTruncate(fd int, size int64) error {
+	ret := C.ceph_ftruncate(mount.mount, C.int(fd), C.int64_t(size))
+	if ret != 0 {
+		log.Errorf("FTruncate: Failed to truncate file")
+		return cephError(ret)
+	}
+	return nil
+}
+
+// Link create a hard link to an existing file
+func (mount *MountInfo) Link(OldPath, NewPath string) error {
+	cOldPath, cNewPath := C.CString(OldPath), C.CString(NewPath)
+	defer C.free(unsafe.Pointer(cOldPath))
+	defer C.free(unsafe.Pointer(cNewPath))
+
+	ret := C.ceph_link(mount.mount, cOldPath, cNewPath)
+	if ret != 0 {
+		log.Errorf("Link: Failed to link oldPath: %s, newPath: %s", OldPath, NewPath)
+		return cephError(ret)
+	}
+	return nil
+}
+
+// Symlink create a symbolic link
+func (mount *MountInfo) Symlink(OldPath, NewPath string) error {
+	cOldPath, cNewPath := C.CString(OldPath), C.CString(NewPath)
+	defer C.free(unsafe.Pointer(cOldPath))
+	defer C.free(unsafe.Pointer(cNewPath))
+
+	ret := C.ceph_symlink(mount.mount, cOldPath, cNewPath)
+	if ret != 0 {
+		log.Errorf("Symlink: Failed to link oldPath: %s, newPath: %s", OldPath, NewPath)
+		return cephError(ret)
+	}
+	return nil
+}
+
+// ReadLink read the value of a symbolic link.
+func (mount *MountInfo) ReadLink(path string) (string, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	stx := Statx{}
+	ret := C.ceph_statx(mount.mount, cPath, &stx.stx, CephStatMask, C.AT_SYMLINK_NOFOLLOW)
+	if ret != 0 {
+		log.Errorf("Stat: Failed to get file status: %s", path)
+		return "", cephError(ret)
+	}
+
+	bufLen := stx.stx.stx_size + 1
+	buf := C.malloc(C.sizeof_char * C.size_t(bufLen))
+	defer C.free(unsafe.Pointer(buf))
+
+	ret = C.ceph_readlink(mount.mount, cPath, (*C.char)(buf), C.int64_t(bufLen))
+	if ret != 0 {
+		log.Errorf("ReadLink: Failed to read link: %s", path)
+		return "", cephError(ret)
+	}
+
+	ptr := unsafe.Pointer((uintptr(buf) + uintptr(ret)))
+	buf = C.memset(ptr, 0, 1)
+	linkName := C.GoString((*C.char)(buf))
+	return linkName, nil
+}
+
+// Unlink delete a name from the file system
+func (mount *MountInfo) Unlink(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.ceph_unlink(mount.mount, cPath)
+	if ret != 0 {
+		log.Errorf("Unlink: Failed to unlink, path: %s", path)
+		return cephError(ret)
+	}
+	return nil
 }

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -14,32 +14,32 @@ var (
 )
 
 func TestCreateMount(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 }
 
 func TestMountRoot(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 }
 
 func TestSyncFs(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	err = mount.SyncFs()
@@ -47,14 +47,14 @@ func TestSyncFs(t *testing.T) {
 }
 
 func TestChangeDir(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	dir1 := mount.CurrentDir()
@@ -79,14 +79,14 @@ func TestChangeDir(t *testing.T) {
 
 func TestRemoveDir(t *testing.T) {
 	dirname := "one"
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	err = mount.MakeDir(dirname, 0755)
@@ -108,7 +108,7 @@ func TestRemoveDir(t *testing.T) {
 }
 
 func TestUnmountMount(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 	fmt.Printf("%#v\n", mount.IsMounted())
@@ -116,7 +116,7 @@ func TestUnmountMount(t *testing.T) {
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 	assert.True(t, mount.IsMounted())
 
@@ -126,7 +126,7 @@ func TestUnmountMount(t *testing.T) {
 }
 
 func TestReleaseMount(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
@@ -134,18 +134,18 @@ func TestReleaseMount(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestChmodDir(t *testing.T) {
+func TestChmod(t *testing.T) {
 	dirname := "two"
 	var stats_before uint32 = 0755
 	var stats_after uint32 = 0700
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	err = mount.MakeDir(dirname, stats_before)
@@ -168,6 +168,21 @@ func TestChmodDir(t *testing.T) {
 
 	err = mount.RemoveDir(dirname)
 	assert.NoError(t, err)
+
+	fd, err := mount.Open("/text.txt", os.O_CREATE, stats_before)
+	assert.NoError(t, err)
+
+    err = mount.Fchmod(fd, stats_after)
+    assert.NoError(t, err)
+
+	stats, err = os.Stat(CephMountTest + "text.txt")
+	assert.Equal(t, uint32(stats.Mode().Perm()), stats_after)
+
+	err = mount.Close(fd)
+	assert.NoError(t, err)
+
+	err = mount.Unlink("/text.txt")
+	assert.NoError(t, err)
 }
 
 // Not cross-platform, go's os does not specifiy Sys return type
@@ -177,14 +192,14 @@ func TestChown(t *testing.T) {
 	var bob uint32 = 1010
 	var root uint32 = 0
 
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	err = mount.MakeDir(dirname, 0755)
@@ -215,7 +230,7 @@ func TestSetGetConf(t *testing.T) {
 	value := "cephx"
 	option := "auth supported"
 
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
@@ -232,14 +247,14 @@ func TestSetGetConf(t *testing.T) {
 }
 
 func TestOpenClose(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	fd, err := mount.Open("/text.txt", os.O_CREATE, 0755)
@@ -253,14 +268,14 @@ func TestOpenClose(t *testing.T) {
 }
 
 func TestWriteRead(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	fd, err := mount.Open("/text.txt", os.O_CREATE|os.O_RDWR, 0755)
@@ -284,14 +299,14 @@ func TestWriteRead(t *testing.T) {
 }
 
 func TestListDir(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	err = mount.MakeDir("/testdir", 0755)
@@ -307,14 +322,14 @@ func TestListDir(t *testing.T) {
 }
 
 func TestStatLink(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := cephfs.CreateMount("")
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount()
+	err = mount.Mount("/")
 	assert.NoError(t, err)
 
 	fd, err := mount.Open("/text.txt", os.O_CREATE, 0755)
@@ -356,5 +371,75 @@ func TestStatLink(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = mount.RemoveDir("/testdir")
+	assert.NoError(t, err)
+}
+
+func TestTruncate(t *testing.T) {
+	mount, err := cephfs.CreateMount("")
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+
+	err = mount.ReadDefaultConfigFile()
+	assert.NoError(t, err)
+
+	err = mount.Mount("/")
+	assert.NoError(t, err)
+
+	fd, err := mount.Open("/text.txt", os.O_CREATE|os.O_RDWR, 0755)
+	assert.NoError(t, err)
+
+	data := []byte("Ceph uniquely delivers object, block, and file storage in one unified system.")
+
+	size, err := mount.Write(fd, data, uint64(len(data)), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, size, len(data))
+
+    stat, err := mount.Stat("/text.txt")
+	assert.Equal(t, int(stat.Size), len(data))
+
+    err = mount.FTruncate(fd, 20)
+    assert.NoError(t, err)
+    stat, err = mount.Stat("/text.txt")
+	assert.Equal(t, int(stat.Size), 20)
+
+    err = mount.Truncate("/text.txt", 10)
+    assert.NoError(t, err)
+    stat, err = mount.Stat("/text.txt")
+	assert.Equal(t, int(stat.Size), 10)
+
+	err = mount.Close(fd)
+	assert.NoError(t, err)
+
+	err = mount.Unlink("/text.txt")
+	assert.NoError(t, err)
+}
+
+func TestLseek(t *testing.T) {
+	mount, err := cephfs.CreateMount("")
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+
+	err = mount.ReadDefaultConfigFile()
+	assert.NoError(t, err)
+
+	err = mount.Mount("/")
+	assert.NoError(t, err)
+
+	fd, err := mount.Open("/text.txt", os.O_CREATE|os.O_RDWR, 0755)
+	assert.NoError(t, err)
+
+	data := []byte("Ceph uniquely delivers object, block, and file storage in one unified system.")
+
+	size, err := mount.Write(fd, data, uint64(len(data)), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, size, len(data))
+
+    err = mount.Lseek(fd, 5, os.SEEK_SET)
+    assert.NoError(t, err)
+
+	err = mount.Close(fd)
+	assert.NoError(t, err)
+
+	err = mount.Unlink("/text.txt")
 	assert.NoError(t, err)
 }

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -172,8 +172,8 @@ func TestChmod(t *testing.T) {
 	fd, err := mount.Open("/text.txt", os.O_CREATE, stats_before)
 	assert.NoError(t, err)
 
-    err = mount.Fchmod(fd, stats_after)
-    assert.NoError(t, err)
+	err = mount.Fchmod(fd, stats_after)
+	assert.NoError(t, err)
 
 	stats, err = os.Stat(CephMountTest + "text.txt")
 	assert.Equal(t, uint32(stats.Mode().Perm()), stats_after)
@@ -394,17 +394,17 @@ func TestTruncate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, size, len(data))
 
-    stat, err := mount.Stat("/text.txt")
+	stat, err := mount.Stat("/text.txt")
 	assert.Equal(t, int(stat.Size), len(data))
 
-    err = mount.FTruncate(fd, 20)
-    assert.NoError(t, err)
-    stat, err = mount.Stat("/text.txt")
+	err = mount.FTruncate(fd, 20)
+	assert.NoError(t, err)
+	stat, err = mount.Stat("/text.txt")
 	assert.Equal(t, int(stat.Size), 20)
 
-    err = mount.Truncate("/text.txt", 10)
-    assert.NoError(t, err)
-    stat, err = mount.Stat("/text.txt")
+	err = mount.Truncate("/text.txt", 10)
+	assert.NoError(t, err)
+	stat, err = mount.Stat("/text.txt")
 	assert.Equal(t, int(stat.Size), 10)
 
 	err = mount.Close(fd)
@@ -434,8 +434,8 @@ func TestLseek(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, size, len(data))
 
-    err = mount.Lseek(fd, 5, os.SEEK_SET)
-    assert.NoError(t, err)
+	err = mount.Lseek(fd, 5, os.SEEK_SET)
+	assert.NoError(t, err)
 
 	err = mount.Close(fd)
 	assert.NoError(t, err)

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	CephMountTest string = "/tmp/ceph/mds/mnt/"
-    CephConfTest string = "/tmp/ceph/ceph.conf"
+	CephConfTest  string = "/tmp/ceph/ceph.conf"
 )
 
 func TestCreateMount(t *testing.T) {

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -345,6 +345,9 @@ func TestStat(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, stat.IsFile, true)
 
+	mode := stat.StrMode()
+	assert.Equal(t, mode, "-rwxr-xr-x")
+
 	stat, err = mount.FStat(fd)
 	assert.NoError(t, err)
 	assert.Equal(t, stat.IsFile, true)

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	CephMountTest string = "/tmp/ceph/mds/mnt/"
+    CephConfTest string = "/tmp/ceph/ceph.conf"
 )
 
 func TestCreateMount(t *testing.T) {
@@ -28,7 +29,7 @@ func TestMountRoot(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
-	err = mount.ReadConfigFile("/etc/ceph/ceph.conf")
+	err = mount.ReadConfigFile(CephConfTest)
 	assert.NoError(t, err)
 
 	err = mount.MountRoot("/")
@@ -345,7 +346,6 @@ func TestStat(t *testing.T) {
 	assert.Equal(t, stat.IsFile, true)
 
 	stat, err = mount.FStat(fd)
-	fmt.Println(stat)
 	assert.NoError(t, err)
 	assert.Equal(t, stat.IsFile, true)
 

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -14,32 +14,36 @@ var (
 )
 
 func TestCreateMount(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
+
+	mountAdmin, err := cephfs.CreateMountWithClient("admin")
+	assert.NoError(t, err)
+	assert.NotNil(t, mountAdmin)
 }
 
 func TestMountRoot(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
-	err = mount.ReadDefaultConfigFile()
+	err = mount.ReadConfigFile("/etc/ceph/ceph.conf")
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.MountRoot("/")
 	assert.NoError(t, err)
 }
 
 func TestSyncFs(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	err = mount.SyncFs()
@@ -47,14 +51,14 @@ func TestSyncFs(t *testing.T) {
 }
 
 func TestChangeDir(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	dir1 := mount.CurrentDir()
@@ -79,14 +83,14 @@ func TestChangeDir(t *testing.T) {
 
 func TestRemoveDir(t *testing.T) {
 	dirname := "one"
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	err = mount.MakeDir(dirname, 0755)
@@ -108,7 +112,7 @@ func TestRemoveDir(t *testing.T) {
 }
 
 func TestUnmountMount(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 	fmt.Printf("%#v\n", mount.IsMounted())
@@ -116,7 +120,7 @@ func TestUnmountMount(t *testing.T) {
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 	assert.True(t, mount.IsMounted())
 
@@ -126,7 +130,7 @@ func TestUnmountMount(t *testing.T) {
 }
 
 func TestReleaseMount(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
@@ -138,14 +142,14 @@ func TestChmod(t *testing.T) {
 	dirname := "two"
 	var stats_before uint32 = 0755
 	var stats_after uint32 = 0700
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	err = mount.MakeDir(dirname, stats_before)
@@ -192,14 +196,14 @@ func TestChown(t *testing.T) {
 	var bob uint32 = 1010
 	var root uint32 = 0
 
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	err = mount.MakeDir(dirname, 0755)
@@ -221,6 +225,7 @@ func TestChown(t *testing.T) {
 	stats, err = os.Stat(CephMountTest + dirname)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(stats.Sys().(*syscall.Stat_t).Uid), bob)
+	assert.Equal(t, uint32(stats.Sys().(*syscall.Stat_t).Gid), bob)
 
 	err = mount.RemoveDir(dirname)
 	assert.NoError(t, err)
@@ -230,7 +235,7 @@ func TestSetGetConf(t *testing.T) {
 	value := "cephx"
 	option := "auth supported"
 
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
@@ -247,14 +252,14 @@ func TestSetGetConf(t *testing.T) {
 }
 
 func TestOpenClose(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	fd, err := mount.Open("/text.txt", os.O_CREATE, 0755)
@@ -268,14 +273,14 @@ func TestOpenClose(t *testing.T) {
 }
 
 func TestWriteRead(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	fd, err := mount.Open("/text.txt", os.O_CREATE|os.O_RDWR, 0755)
@@ -299,14 +304,14 @@ func TestWriteRead(t *testing.T) {
 }
 
 func TestListDir(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	err = mount.MakeDir("/testdir", 0755)
@@ -321,23 +326,27 @@ func TestListDir(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestStatLink(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+func TestStat(t *testing.T) {
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	fd, err := mount.Open("/text.txt", os.O_CREATE, 0755)
 	assert.NoError(t, err)
-	err = mount.Close(fd)
-	assert.NoError(t, err)
 
 	stat, err := mount.LStat("/text.txt")
+	assert.NoError(t, err)
+	assert.Equal(t, stat.IsFile, true)
+
+	stat, err = mount.FStat(fd)
+	fmt.Println(stat)
+	assert.NoError(t, err)
 	assert.Equal(t, stat.IsFile, true)
 
 	err = mount.MakeDir("/testdir", 0755)
@@ -345,9 +354,33 @@ func TestStatLink(t *testing.T) {
 	stat, err = mount.Stat("/testdir")
 	assert.Equal(t, stat.IsDir, true)
 
+	err = mount.Close(fd)
+	assert.NoError(t, err)
+
+	err = mount.Unlink("/text.txt")
+	assert.NoError(t, err)
+
+	err = mount.RemoveDir("/testdir")
+	assert.NoError(t, err)
+}
+
+func TestLink(t *testing.T) {
+	mount, err := cephfs.CreateMount()
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+
+	err = mount.ReadDefaultConfigFile()
+	assert.NoError(t, err)
+
+	err = mount.Mount()
+	assert.NoError(t, err)
+
+	fd, err := mount.Open("/text.txt", os.O_CREATE, 0755)
+	assert.NoError(t, err)
+
 	err = mount.Link("/text.txt", "/hardLink")
 	assert.NoError(t, err)
-	stat, err = mount.LStat("/hardLink")
+	stat, err := mount.LStat("/hardLink")
 	assert.Equal(t, stat.IsSymlink, false)
 
 	err = mount.Symlink("/text.txt", "/link")
@@ -357,11 +390,15 @@ func TestStatLink(t *testing.T) {
 	stat, err = mount.LStat("/link")
 	assert.Equal(t, stat.IsSymlink, true)
 
-	/*
-	   name, err := mount.ReadLink("/link")
-	   assert.NoError(t, err)
-	   assert.Equal(t, "/text.txt", name)
-	*/
+	cwd := mount.CurrentDir()
+	fmt.Println(cwd)
+
+	name, err = mount.ReadLink("/link")
+	assert.NoError(t, err)
+	assert.Equal(t, "/text.txt", name)
+
+	err = mount.Close(fd)
+	assert.NoError(t, err)
 
 	err = mount.Unlink("/link")
 	assert.NoError(t, err)
@@ -369,20 +406,17 @@ func TestStatLink(t *testing.T) {
 	assert.NoError(t, err)
 	err = mount.Unlink("/text.txt")
 	assert.NoError(t, err)
-
-	err = mount.RemoveDir("/testdir")
-	assert.NoError(t, err)
 }
 
 func TestTruncate(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	fd, err := mount.Open("/text.txt", os.O_CREATE|os.O_RDWR, 0755)
@@ -415,14 +449,14 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestLseek(t *testing.T) {
-	mount, err := cephfs.CreateMount("")
+	mount, err := cephfs.CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 
 	err = mount.ReadDefaultConfigFile()
 	assert.NoError(t, err)
 
-	err = mount.Mount("/")
+	err = mount.Mount()
 	assert.NoError(t, err)
 
 	fd, err := mount.Open("/text.txt", os.O_CREATE|os.O_RDWR, 0755)


### PR DESCRIPTION
Compared with Java/Python Bindings, the Go version for CephFS part is poor, thus I add more support for CephFS, feature including
1. File Open/Close
2. File Read/Write
3. File Stat
4. Link/SymLink
5. ListDir
6. Lseek
7. Truncate