### PR TITLE
add rados aio operation support

### DIFF
--- a/rados/future.go
+++ b/rados/future.go
@@ -1,0 +1,118 @@
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <stdlib.h>
+// #include <rados/librados.h>
+// extern void commit_callback(rados_completion_t comp, void *arg);
+// extern int create_aio_read_completion(void* p, int* ret, rados_completion_t* comp);
+// extern int create_aio_write_completion(void* p, int* ret, rados_completion_t* comp);
+// typedef struct callback_args_t {
+//     void* lock;
+//     int*  ret;
+// } callback_args_t;
+import "C"
+
+import (
+	"sync"
+	"unsafe"
+)
+
+type IOType int
+
+const (
+	IORead IOType = iota
+	IOWrite
+	IOAppend
+)
+
+//AioComplete is a wrapper of the callback
+//export AioComplete
+func AioComplete(p unsafe.Pointer, ret int) {
+	arg := (*C.callback_args_t)(p)
+	*arg.ret = C.int(ret)
+	(*sync.Mutex)(arg.lock).Unlock()
+}
+
+type future interface {
+	// Get should block until the work is completed.
+	Get() (interface{}, error)
+}
+
+type aioFuture struct {
+	err    error
+	n      *int
+	o      sync.Once
+	buf    []byte
+	offset uint64
+	oid    string
+	ioctx  *IOContext
+	tp     IOType
+	mu     *sync.Mutex
+}
+
+func (a *aioFuture) read() {
+	c_oid := C.CString(a.oid)
+	defer C.free(unsafe.Pointer(c_oid))
+	var comp C.rados_completion_t
+	ret := C.create_aio_read_completion(unsafe.Pointer(a.mu), (*C.int)(unsafe.Pointer(a.n)), &comp)
+	if err := GetRadosError(int(ret)); err != nil {
+		a.err = err
+		return
+	}
+	a.mu.Lock()
+	ret = C.rados_aio_read(a.ioctx.ioctx, c_oid, comp, (*C.char)(unsafe.Pointer(&a.buf[0])), (C.size_t)(len(a.buf)), (C.uint64_t)(a.offset))
+	if err := GetRadosError(int(ret)); err != nil {
+		a.err = err
+		return
+	}
+}
+
+// Get will be blocked until the aio callback is called.
+func (a *aioFuture) Get() (interface{}, error) {
+	a.o.Do(func() {
+		if a.err != nil {
+			return
+		}
+		a.mu.Lock()
+		if int(*a.n) < 0 {
+			a.err = GetRadosError(int(*a.n))
+		}
+	})
+	return int(*a.n), a.err
+}
+
+func (a *aioFuture) write() {
+	c_oid := C.CString(a.oid)
+	defer C.free(unsafe.Pointer(c_oid))
+	var comp C.rados_completion_t
+	ret := C.create_aio_write_completion(unsafe.Pointer(a.mu), (*C.int)(unsafe.Pointer(a.n)), &comp)
+	if err := GetRadosError(int(ret)); err != nil {
+		a.err = err
+		return
+	}
+	a.mu.Lock()
+	ret = C.rados_aio_write(a.ioctx.ioctx, c_oid, comp, (*C.char)(unsafe.Pointer(&a.buf[0])), (C.size_t)(len(a.buf)), (C.uint64_t)(a.offset))
+	if err := GetRadosError(int(ret)); err != nil {
+		a.err = err
+		return
+	}
+
+}
+
+func (a *aioFuture) append() {
+	c_oid := C.CString(a.oid)
+	defer C.free(unsafe.Pointer(c_oid))
+	var comp C.rados_completion_t
+	ret := C.create_aio_write_completion(unsafe.Pointer(a.mu), (*C.int)(unsafe.Pointer(a.n)), (*C.rados_completion_t)(&comp))
+	if err := GetRadosError(int(ret)); err != nil {
+		a.err = err
+		return
+	}
+	a.mu.Lock()
+	ret = C.rados_aio_append(a.ioctx.ioctx, c_oid, comp, (*C.char)(unsafe.Pointer(&a.buf[0])), (C.size_t)(len(a.buf)))
+	if err := GetRadosError(int(ret)); err != nil {
+		a.err = err
+		return
+	}
+
+}

--- a/rados/future.go
+++ b/rados/future.go
@@ -27,7 +27,7 @@ const (
 
 //AioComplete is a wrapper of the callback
 //export AioComplete
-func AioComplete(p unsafe.Pointer, ret int) {
+func AioComplete(p unsafe.Pointer, ret int32) {
 	arg := (*C.callback_args_t)(p)
 	*arg.ret = C.int(ret)
 	(*sync.Mutex)(arg.lock).Unlock()
@@ -40,7 +40,7 @@ type future interface {
 
 type aioFuture struct {
 	err    error
-	n      *int
+	n      *int32
 	o      sync.Once
 	buf    []byte
 	offset uint64
@@ -74,7 +74,7 @@ func (a *aioFuture) Get() (interface{}, error) {
 			return
 		}
 		a.mu.Lock()
-		if int(*a.n) < 0 {
+		if (*a.n) < 0 {
 			a.err = GetRadosError(int(*a.n))
 		}
 	})

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -11,6 +11,31 @@ package rados
 // 	*idx += strlen(*idx) + 1;
 // 	return copy;
 // }
+// typedef struct callback_args_t {
+//     void* lock;
+//     int*  ret;
+// } callback_args_t;
+//
+// void commit_callback(rados_completion_t comp, void *arg) {
+// 	int ret = rados_aio_get_return_value(comp);
+// 	AioComplete(arg, ret);
+//      rados_aio_release(comp);
+//      free(arg);
+// }
+//
+// int create_aio_read_completion(void* p, int* ret, rados_completion_t* comp) {
+//      callback_args_t* args = malloc(sizeof(callback_args_t));
+//      args->lock=p;
+//      args->ret=ret;
+//      return rados_aio_create_completion(args, NULL, commit_callback, comp);
+// }
+//
+// int create_aio_write_completion(void* p, int* ret, rados_completion_t* comp) {
+//      callback_args_t* args = malloc(sizeof(callback_args_t));
+//      args->lock=p;
+//      args->ret=ret;
+//      return rados_aio_create_completion(args, commit_callback, NULL, comp);
+// }
 //
 // #if __APPLE__
 // #define ceph_time_t __darwin_time_t
@@ -25,6 +50,7 @@ package rados
 import "C"
 
 import (
+	"sync"
 	"syscall"
 	"time"
 	"unsafe"
@@ -93,6 +119,22 @@ func (ioctx *IOContext) SetNamespace(namespace string) {
 	C.rados_ioctx_set_namespace(ioctx.ioctx, c_ns)
 }
 
+// AIOWrite writes data to object with key oid.
+// A future interface will be returned to get the write result.
+func (ioctx *IOContext) AIOWrite(oid string, data []byte, offset uint64) future {
+	f := &aioFuture{
+		buf:    data,
+		offset: offset,
+		oid:    oid,
+		ioctx:  ioctx,
+		tp:     IOWrite,
+		n:      new(int),
+		mu:     &sync.Mutex{},
+	}
+	f.write()
+	return f
+}
+
 // Write writes len(data) bytes to the object with key oid starting at byte
 // offset offset. It returns an error, if any.
 func (ioctx *IOContext) Write(oid string, data []byte, offset uint64) error {
@@ -125,6 +167,21 @@ func (ioctx *IOContext) WriteFull(oid string, data []byte) error {
 	return GetRadosError(int(ret))
 }
 
+// AIOAppend appends data to object with key oid.
+// A future interface will be returned to get the append result.
+func (ioctx *IOContext) AIOAppend(oid string, data []byte) future {
+	f := &aioFuture{
+		buf:   data,
+		oid:   oid,
+		ioctx: ioctx,
+		tp:    IOAppend,
+		n:     new(int),
+		mu:    &sync.Mutex{},
+	}
+	f.append()
+	return f
+}
+
 // Append appends len(data) bytes to the object with key oid.
 // The object is appended with the provided data. If the object exists,
 // it is atomically appended to. It returns an error, if any.
@@ -136,6 +193,22 @@ func (ioctx *IOContext) Append(oid string, data []byte) error {
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
 	return GetRadosError(int(ret))
+}
+
+// AIORead reads data from object with key oid.
+// A future interface will be returned to get the read result.
+func (ioctx *IOContext) AIORead(oid string, data []byte, offset uint64) future {
+	f := &aioFuture{
+		buf:    data,
+		offset: offset,
+		oid:    oid,
+		ioctx:  ioctx,
+		tp:     IORead,
+		n:      new(int),
+		mu:     &sync.Mutex{},
+	}
+	f.read()
+	return f
 }
 
 // Read reads up to len(data) bytes from the object with key oid starting at byte

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -128,7 +128,7 @@ func (ioctx *IOContext) AIOWrite(oid string, data []byte, offset uint64) future 
 		oid:    oid,
 		ioctx:  ioctx,
 		tp:     IOWrite,
-		n:      new(int),
+		n:      new(int32),
 		mu:     &sync.Mutex{},
 	}
 	f.write()
@@ -175,7 +175,7 @@ func (ioctx *IOContext) AIOAppend(oid string, data []byte) future {
 		oid:   oid,
 		ioctx: ioctx,
 		tp:    IOAppend,
-		n:     new(int),
+		n:     new(int32),
 		mu:    &sync.Mutex{},
 	}
 	f.append()
@@ -204,7 +204,7 @@ func (ioctx *IOContext) AIORead(oid string, data []byte, offset uint64) future {
 		oid:    oid,
 		ioctx:  ioctx,
 		tp:     IORead,
-		n:      new(int),
+		n:      new(int32),
 		mu:     &sync.Mutex{},
 	}
 	f.read()


### PR DESCRIPTION
All aio operation will return a future object to the caller.
If the caller call future.Get, the go routine will be blocked
until the aio callback is called which means the aio operation
is completed.

Signed-off-by: Liu Qing <liuqing@chinac.com>