### PR TITLE
[RFC] Custom logging infrastructure

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -10,7 +10,6 @@ import "C"
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"math"
 	"syscall"
 	"unsafe"

--- a/cephfs/log.go
+++ b/cephfs/log.go
@@ -1,0 +1,12 @@
+package cephfs
+
+import (
+	"github.com/ceph/go-ceph/logging"
+)
+
+var log logging.Logger = logging.NewStubLogger()
+
+// SetLogger sets the logger l as the log destination for the cephfs package.
+func SetLogger(l logging.Logger) {
+	log = l
+}

--- a/logging/doc.go
+++ b/logging/doc.go
@@ -1,0 +1,27 @@
+/*
+Package logging provides hooks to support logging within the go-ceph library
+packages without depending on any particular logging library.
+
+The package provides a Logger interface that is fairly minimal with functions
+for logging error, info, and debug messages. Users of this library can provide
+any compatible type or write an adapter type for the logger in use as needed.
+
+Each package that supports logging will provide a SetLogger function to replace
+the current logger with the specified one.
+
+The logrus package is already compatible.
+Example:
+  package main
+
+  import (
+    "github.com/ceph/go-ceph/cephfs"
+    "github.com/sirupsen/logrus"
+  )
+
+  func main() {
+    // set up cephfs to use logrus logging
+    cephfs.SetLogger(logrus.New())
+  }
+
+*/
+package logging

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -1,0 +1,10 @@
+package logging
+
+// Logger is an interface that allows callers of the library to
+// provide the library packages with logging capabilities.
+//
+type Logger interface {
+	Errorf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+}

--- a/logging/stub.go
+++ b/logging/stub.go
@@ -1,0 +1,21 @@
+package logging
+
+// StubLogger is a type that meets the Logger interface but goes nowhere and
+// does nothing.
+type StubLogger struct{}
+
+func NewStubLogger() StubLogger {
+	return StubLogger{}
+}
+
+func (StubLogger) Errorf(format string, args ...interface{}) {
+	return
+}
+
+func (StubLogger) Infof(format string, args ...interface{}) {
+	return
+}
+
+func (StubLogger) Debugf(format string, args ...interface{}) {
+	return
+}

--- a/logging/stub_test.go
+++ b/logging/stub_test.go
@@ -1,0 +1,19 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInterface verifies that stub logger is something and that something
+// meets the Logger interface. StubLogger doesn't actually do anything
+// (intentionally) so there's not a lot more to assert.
+func TestInterface(t *testing.T) {
+	s := NewStubLogger()
+	assert.NotNil(t, s)
+
+	var l Logger = s
+	l.Errorf("foo %v", 77)
+	l.Errorf("bar %v, %s", 101, "blat")
+}


### PR DESCRIPTION
While auditing the code I noted that the cephfs package relies on logrus. This bugged me as I feel that generally libraries should not a) require logging and b) mandate a particular logging approach.
In this PR I create a new helper package "logging" that defines a minimalistic interface for the kinds of logging this library may need along with a no-op StubLogger.
Then, the dependency on logrus is removed from cephfs and instead we rely on a private Logger var that can be set by the calling code by using SetLogger function call.