### PR TITLE
Increase test coverage for RBD package

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -47,6 +47,11 @@ const (
 
 	// Features that only work when used with a single client using the image for writes.
 	RbdFeaturesSingleClient = uint64(C.RBD_FEATURES_SINGLE_CLIENT)
+
+	// Image.Seek() constants
+	SeekSet = int(C.SEEK_SET)
+	SeekCur = int(C.SEEK_CUR)
+	SeekEnd = int(C.SEEK_END)
 )
 
 // bits for Image.validate() and Snapshot.validate()
@@ -863,11 +868,11 @@ func (image *Image) Write(data []byte) (n int, err error) {
 
 func (image *Image) Seek(offset int64, whence int) (int64, error) {
 	switch whence {
-	case 0:
+	case SeekSet:
 		image.offset = offset
-	case 1:
+	case SeekCur:
 		image.offset += offset
-	case 2:
+	case SeekEnd:
 		stats, err := image.Stat()
 		if err != nil {
 			return 0, err

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -24,29 +24,29 @@ import (
 
 const (
 	// RBD features.
-	RbdFeatureLayering      = C.RBD_FEATURE_LAYERING
-	RbdFeatureStripingV2    = C.RBD_FEATURE_STRIPINGV2
-	RbdFeatureExclusiveLock = C.RBD_FEATURE_EXCLUSIVE_LOCK
-	RbdFeatureObjectMap     = C.RBD_FEATURE_OBJECT_MAP
-	RbdFeatureFastDiff      = C.RBD_FEATURE_FAST_DIFF
-	RbdFeatureDeepFlatten   = C.RBD_FEATURE_DEEP_FLATTEN
-	RbdFeatureJournaling    = C.RBD_FEATURE_JOURNALING
-	RbdFeatureDataPool      = C.RBD_FEATURE_DATA_POOL
+	RbdFeatureLayering      = uint64(C.RBD_FEATURE_LAYERING)
+	RbdFeatureStripingV2    = uint64(C.RBD_FEATURE_STRIPINGV2)
+	RbdFeatureExclusiveLock = uint64(C.RBD_FEATURE_EXCLUSIVE_LOCK)
+	RbdFeatureObjectMap     = uint64(C.RBD_FEATURE_OBJECT_MAP)
+	RbdFeatureFastDiff      = uint64(C.RBD_FEATURE_FAST_DIFF)
+	RbdFeatureDeepFlatten   = uint64(C.RBD_FEATURE_DEEP_FLATTEN)
+	RbdFeatureJournaling    = uint64(C.RBD_FEATURE_JOURNALING)
+	RbdFeatureDataPool      = uint64(C.RBD_FEATURE_DATA_POOL)
 
-	RbdFeaturesDefault = C.RBD_FEATURES_DEFAULT
+	RbdFeaturesDefault = uint64(C.RBD_FEATURES_DEFAULT)
 
 	// Features that make an image inaccessible for read or write by clients that don't understand
 	// them.
-	RbdFeaturesIncompatible = C.RBD_FEATURES_INCOMPATIBLE
+	RbdFeaturesIncompatible = uint64(C.RBD_FEATURES_INCOMPATIBLE)
 
 	// Features that make an image unwritable by clients that don't understand them.
-	RbdFeaturesRwIncompatible = C.RBD_FEATURES_RW_INCOMPATIBLE
+	RbdFeaturesRwIncompatible = uint64(C.RBD_FEATURES_RW_INCOMPATIBLE)
 
 	// Features that may be dynamically enabled or disabled.
-	RbdFeaturesMutable = C.RBD_FEATURES_MUTABLE
+	RbdFeaturesMutable = uint64(C.RBD_FEATURES_MUTABLE)
 
 	// Features that only work when used with a single client using the image for writes.
-	RbdFeaturesSingleClient = C.RBD_FEATURES_SINGLE_CLIENT
+	RbdFeaturesSingleClient = uint64(C.RBD_FEATURES_SINGLE_CLIENT)
 )
 
 // bits for Image.validate() and Snapshot.validate()

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -885,13 +885,17 @@ func (image *Image) Seek(offset int64, whence int) (int64, error) {
 }
 
 // int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
-func (image *Image) Discard(ofs uint64, length uint64) error {
+func (image *Image) Discard(ofs uint64, length uint64) (int, error) {
 	if err := image.validate(imageIsOpen); err != nil {
-		return err
+		return 0, err
 	}
 
-	return RBDError(C.rbd_discard(image.image, C.uint64_t(ofs),
-		C.uint64_t(length)))
+	ret := C.rbd_discard(image.image, C.uint64_t(ofs), C.uint64_t(length))
+	if ret < 0 {
+		return 0, RBDError(ret)
+	}
+
+	return int(ret), nil
 }
 
 func (image *Image) ReadAt(data []byte, off int64) (n int, err error) {

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -226,7 +226,7 @@ func TestGetImageNames(t *testing.T) {
 	conn.Shutdown()
 }
 
-func TestImageReadOnly(t *testing.T) {
+func TestImageOpen(t *testing.T) {
 	conn, _ := rados.NewConn()
 	conn.ReadDefaultConfigFile()
 	conn.Connect()
@@ -242,6 +242,11 @@ func TestImageReadOnly(t *testing.T) {
 	image, err := Create(ioctx, name, 1<<22, 22)
 	assert.NoError(t, err)
 
+	// an integer is not a valid argument
+	err = image.Open(123)
+	assert.Error(t, err)
+
+	// open read-only
 	err = image.Open(true)
 	assert.NoError(t, err)
 

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -652,6 +652,10 @@ func TestParentInfo(t *testing.T) {
 	assert.Equal(t, len(pools), 0, "pools equal")
 	assert.Equal(t, len(images), 0, "children length equal")
 
+	// invalid order, should fail
+	_, err = img.Clone("mysnap", ioctx, "child", 1, -1)
+	assert.Error(t, err)
+
 	imgNew, err := img.Clone("mysnap", ioctx, "child", 1, 22)
 	assert.NoError(t, err)
 

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -226,6 +226,35 @@ func TestGetImageNames(t *testing.T) {
 	conn.Shutdown()
 }
 
+func TestImageRename(t *testing.T) {
+	conn, _ := rados.NewConn()
+	conn.ReadDefaultConfigFile()
+	conn.Connect()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+
+	name := GetUUID()
+	img, err := Create(ioctx, name, 1<<22, 22)
+	assert.NoError(t, err)
+
+	err = img.Rename(name)
+	assert.Error(t, err)
+
+	err = img.Rename(GetUUID())
+	assert.NoError(t, err)
+
+	img.Remove()
+
+	ioctx.Destroy()
+	conn.DeletePool(poolname)
+	conn.Shutdown()
+}
+
 func TestIOReaderWriter(t *testing.T) {
 	conn, _ := rados.NewConn()
 	conn.ReadDefaultConfigFile()


### PR DESCRIPTION
With these changes the test coverage of `rbd/rbd.go` increases to 69.3% (from 59.3% on current master, hence the edits of this message).

Minor improvements might have sneaked in (constants for `Image.Seek()` `whence` values), and improvements for `Image.Discard()` as mentioned in #123.