### PR TITLE
makefile: support using other container runtimes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 DOCKER_CI_IMAGE = go-ceph-ci
+CONTAINER_CMD := docker
+CONTAINER_OPTS := --security-opt apparmor:unconfined
+
 build:
 	go build -v
 fmt:
@@ -7,11 +10,11 @@ test:
 	go test -v ./...
 
 test-docker: .build-docker
-	docker run --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --rm -it -v $(CURDIR):/go/src/github.com/ceph/go-ceph $(DOCKER_CI_IMAGE)
+	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm -it -v $(CURDIR):/go/src/github.com/ceph/go-ceph $(DOCKER_CI_IMAGE)
 
 .build-docker:
-	docker build -t $(DOCKER_CI_IMAGE) .
-	@docker inspect -f '{{.Id}}' $(DOCKER_CI_IMAGE) > .build-docker
+	$(CONTAINER_CMD) build -t $(DOCKER_CI_IMAGE) .
+	@$(CONTAINER_CMD) inspect -f '{{.Id}}' $(DOCKER_CI_IMAGE) > .build-docker
 
 check:
 	# TODO: add this when golint is fixed	@for d in $$(go list ./... | grep -v /vendor/); do golint -set_exit_status $${d}; done


### PR DESCRIPTION
Add new variables to the Makefile that allow the use of other container
runtimes (that have a docker compatible cli) and allow setting extra
opts to work on platforms that don't run apparmor.
All defaults continue to be the same as before.

Signed-off-by: John Mulligan <jmulligan@redhat.com>