### PR TITLE
Make error handling more common 

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -10,19 +10,19 @@ import "C"
 
 import (
 	"fmt"
-	"math"
-	"syscall"
 	"unsafe"
+
+	"github.com/ceph/go-ceph/errutil"
 )
 
 type cephError int
 
 func (e cephError) Error() string {
-	if e == 0 {
-		return fmt.Sprintf("cephfs: no error given")
+	errno, s := errutil.FormatErrno(int(e))
+	if s == "" {
+		return fmt.Sprintf("cephfs: ret=%d", errno)
 	}
-	err := syscall.Errno(uint(math.Abs(float64(e))))
-	return fmt.Sprintf("cephfs: ret=(%d) %v", e, err)
+	return fmt.Sprintf("cephfs: ret=%d, %s", errno, s)
 }
 
 // MountInfo exports ceph's ceph_mount_info from libcephfs.cc

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -204,3 +204,16 @@ func TestChown(t *testing.T) {
 	assert.Equal(t, uint32(stats.Sys().(*syscall.Stat_t).Gid), bob)
 
 }
+
+func TestCephFSError(t *testing.T) {
+	err := getError(0)
+	assert.NoError(t, err)
+
+	err = getError(-5) // IO error
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "cephfs: ret=5, Input/output error")
+
+	err = getError(345) // no such errno
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "cephfs: ret=345")
+}

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -1,4 +1,4 @@
-package cephfs_test
+package cephfs
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/ceph/go-ceph/cephfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,13 +15,13 @@ var (
 )
 
 func TestCreateMount(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 }
 
 func TestMountRoot(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	require.NotNil(t, mount)
 
@@ -34,7 +33,7 @@ func TestMountRoot(t *testing.T) {
 }
 
 func TestSyncFs(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	require.NotNil(t, mount)
 
@@ -49,7 +48,7 @@ func TestSyncFs(t *testing.T) {
 }
 
 func TestChangeDir(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	require.NotNil(t, mount)
 
@@ -78,7 +77,7 @@ func TestChangeDir(t *testing.T) {
 
 func TestRemoveDir(t *testing.T) {
 	dirname := "one"
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	require.NotNil(t, mount)
 
@@ -107,7 +106,7 @@ func TestRemoveDir(t *testing.T) {
 }
 
 func TestUnmountMount(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	require.NotNil(t, mount)
 	fmt.Printf("%#v\n", mount.IsMounted())
@@ -125,7 +124,7 @@ func TestUnmountMount(t *testing.T) {
 }
 
 func TestReleaseMount(t *testing.T) {
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	require.NotNil(t, mount)
 
@@ -137,7 +136,7 @@ func TestChmodDir(t *testing.T) {
 	dirname := "two"
 	var stats_before uint32 = 0755
 	var stats_after uint32 = 0700
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	require.NotNil(t, mount)
 
@@ -173,7 +172,7 @@ func TestChown(t *testing.T) {
 	var bob uint32 = 1010
 	var root uint32 = 0
 
-	mount, err := cephfs.CreateMount()
+	mount, err := CreateMount()
 	assert.NoError(t, err)
 	require.NotNil(t, mount)
 

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	CephMountTest string = "/tmp/ceph/mds/mnt/"
+	CephMountTest = "/tmp/ceph/mds/mnt/"
 )
 
 func TestCreateMount(t *testing.T) {
@@ -170,7 +170,7 @@ func TestChown(t *testing.T) {
 	dirname := "three"
 	// dockerfile creates bob user account
 	var bob uint32 = 1010
-	var root uint32 = 0
+	var root uint32
 
 	mount, err := CreateMount()
 	assert.NoError(t, err)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,7 @@ else
     testargs=(\
         "-covermode=count" \
         "-coverprofile=cover.out" \
-        "-coverpkg=$P/cephfs,$P/rados,$P/rbd")
+        "-coverpkg=$P/cephfs,$P/rados,$P/rbd,$P/errutil")
     # disable caching of tests results
     testargs+=("-count=1")
     if [[ ${TEST_RUN} != ALL ]]; then

--- a/errutil/strerror.go
+++ b/errutil/strerror.go
@@ -1,0 +1,41 @@
+package errutil
+
+/* force XSI-complaint strerror_r() */
+
+// #define _POSIX_C_SOURCE 200112L
+// #undef _GNU_SOURCE
+// #include <stdlib.h>
+// #include <errno.h>
+// #include <string.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+// FormatErrno returns the absolute value of the errno as well as a string
+// describing the errno. The string will be empty is the errno is not known.
+func FormatErrno(errno int) (int, string) {
+	buf := make([]byte, 1024)
+	// strerror expects errno >= 0
+	if errno < 0 {
+		errno = -errno
+	}
+
+	ret := C.strerror_r(
+		C.int(errno),
+		(*C.char)(unsafe.Pointer(&buf[0])),
+		C.size_t(len(buf)))
+	if ret != 0 {
+		return errno, ""
+	}
+
+	return errno, C.GoString((*C.char)(unsafe.Pointer(&buf[0])))
+}
+
+// StrError returns a string describing the errno. The string will be empty if
+// the errno is not known.
+func StrError(errno int) string {
+	_, s := FormatErrno(errno)
+	return s
+}

--- a/errutil/strerror_test.go
+++ b/errutil/strerror_test.go
@@ -1,0 +1,32 @@
+package errutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatError(t *testing.T) {
+	e, msg := FormatErrno(39)
+	assert.Equal(t, 39, e)
+	assert.Equal(t, msg, "Directory not empty")
+
+	e, msg = FormatErrno(-5)
+	assert.Equal(t, 5, e)
+	assert.Equal(t, msg, "Input/output error")
+
+	e, msg = FormatErrno(345)
+	assert.Equal(t, 345, e)
+	assert.Equal(t, msg, "")
+}
+
+func TestStrError(t *testing.T) {
+	msg := StrError(39)
+	assert.Equal(t, msg, "Directory not empty")
+
+	msg = StrError(-5)
+	assert.Equal(t, msg, "Input/output error")
+
+	msg = StrError(345)
+	assert.Equal(t, msg, "")
+}

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -10,12 +10,18 @@ import (
 	"fmt"
 	"runtime"
 	"unsafe"
+
+	"github.com/ceph/go-ceph/errutil"
 )
 
 type RadosError int
 
 func (e RadosError) Error() string {
-	return fmt.Sprintf("rados: %s", C.GoString(C.strerror(C.int(-e))))
+	errno, s := errutil.FormatErrno(int(e))
+	if s == "" {
+		return fmt.Sprintf("rados: ret=%d", errno)
+	}
+	return fmt.Sprintf("rados: ret=%d, %s", errno, s)
 }
 
 var RadosAllNamespaces = C.LIBRADOS_ALL_NSPACES

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -1136,3 +1136,16 @@ func (suite *RadosTestSuite) TestOmapOnNonexistentObjectError() {
 func TestRadosTestSuite(t *testing.T) {
 	suite.Run(t, new(RadosTestSuite))
 }
+
+func TestRadosError(t *testing.T) {
+	err := GetRadosError(0)
+	assert.NoError(t, err)
+
+	err = GetRadosError(-5) // IO error
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "rados: ret=5, Input/output error")
+
+	err = GetRadosError(345) // no such errno
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "rados: ret=345")
+}

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -23,7 +23,7 @@ func TestRBDError(t *testing.T) {
 
 	err = GetError(-39) // NOTEMPTY (image still has a snapshot)
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "rbd: ret=-39, Directory not empty")
+	assert.Equal(t, err.Error(), "rbd: ret=39, Directory not empty")
 
 	err = GetError(345) // no such errno
 	assert.Error(t, err)


### PR DESCRIPTION
This series is insipred by #120 and refactors the changes there to use a common approach across all sub packages in the library. It incidentally also tries to clean up some of the disparate error handling approaches across the packages.

This PR is current do-not-merge because, due to mistakes and laziness it currently incorporates changes from other PRs. Please take a look at those first (PRs #130 and #131 IIRC) and I'll rebase when the time is right. This PR partially exists as a preview and so that I don't just sit on the work. :-)

Feel free to be harsh with the naming of the error handling utility functions and package that I added.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
