### PR TITLE
Enable stricter checking by default

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -1,6 +1,6 @@
 
 ignoreGeneratedHeader = false
-severity = "warning"
+severity = "error"
 confidence = 0.8
 errorCode = 1
 warningCode = 0

--- a/.revive.toml
+++ b/.revive.toml
@@ -14,7 +14,8 @@ warningCode = 0
 [rule.error-return]
 [rule.error-strings]
 [rule.error-naming]
-#[rule.exported]
+[rule.exported]
+severity = "warning"
 [rule.if-return]
 [rule.increment-decrement]
 #[rule.var-naming]


### PR DESCRIPTION
Previously, revive was configured to only warn on detected issues.  We
have eliminated all those issues and so can set revive to error out and
thus the 'make check' rule will fail if new issues are introduced.

Also, enable exported vars check at the warning (non-failing) level.