### PR TITLE
github: configure a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+
+<!--
+Thank you for opening a pull request. Please provide:
+
+- A clear summary of your changes
+
+- Descriptive and succinct commit messages with the format:
+  """
+  [topic]: [short description]
+
+  [Longer description]
+
+  Signed-off-by: [Your Name] <[your email]>
+  """
+
+  Topic will generally be the go ceph package dir you are working in.
+
+- Ensure checklist items listed below are accounted for
+-->
+
+## Checklist
+- [ ] Added tests for features and functional changes
+- [ ] Public functions and types are documented
+- [ ] Standard formatting is applied to Go code


### PR DESCRIPTION
Template provides brief reminders on what the project expects on
all prs. Some of the boilerplate I borrowed from ceph/ceph's template other parts are just what's been frequently requested in existing PRs.