### PR TITLE
rbd: split Create() off into Create2() ad Create3() following librbd.h

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -174,6 +174,8 @@ func GetImage(ioctx *rados.IOContext, name string) *Image {
 }
 
 // int rbd_create(rados_ioctx_t io, const char *name, uint64_t size, int *order);
+//
+// But also (for backward compability):
 // int rbd_create2(rados_ioctx_t io, const char *name, uint64_t size,
 //          uint64_t features, int *order);
 // int rbd_create3(rados_ioctx_t io, const char *name, uint64_t size,
@@ -183,28 +185,72 @@ func Create(ioctx *rados.IOContext, name string, size uint64, order int,
 	args ...uint64) (image *Image, err error) {
 	var ret C.int
 
-	c_order := C.int(order)
-	c_name := C.CString(name)
-
-	defer C.free(unsafe.Pointer(c_name))
-
 	switch len(args) {
 	case 3:
-		ret = C.rbd_create3(C.rados_ioctx_t(ioctx.Pointer()),
-			c_name, C.uint64_t(size),
-			C.uint64_t(args[0]), &c_order,
-			C.uint64_t(args[1]), C.uint64_t(args[2]))
+		return Create3(ioctx, name, size, args[0], order, args[1],
+			args[2])
 	case 1:
-		ret = C.rbd_create2(C.rados_ioctx_t(ioctx.Pointer()),
-			c_name, C.uint64_t(size),
-			C.uint64_t(args[0]), &c_order)
+		return Create2(ioctx, name, size, args[0], order)
 	case 0:
+		c_order := C.int(order)
+		c_name := C.CString(name)
+
+		defer C.free(unsafe.Pointer(c_name))
+
 		ret = C.rbd_create(C.rados_ioctx_t(ioctx.Pointer()),
 			c_name, C.uint64_t(size), &c_order)
 	default:
 		return nil, errors.New("Wrong number of argument")
 	}
 
+	if ret < 0 {
+		return nil, RBDError(ret)
+	}
+
+	return &Image{
+		ioctx: ioctx,
+		name:  name,
+	}, nil
+}
+
+// int rbd_create2(rados_ioctx_t io, const char *name, uint64_t size,
+//          uint64_t features, int *order);
+func Create2(ioctx *rados.IOContext, name string, size uint64, features uint64,
+	order int) (image *Image, err error) {
+	var ret C.int
+
+	c_order := C.int(order)
+	c_name := C.CString(name)
+
+	defer C.free(unsafe.Pointer(c_name))
+
+	ret = C.rbd_create2(C.rados_ioctx_t(ioctx.Pointer()), c_name,
+		C.uint64_t(size), C.uint64_t(features), &c_order)
+	if ret < 0 {
+		return nil, RBDError(ret)
+	}
+
+	return &Image{
+		ioctx: ioctx,
+		name:  name,
+	}, nil
+}
+
+// int rbd_create3(rados_ioctx_t io, const char *name, uint64_t size,
+//        uint64_t features, int *order,
+//        uint64_t stripe_unit, uint64_t stripe_count);
+func Create3(ioctx *rados.IOContext, name string, size uint64, features uint64,
+	order int, stripe_unit uint64, stripe_count uint64) (image *Image, err error) {
+	var ret C.int
+
+	c_order := C.int(order)
+	c_name := C.CString(name)
+
+	defer C.free(unsafe.Pointer(c_name))
+
+	ret = C.rbd_create3(C.rados_ioctx_t(ioctx.Pointer()), c_name,
+		C.uint64_t(size), C.uint64_t(features), &c_order,
+		C.uint64_t(stripe_unit), C.uint64_t(stripe_count))
 	if ret < 0 {
 		return nil, RBDError(ret)
 	}

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -28,7 +28,7 @@ func TestVersion(t *testing.T) {
 	assert.False(t, patch < 0 || patch > 1000, "invalid patch")
 }
 
-func TestCreateImage(t *testing.T) {
+func TestImageCreate(t *testing.T) {
 	conn, _ := rados.NewConn()
 	conn.ReadDefaultConfigFile()
 	conn.Connect()
@@ -56,6 +56,54 @@ func TestCreateImage(t *testing.T) {
 	name = GetUUID()
 	image, err = rbd.Create(ioctx, name, 1<<22, 22,
 		RbdFeatureLayering|RbdFeatureStripingV2, 4096, 2)
+	assert.NoError(t, err)
+	err = image.Remove()
+	assert.NoError(t, err)
+
+	ioctx.Destroy()
+	conn.DeletePool(poolname)
+	conn.Shutdown()
+}
+
+func TestImageCreate2(t *testing.T) {
+	conn, _ := rados.NewConn()
+	conn.ReadDefaultConfigFile()
+	conn.Connect()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	assert.NoError(t, err)
+
+	name := GetUUID()
+	image, err := rbd.Create2(ioctx, name, 1<<22,
+		RbdFeatureLayering|RbdFeatureStripingV2, 22)
+	assert.NoError(t, err)
+	err = image.Remove()
+	assert.NoError(t, err)
+
+	ioctx.Destroy()
+	conn.DeletePool(poolname)
+	conn.Shutdown()
+}
+
+func TestImageCreate3(t *testing.T) {
+	conn, _ := rados.NewConn()
+	conn.ReadDefaultConfigFile()
+	conn.Connect()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	assert.NoError(t, err)
+
+	name := GetUUID()
+	image, err := rbd.Create3(ioctx, name, 1<<22,
+		RbdFeatureLayering|RbdFeatureStripingV2, 22, 4096, 2)
 	assert.NoError(t, err)
 	err = image.Remove()
 	assert.NoError(t, err)


### PR DESCRIPTION
The C library offers rbd_create2() and rbd_create3() and does not try to
cover all options with rbd_create(). For users that are familiar with
the C API, the Create2() and Create3() functions have been added.

The existing Create() API still handles the complete set of
rbd_create*() functions, so backwards compatibility is covered.

**Note:** `Create4()` is added with #111 
<hr/>
If this is accepted, adding the other variations for `Clone*()` and so on would be needed too. This can be done in addition PRs, or I can extend this one.