### PR TITLE
entrypoint: handle the sub-packages separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build-docker
 *.swp
+*.out


### PR DESCRIPTION
Run the tests for each sub-package as a separate invocation.
Make the package selectable.
This has a few small advantages:
* When iterating on a single package the other packages do not run
* Better coverage summary line printed after each test
* Slightly better output with verbose test output

