### PR TITLE
rbd: use uuid library, rather than shelling out, in rbd test

### DIFF
--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -3,13 +3,13 @@ package rbd_test
 import (
 	"bytes"
 	"encoding/json"
-	"os/exec"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/ceph/go-ceph/rados"
 	"github.com/ceph/go-ceph/rbd"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,8 +19,7 @@ var RbdFeatureLayering = uint64(1 << 0)
 var RbdFeatureStripingV2 = uint64(1 << 1)
 
 func GetUUID() string {
-	out, _ := exec.Command("uuidgen").Output()
-	return string(out[:36])
+	return uuid.Must(uuid.NewV4()).String()
 }
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
Previously, the tests were shelling out to run 'uuidgen' which
is not particularly efficient and a bit ugly. Switch this test
to use the same uuid library already in use by the rados test code.

Signed-off-by: John Mulligan <jmulligan@redhat.com>