### PR TITLE
rbd: separate standard lib imports from pkg imports

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -15,10 +15,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/ceph/go-ceph/rados"
 	"io"
 	"time"
 	"unsafe"
+
+	"github.com/ceph/go-ceph/rados"
 )
 
 const (


### PR DESCRIPTION
By convention many projects are separating the golang stdlib imports
from other imports. Do that as well for rbd.go.

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [x] Standard formatting is applied to Go code
