### PR TITLE
Fix package comments for doc.go files

### DIFF
--- a/rados/doc.go
+++ b/rados/doc.go
@@ -1,4 +1,4 @@
 /*
-Set of wrappers around librados API.
+Package rados contains a set of wrappers around Ceph's librados API.
 */
 package rados

--- a/rbd/doc.go
+++ b/rbd/doc.go
@@ -1,4 +1,4 @@
 /*
-Wrappers around librbd.
+Package rbd contains a set of wrappers around Ceph's librbd API.
 */
 package rbd


### PR DESCRIPTION
The rbd and rados packages had doc.go files with only packages but the doc comment was not formatted in the standard manner. Change them to the standard style.