### PR TITLE
Makefile: Fix CONTAINER_OPTS for Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_CI_IMAGE = go-ceph-ci
 CONTAINER_CMD := docker
-CONTAINER_OPTS := --security-opt apparmor:unconfined
+CONTAINER_OPTS := --security-opt $(shell grep -q selinux /sys/kernel/security/lsm && echo "label=disabled" || echo "apparmor:unconfined")
 VOLUME_FLAGS := 
 
 SELINUX := $(shell getenforce 2>/dev/null)


### PR DESCRIPTION
Fedora based distributions don't use AppArmor but SELinux instead.
This change detects the distribution and sets the --security-opts
accordingly.

Signed-off-by: Sven Anderson <sven@redhat.com>