### PR TITLE
Improve 'make test-docker'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG CEPH_REPO_URL=https://download.ceph.com/debian-luminous/
 RUN wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
 RUN apt-add-repository "deb ${CEPH_REPO_URL} xenial main"
 
-RUN add-apt-repository ppa:gophers/archive
+RUN add-apt-repository -y ppa:gophers/archive
 
 RUN apt-get update && apt-get install -y \
   ceph \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 DOCKER_CI_IMAGE = go-ceph-ci
 CONTAINER_CMD := docker
 CONTAINER_OPTS := --security-opt apparmor:unconfined
+VOLUME_FLAGS := 
+
+SELINUX := $(shell getenforce 2>/dev/null)
+ifeq ($(SELINUX),Enforcing)
+	VOLUME_FLAGS = :z
+endif
 
 build:
 	go build -v
@@ -10,7 +16,7 @@ test:
 	go test -v ./...
 
 test-docker: .build-docker
-	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm -it -v $(CURDIR):/go/src/github.com/ceph/go-ceph $(DOCKER_CI_IMAGE)
+	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm -it -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(DOCKER_CI_IMAGE)
 
 .build-docker:
 	$(CONTAINER_CMD) build -t $(DOCKER_CI_IMAGE) .


### PR DESCRIPTION
This PR fixes two issues where `make test-docker` does not work on my system:

1. blocked waiting for input while enabling ppa:gophers/archive repository
2. failure with `go get` dependencies