### PR TITLE
rbd: remove usage of deprecated functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ matrix:
     - env: CEPH_VERSION=nautilus
 
 before_install: |
-  CEPH_REPO_URL="https://download.ceph.com/debian-${CEPH_VERSION}/"
-  docker build --build-arg CEPH_REPO_URL="${CEPH_REPO_URL}" -t ceph-golang-ci .
+  docker build --build-arg CEPH_VERSION="${CEPH_VERSION}" -t ceph-golang-ci .
 
 before_script:
   - go get github.com/mgechev/revive

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get update && apt-get install -y \
   uuid-runtime \
   wget
 
-ARG CEPH_REPO_URL=https://download.ceph.com/debian-nautilus/
+ARG CEPH_VERSION
+ENV CEPH_VERSION=${CEPH_VERSION:-nautilus}
+ARG CEPH_REPO_URL=https://download.ceph.com/debian-${CEPH_VERSION}/
 RUN wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
 RUN true && \
   apt-add-repository "deb ${CEPH_REPO_URL} xenial main" && \

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ On rpm based systems (dnf, yum, etc):
 libcephfs-devel librbd-devel librados-devel
 ```
 
+go-ceph tries to support different Ceph versions. However some functions might
+only be available in recent versions, and others can be deprecated. In order to
+work with non-current versions of Ceph, it is required to pass build-tags to on
+the `go` commandline. A tag with the named Ceph release will enable/disable
+certain features of the go-ceph packages, and prevent warnings or compile
+problems. E.g. build against libcephfs/librados/librbd from Mimic, or run `go
+test` against Limunous, use:
+```sh
+go build -tags mimic ....
+go test -tags luminous ....
+```
+
 ## Documentation
 
 Detailed documentation is available at

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ COVERAGE=yes
 CPUPROFILE=no
 MEMPROFILE=no
 MICRO_OSD_PATH="/micro-osd.sh"
+BUILD_TAGS=""
 
 CLI="$(getopt -o h --long test-run:,test-pkg:,pause,cpuprofile,memprofile,no-cover,micro-osd:,help -n "${0}" -- "$@")"
 eval set -- "${CLI}"
@@ -69,6 +70,10 @@ while true ; do
     esac
 done
 
+if [ -n "${CEPH_VERSION}" ]; then
+    BUILD_TAGS="-tags ${CEPH_VERSION}"
+fi
+
 show() {
     echo "*** running:" "$@"
     "$@"
@@ -87,7 +92,8 @@ test_pkg() {
         return 0
     fi
     # disable caching of tests results
-    testargs=("-count=1")
+    testargs=("-count=1"\
+            ${BUILD_TAGS})
     if [[ ${TEST_RUN} != ALL ]]; then
         testargs+=("-run" "${TEST_RUN}")
     fi
@@ -112,7 +118,7 @@ test_pkg() {
 
 pre_all_tests() {
     # Prepare Go code
-    go get -t -v ./...
+    go get -t -v ${BUILD_TAGS} ./...
     diff -u <(echo -n) <(gofmt -d -s .)
 
     # TODO: Consider enabling go vet but it currently fails

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1015,29 +1015,6 @@ func (image *Image) GetSnapshot(snapname string) *Snapshot {
 	}
 }
 
-// int rbd_get_parent_info(rbd_image_t image,
-//  char *parent_pool_name, size_t ppool_namelen, char *parent_name,
-//  size_t pnamelen, char *parent_snap_name, size_t psnap_namelen)
-func (image *Image) GetParentInfo(p_pool, p_name, p_snapname []byte) error {
-	if err := image.validate(imageIsOpen); err != nil {
-		return err
-	}
-
-	ret := C.rbd_get_parent_info(
-		image.image,
-		(*C.char)(unsafe.Pointer(&p_pool[0])),
-		(C.size_t)(len(p_pool)),
-		(*C.char)(unsafe.Pointer(&p_name[0])),
-		(C.size_t)(len(p_name)),
-		(*C.char)(unsafe.Pointer(&p_snapname[0])),
-		(C.size_t)(len(p_snapname)))
-	if ret == 0 {
-		return nil
-	} else {
-		return RBDError(ret)
-	}
-}
-
 // int rbd_metadata_get(rbd_image_t image, const char *key, char *value, size_t *vallen)
 func (image *Image) GetMetadata(key string) (string, error) {
 	if err := image.validate(imageIsOpen); err != nil {

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -203,30 +203,6 @@ func Version() (int, int, int) {
 	return int(c_major), int(c_minor), int(c_patch)
 }
 
-// GetImageNames returns the list of current RBD images.
-func GetImageNames(ioctx *rados.IOContext) (names []string, err error) {
-	buf := make([]byte, 4096)
-	for {
-		size := C.size_t(len(buf))
-		ret := C.rbd_list(C.rados_ioctx_t(ioctx.Pointer()),
-			(*C.char)(unsafe.Pointer(&buf[0])), &size)
-		if ret == -C.ERANGE {
-			buf = make([]byte, size)
-			continue
-		} else if ret < 0 {
-			return nil, RBDError(ret)
-		}
-		tmp := bytes.Split(buf[:size-1], []byte{0})
-		for _, s := range tmp {
-			if len(s) > 0 {
-				name := C.GoString((*C.char)(unsafe.Pointer(&s[0])))
-				names = append(names, name)
-			}
-		}
-		return names, nil
-	}
-}
-
 // GetImage gets a reference to a previously created rbd image.
 func GetImage(ioctx *rados.IOContext, name string) *Image {
 	return &Image{

--- a/rbd/rbd_mimic.go
+++ b/rbd/rbd_mimic.go
@@ -1,0 +1,43 @@
+// +build luminous mimic
+// +build !nautilus
+//
+// Ceph Nautilus includes rbd_list2() and marked rbd_list() deprecated.
+
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <rados/librados.h>
+// #include <rbd/librbd.h>
+// #include <errno.h>
+import "C"
+
+import (
+	"bytes"
+	"unsafe"
+
+	"github.com/ceph/go-ceph/rados"
+)
+
+// GetImageNames returns the list of current RBD images.
+func GetImageNames(ioctx *rados.IOContext) (names []string, err error) {
+	buf := make([]byte, 4096)
+	for {
+		size := C.size_t(len(buf))
+		ret := C.rbd_list(C.rados_ioctx_t(ioctx.Pointer()),
+			(*C.char)(unsafe.Pointer(&buf[0])), &size)
+		if ret == -C.ERANGE {
+			buf = make([]byte, size)
+			continue
+		} else if ret < 0 {
+			return nil, RBDError(ret)
+		}
+		tmp := bytes.Split(buf[:size-1], []byte{0})
+		for _, s := range tmp {
+			if len(s) > 0 {
+				name := C.GoString((*C.char)(unsafe.Pointer(&s[0])))
+				names = append(names, name)
+			}
+		}
+		return names, nil
+	}
+}

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -1,0 +1,45 @@
+// +build !luminous,!mimic
+//
+// Ceph Nautilus is the first release that includes rbd_list2().
+
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <rados/librados.h>
+// #include <rbd/librbd.h>
+// #include <errno.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/ceph/go-ceph/rados"
+)
+
+// GetImageNames returns the list of current RBD images.
+func GetImageNames(ioctx *rados.IOContext) ([]string, error) {
+	size := C.size_t(0)
+	ret := C.rbd_list2(C.rados_ioctx_t(ioctx.Pointer()), nil, &size)
+	if ret < 0 && ret != -C.ERANGE {
+		return nil, RBDError(ret)
+	} else if ret > 0 {
+		return nil, fmt.Errorf("rbd_list2() returned %d names, expected 0", ret)
+	} else if ret == 0 && size == 0 {
+		return nil, nil
+	}
+
+	// expected: ret == -ERANGE, size contains number of image names
+	images := make([]C.rbd_image_spec_t, size)
+	ret = C.rbd_list2(C.rados_ioctx_t(ioctx.Pointer()), (*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])), &size)
+	if ret < 0 {
+		return nil, RBDError(ret)
+	}
+	defer C.rbd_image_spec_list_cleanup((*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])), size)
+
+	names := make([]string, size)
+	for i, image := range images {
+		names[i] = C.GoString(image.name)
+	}
+	return names, nil
+}

--- a/rbd/snapshot_mimic.go
+++ b/rbd/snapshot_mimic.go
@@ -43,3 +43,59 @@ func (image *Image) GetParentInfo(p_pool, p_name, p_snapname []byte) error {
 		return RBDError(ret)
 	}
 }
+
+// ListChildren returns arrays with the pools and names of the images that are
+// children of the given image. The index of the pools and images arrays can be
+// used to link the two items together.
+//
+// Implements:
+//   ssize_t rbd_list_children(rbd_image_t image, char *pools,
+//                             size_t *pools_len,
+//                             char *images, size_t *images_len);
+func (image *Image) ListChildren() (pools []string, images []string, err error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return nil, nil, err
+	}
+
+	var c_pools_len, c_images_len C.size_t
+
+	ret := C.rbd_list_children(image.image,
+		nil, &c_pools_len,
+		nil, &c_images_len)
+	if ret == 0 {
+		return nil, nil, nil
+	}
+	if ret < 0 && ret != -C.ERANGE {
+		return nil, nil, RBDError(ret)
+	}
+
+	pools_buf := make([]byte, c_pools_len)
+	images_buf := make([]byte, c_images_len)
+
+	ret = C.rbd_list_children(image.image,
+		(*C.char)(unsafe.Pointer(&pools_buf[0])),
+		&c_pools_len,
+		(*C.char)(unsafe.Pointer(&images_buf[0])),
+		&c_images_len)
+	if ret < 0 {
+		return nil, nil, RBDError(ret)
+	}
+
+	tmp := bytes.Split(pools_buf[:c_pools_len-1], []byte{0})
+	for _, s := range tmp {
+		if len(s) > 0 {
+			name := C.GoString((*C.char)(unsafe.Pointer(&s[0])))
+			pools = append(pools, name)
+		}
+	}
+
+	tmp = bytes.Split(images_buf[:c_images_len-1], []byte{0})
+	for _, s := range tmp {
+		if len(s) > 0 {
+			name := C.GoString((*C.char)(unsafe.Pointer(&s[0])))
+			images = append(images, name)
+		}
+	}
+
+	return pools, images, nil
+}

--- a/rbd/snapshot_mimic.go
+++ b/rbd/snapshot_mimic.go
@@ -1,0 +1,45 @@
+// +build luminous mimic
+// +build !nautilus
+//
+// Ceph Nautilus introduced rbd_get_parent() and deprecated rbd_get_parent_info().
+// Ceph Nautilus introduced rbd_list_children3() and deprecated rbd_list_children().
+
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <rbd/librbd.h>
+// #include <errno.h>
+import "C"
+
+import (
+	"bytes"
+	"unsafe"
+)
+
+// GetParentInfo looks for the parent of the image and stores the pool, name
+// and snapshot-name in the byte-arrays that are passed as arguments.
+//
+// Implements:
+//   int rbd_get_parent_info(rbd_image_t image, char *parent_pool_name,
+//                           size_t ppool_namelen, char *parent_name,
+//                           size_t pnamelen, char *parent_snap_name,
+//                           size_t psnap_namelen)
+func (image *Image) GetParentInfo(p_pool, p_name, p_snapname []byte) error {
+	if err := image.validate(imageIsOpen); err != nil {
+		return err
+	}
+
+	ret := C.rbd_get_parent_info(
+		image.image,
+		(*C.char)(unsafe.Pointer(&p_pool[0])),
+		(C.size_t)(len(p_pool)),
+		(*C.char)(unsafe.Pointer(&p_name[0])),
+		(C.size_t)(len(p_name)),
+		(*C.char)(unsafe.Pointer(&p_snapname[0])),
+		(C.size_t)(len(p_snapname)))
+	if ret == 0 {
+		return nil
+	} else {
+		return RBDError(ret)
+	}
+}

--- a/rbd/snapshot_nautilus.go
+++ b/rbd/snapshot_nautilus.go
@@ -1,0 +1,65 @@
+// +build !luminous,!mimic
+//
+// Ceph Nautilus introduced rbd_get_parent() and deprecated rbd_get_parent_info().
+// Ceph Nautilus introduced rbd_list_children3() and deprecated rbd_list_children().
+
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <rbd/librbd.h>
+// #include <errno.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// GetParentInfo looks for the parent of the image and stores the pool, name
+// and snapshot-name in the byte-arrays that are passed as arguments.
+//
+// Implements:
+//   int rbd_get_parent(rbd_image_t image,
+//                      rbd_linked_image_spec_t *parent_image,
+//                      rbd_snap_spec_t *parent_snap)
+func (image *Image) GetParentInfo(pool, name, snapname []byte) error {
+	if err := image.validate(imageIsOpen); err != nil {
+		return err
+	}
+
+	parentImage := C.rbd_linked_image_spec_t{}
+	parentSnap := C.rbd_snap_spec_t{}
+	ret := C.rbd_get_parent(image.image, &parentImage, &parentSnap)
+	if ret != 0 {
+		return RBDError(ret)
+	}
+
+	defer C.rbd_linked_image_spec_cleanup(&parentImage)
+	defer C.rbd_snap_spec_cleanup(&parentSnap)
+
+	strlen := int(C.strlen(parentImage.pool_name))
+	if len(pool) < strlen {
+		return RBDError(C.ERANGE)
+	}
+	if copy(pool, C.GoString(parentImage.pool_name)) != strlen {
+		return RBDError(C.ERANGE)
+	}
+
+	strlen = int(C.strlen(parentImage.image_name))
+	if len(name) < strlen {
+		return RBDError(C.ERANGE)
+	}
+	if copy(name, C.GoString(parentImage.image_name)) != strlen {
+		return RBDError(C.ERANGE)
+	}
+
+	strlen = int(C.strlen(parentSnap.name))
+	if len(snapname) < strlen {
+		return RBDError(C.ERANGE)
+	}
+	if copy(snapname, C.GoString(parentSnap.name)) != strlen {
+		return RBDError(C.ERANGE)
+	}
+
+	return nil
+}


### PR DESCRIPTION
The following warnings about using deprecated functions are being resolved with this PR:
```
# github.com/ceph/go-ceph/rbd
cgo-gcc-prolog: In function '_cgo_8f906ca4e7ab_Cfunc_rbd_get_parent_info':
cgo-gcc-prolog:349:2: warning: 'rbd_get_parent_info' is deprecated [-Wdeprecated-declarations]
In file included from $WORK/b128/rbd.cover.go:10:0:
/usr/include/rbd/librbd.h:571:18: note: declared here
 CEPH_RBD_API int rbd_get_parent_info(rbd_image_t image,
                  ^
cgo-gcc-prolog: In function '_cgo_8f906ca4e7ab_Cfunc_rbd_list':
cgo-gcc-prolog:426:2: warning: 'rbd_list' is deprecated [-Wdeprecated-declarations]
In file included from $WORK/b128/rbd.cover.go:10:0:
/usr/include/rbd/librbd.h:330:18: note: declared here
 CEPH_RBD_API int rbd_list(rados_ioctx_t io, char *names, size_t *size)
                  ^
cgo-gcc-prolog: In function '_cgo_8f906ca4e7ab_Cfunc_rbd_list_children':
cgo-gcc-prolog:447:2: warning: 'rbd_list_children' is deprecated [-Wdeprecated-declarations]
In file included from $WORK/b128/rbd.cover.go:10:0:
/usr/include/rbd/librbd.h:766:22: note: declared here
 CEPH_RBD_API ssize_t rbd_list_children(rbd_image_t image, char *pools,
                      ^
```
No functional changes are done, the existing tests pass and have not been modified.

Some of the new functions seem to have been added with Ceph Nautilus, so this will likely not work on older Ceph versions.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code

Fixes: #42