### PR TITLE
[RFC] Use the revive checker for style checks

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,33 @@
+
+ignoreGeneratedHeader = false
+severity = "warning"
+confidence = 0.8
+errorCode = 1
+warningCode = 0
+
+[directive.specify-disable-reason]
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.context-keys-type]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+#[rule.exported]
+[rule.if-return]
+[rule.increment-decrement]
+#[rule.var-naming]
+[rule.var-declaration]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.time-naming]
+[rule.unexported-return]
+#[rule.indent-error-flow]
+[rule.errorf]
+[rule.empty-block]
+[rule.superfluous-else]
+[rule.unused-parameter]
+[rule.unreachable-code]
+[rule.redefines-builtin-id]

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,10 @@ before_install: |
   docker build --build-arg CEPH_REPO_URL="${CEPH_REPO_URL}" -t ceph-golang-ci .
 
 before_script:
-  - go get golang.org/x/lint/golint
+  - go get github.com/mgechev/revive
 
 # cephfs (fuse) requires: --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined
 script:
   - docker run --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined --rm -it -v ${PWD}:/go/src/github.com/ceph/go-ceph:z ceph-golang-ci
-# run golint and other style checks
-  - go get golang.org/x/lint/golint
+# run style checks
   - make check

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,6 @@ test-docker: .build-docker
 	@$(CONTAINER_CMD) inspect -f '{{.Id}}' $(DOCKER_CI_IMAGE) > .build-docker
 
 check:
-	# TODO: add this when golint is fixed	@for d in $$(go list ./... | grep -v /vendor/); do golint -set_exit_status $${d}; done
-	@for d in $$(go list ./... | grep -v /vendor/); do golint $${d}; done
+	# Configure project's revive checks using .revive.toml
+	# See: https://github.com/mgechev/revive
+	@for d in $$(go list ./... | grep -v /vendor/); do revive -config .revive.toml $${d}; done


### PR DESCRIPTION
Unlike the rather strict golint tool the [revive](https://github.com/mgechev/revive) tool is configurable and will allow us to incrementally improve things and/or leave suboptimal items in place for backwards compatibility. This initial pr adds configuration for revive and uses it in the Travis CI config and Makefile.