### PR TITLE
rbd: use conventional naming style for errors

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -60,11 +60,15 @@ const (
 type RBDError int
 
 var (
-	RbdErrorNoIOContext    = errors.New("RBD image does not have an IOContext")
-	RbdErrorNoName         = errors.New("RBD image does not have a name")
-	RbdErrorSnapshotNoName = errors.New("RBD snapshot does not have a name")
-	RbdErrorImageNotOpen   = errors.New("RBD image not open")
-	RbdErrorNotFound       = errors.New("RBD image not found")
+	ErrNoIOContext    = errors.New("RBD image does not have an IOContext")
+	ErrNoName         = errors.New("RBD image does not have a name")
+	ErrSnapshotNoName = errors.New("RBD snapshot does not have a name")
+	ErrImageNotOpen   = errors.New("RBD image not open")
+	ErrNotFound       = errors.New("RBD image not found")
+
+	// retained for compatibility with old versions
+	RbdErrorImageNotOpen = ErrImageNotOpen
+	RbdErrorNotFound     = ErrNotFound
 )
 
 //
@@ -140,11 +144,11 @@ func hasBit(value, bit uint32) bool {
 // case the attribute is not set
 func (image *Image) validate(req uint32) error {
 	if hasBit(req, imageNeedsName) && image.name == "" {
-		return RbdErrorNoName
+		return ErrNoName
 	} else if hasBit(req, imageNeedsIOContext) && image.ioctx == nil {
-		return RbdErrorNoIOContext
+		return ErrNoIOContext
 	} else if hasBit(req, imageIsOpen) && image.image == nil {
-		return RbdErrorImageNotOpen
+		return ErrImageNotOpen
 	}
 
 	return nil
@@ -155,7 +159,7 @@ func (image *Image) validate(req uint32) error {
 // Calls snapshot.image.validate(req) to validate the image attributes.
 func (snapshot *Snapshot) validate(req uint32) error {
 	if hasBit(req, snapshotNeedsName) && snapshot.name == "" {
-		return RbdErrorSnapshotNoName
+		return ErrSnapshotNoName
 	} else if snapshot.image != nil {
 		return snapshot.image.validate(req)
 	}
@@ -184,7 +188,7 @@ func (e RBDError) Error() string {
 func GetError(err C.int) error {
 	if err != 0 {
 		if err == -C.ENOENT {
-			return RbdErrorNotFound
+			return ErrNotFound
 		}
 		return RBDError(err)
 	} else {

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -449,64 +449,64 @@ func TestErrorImageNotOpen(t *testing.T) {
 	image := rbd.GetImage(nil, "nonexistent")
 
 	err := image.Close()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	err = image.Resize(2 << 22)
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.Stat()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.IsOldFormat()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.GetSize()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.GetFeatures()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.GetStripeUnit()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.GetStripeCount()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.GetOverlap()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	err = image.Flatten()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, _, err = image.ListChildren()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, _, err = image.ListLockers()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	err = image.LockExclusive("a magic cookie")
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	err = image.LockShared("a magic cookie", "tasty")
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	err = image.BreakLock("a magic cookie", "tasty")
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.Read(nil)
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.Write(nil)
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.ReadAt(nil, 0)
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	_, err = image.WriteAt(nil, 0)
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 
 	err = image.Flush()
-	assert.Equal(t, err, rbd.RbdErrorImageNotOpen)
+	assert.Equal(t, err, rbd.ErrImageNotOpen)
 }
 
 func TestNotFound(t *testing.T) {
@@ -525,10 +525,10 @@ func TestNotFound(t *testing.T) {
 
 	img := rbd.GetImage(ioctx, name)
 	err = img.Open()
-	assert.Equal(t, err, rbd.RbdErrorNotFound)
+	assert.Equal(t, err, rbd.ErrNotFound)
 
 	err = img.Remove()
-	assert.Equal(t, err, rbd.RbdErrorNotFound)
+	assert.Equal(t, err, rbd.ErrNotFound)
 
 	ioctx.Destroy()
 	conn.DeletePool(poolname)

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -414,35 +414,35 @@ func TestNoIOContext(t *testing.T) {
 	image := rbd.GetImage(nil, "nonexistent")
 
 	_, err := image.Clone("new snapshot", nil, "clone", 0, 0)
-	assert.Equal(t, err, rbd.RbdErrorNoIOContext)
+	assert.Equal(t, err, rbd.ErrNoIOContext)
 
 	err = image.Remove()
-	assert.Equal(t, err, rbd.RbdErrorNoIOContext)
+	assert.Equal(t, err, rbd.ErrNoIOContext)
 
 	err = image.Trash(15 * time.Second)
-	assert.Equal(t, err, rbd.RbdErrorNoIOContext)
+	assert.Equal(t, err, rbd.ErrNoIOContext)
 
 	err = image.Rename("unknown")
-	assert.Equal(t, err, rbd.RbdErrorNoIOContext)
+	assert.Equal(t, err, rbd.ErrNoIOContext)
 
 	err = image.Open()
-	assert.Equal(t, err, rbd.RbdErrorNoIOContext)
+	assert.Equal(t, err, rbd.ErrNoIOContext)
 }
 
 func TestErrorNoName(t *testing.T) {
 	image := rbd.GetImage(nil, "")
 
 	err := image.Remove()
-	assert.Equal(t, err, rbd.RbdErrorNoName)
+	assert.Equal(t, err, rbd.ErrNoName)
 
 	err = image.Trash(15 * time.Second)
-	assert.Equal(t, err, rbd.RbdErrorNoName)
+	assert.Equal(t, err, rbd.ErrNoName)
 
 	err = image.Rename("unknown")
-	assert.Equal(t, err, rbd.RbdErrorNoName)
+	assert.Equal(t, err, rbd.ErrNoName)
 
 	err = image.Open()
-	assert.Equal(t, err, rbd.RbdErrorNoName)
+	assert.Equal(t, err, rbd.ErrNoName)
 }
 
 func TestErrorImageNotOpen(t *testing.T) {
@@ -562,22 +562,22 @@ func TestErrorSnapshotNoName(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = snapshot.Remove()
-	assert.Equal(t, err, rbd.RbdErrorSnapshotNoName)
+	assert.Equal(t, err, rbd.ErrSnapshotNoName)
 
 	err = snapshot.Rollback()
-	assert.Equal(t, err, rbd.RbdErrorSnapshotNoName)
+	assert.Equal(t, err, rbd.ErrSnapshotNoName)
 
 	err = snapshot.Protect()
-	assert.Equal(t, err, rbd.RbdErrorSnapshotNoName)
+	assert.Equal(t, err, rbd.ErrSnapshotNoName)
 
 	err = snapshot.Unprotect()
-	assert.Equal(t, err, rbd.RbdErrorSnapshotNoName)
+	assert.Equal(t, err, rbd.ErrSnapshotNoName)
 
 	_, err = snapshot.IsProtected()
-	assert.Equal(t, err, rbd.RbdErrorSnapshotNoName)
+	assert.Equal(t, err, rbd.ErrSnapshotNoName)
 
 	err = snapshot.Set()
-	assert.Equal(t, err, rbd.RbdErrorSnapshotNoName)
+	assert.Equal(t, err, rbd.ErrSnapshotNoName)
 
 	// image can not be removed as the snapshot still exists
 	// err = img.Remove()


### PR DESCRIPTION
A recent PR added new error values that were similar to the existing
naming convention but were not the normal go convention. Change all the
errors to match typical convention but leave the older names as aliases
such that older code will continue to work (for now).