### PR TITLE
rbd: update rbd open, create and remove image functions

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -334,32 +334,6 @@ func Create3(ioctx *rados.IOContext, name string, size uint64, features uint64,
 	}, nil
 }
 
-// Create4 creates a new rbd image using provided image options.
-//
-// Implements:
-//  int rbd_create4(rados_ioctx_t io, const char *name, uint64_t size,
-//                 rbd_image_options_t opts);
-func Create4(ioctx *rados.IOContext, name string, size uint64, rio *RbdImageOptions) (image *Image, err error) {
-	if rio == nil {
-		return nil, RBDError(C.EINVAL)
-	}
-
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
-
-	ret := C.rbd_create4(C.rados_ioctx_t(ioctx.Pointer()), c_name,
-		C.uint64_t(size), C.rbd_image_options_t(rio.options))
-
-	if ret < 0 {
-		return nil, RBDError(ret)
-	}
-
-	return &Image{
-		ioctx: ioctx,
-		name:  name,
-	}, nil
-}
-
 // Clone a new rbd image from a snapshot.
 //
 // Implements:
@@ -1358,4 +1332,23 @@ func OpenImageReadOnly(ioctx *rados.IOContext, name, snapName string) (*Image, e
 		name:  name,
 		image: cImage,
 	}, nil
+}
+
+// CreateImage creates a new rbd image using provided image options.
+//
+// Implements:
+//  int rbd_create4(rados_ioctx_t io, const char *name, uint64_t size,
+//                 rbd_image_options_t opts);
+func CreateImage(ioctx *rados.IOContext, name string, size uint64, rio *RbdImageOptions) error {
+
+	if rio == nil {
+		return RBDError(C.EINVAL)
+	}
+
+	c_name := C.CString(name)
+	defer C.free(unsafe.Pointer(c_name))
+
+	ret := C.rbd_create4(C.rados_ioctx_t(ioctx.Pointer()), c_name,
+		C.uint64_t(size), C.rbd_image_options_t(rio.options))
+	return GetError(ret)
 }

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -376,10 +376,7 @@ func (image *Image) Remove() error {
 	if err := image.validate(imageNeedsIOContext | imageNeedsName); err != nil {
 		return err
 	}
-
-	c_name := C.CString(image.name)
-	defer C.free(unsafe.Pointer(c_name))
-	return GetError(C.rbd_remove(C.rados_ioctx_t(image.ioctx.Pointer()), c_name))
+	return RemoveImage(image.ioctx, image.name)
 }
 
 // Trash will move an image into the RBD trash, where it will be protected (i.e., salvageable) for
@@ -1351,4 +1348,14 @@ func CreateImage(ioctx *rados.IOContext, name string, size uint64, rio *RbdImage
 	ret := C.rbd_create4(C.rados_ioctx_t(ioctx.Pointer()), c_name,
 		C.uint64_t(size), C.rbd_image_options_t(rio.options))
 	return GetError(ret)
+}
+
+// RemoveImage removes the specified rbd image.
+//
+// Implements:
+//  int rbd_remove(rados_ioctx_t io, const char *name);
+func RemoveImage(ioctx *rados.IOContext, name string) error {
+	c_name := C.CString(name)
+	defer C.free(unsafe.Pointer(c_name))
+	return GetError(C.rbd_remove(C.rados_ioctx_t(ioctx.Pointer()), c_name))
 }

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -160,25 +160,25 @@ func TestCreateImageWithOptions(t *testing.T) {
 
 	// nil options, causes a panic if not handled correctly
 	name := GetUUID()
-	image, err := Create4(ioctx, name, 1<<22, nil)
+	err = CreateImage(ioctx, name, 1<<22, nil)
 	assert.Error(t, err)
 
 	options := NewRbdImageOptions()
 
 	// empty/default options
 	name = GetUUID()
-	image, err = Create4(ioctx, name, 1<<22, options)
+	err = CreateImage(ioctx, name, 1<<22, options)
 	assert.NoError(t, err)
-	err = image.Remove()
+	err = GetImage(ioctx, name).Remove()
 	assert.NoError(t, err)
 
 	// create image with RbdImageOptionOrder
 	err = options.SetUint64(RbdImageOptionOrder, 22)
 	assert.NoError(t, err)
 	name = GetUUID()
-	image, err = Create4(ioctx, name, 1<<22, options)
+	err = CreateImage(ioctx, name, 1<<22, options)
 	assert.NoError(t, err)
-	err = image.Remove()
+	err = GetImage(ioctx, name).Remove()
 	assert.NoError(t, err)
 	options.Clear()
 
@@ -189,9 +189,9 @@ func TestCreateImageWithOptions(t *testing.T) {
 	err = options.SetString(RbdImageOptionDataPool, datapool)
 	assert.NoError(t, err)
 	name = GetUUID()
-	image, err = Create4(ioctx, name, 1<<22, options)
+	err = CreateImage(ioctx, name, 1<<22, options)
 	assert.NoError(t, err)
-	err = image.Remove()
+	err = GetImage(ioctx, name).Remove()
 	assert.NoError(t, err)
 	conn.DeletePool(datapool)
 

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -238,7 +238,7 @@ func TestGetImageNames(t *testing.T) {
 	conn.Shutdown()
 }
 
-func TestImageOpen(t *testing.T) {
+func TestDeprecatedImageOpen(t *testing.T) {
 	conn := radosConnect(t)
 
 	poolname := GetUUID()
@@ -255,6 +255,12 @@ func TestImageOpen(t *testing.T) {
 	// an integer is not a valid argument
 	err = image.Open(123)
 	assert.Error(t, err)
+
+	// open read-write
+	err = image.Open()
+	assert.NoError(t, err)
+	err = image.Close()
+	assert.NoError(t, err)
 
 	// open read-only
 	err = image.Open(true)

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -1332,7 +1332,9 @@ func TestRemoveImage(t *testing.T) {
 
 	// create and then remove an image
 	name := GetUUID()
-	err = CreateImage(ioctx, name, testImageSize, NewRbdImageOptions())
+	options := NewRbdImageOptions()
+	defer options.Destroy()
+	err = CreateImage(ioctx, name, testImageSize, options)
 	assert.NoError(t, err)
 
 	imageNames, err := GetImageNames(ioctx)


### PR DESCRIPTION
First off I am adding two new functions that map to librbd's rbd_open and rbd_open_read_only, currently named OpenImage and OpenImageReadOnly. These return new Image instances.

The Create4 function is renamed to CreateImage and I hope to have that be the canonical way to create an image in the future.

A new standalone RemoveImage function is added that more closely maps to the underlying ceph apis. The current Remove function is re-implemented to use RemoveImage.

The current Open method is marked deprecated. I plan on retaining the Open method for at least one release [1] and then removing it. I think we should do this because I expect Open to be a very commonly used function. 

I would like to see some of the other PRs that clean up the comments and test code merged prior to this one so I can make sure this PR is rebased on those before I make this mergable. Those will enable additional code checks and style are consistent.

[1] - Yeah, it's not strictly needed since we have not promised backwards compat. but I'd prefer to do it for api's that are not a total disaster and then when we start doing proper releases we can remove the bad/deprecated stuff at a predictable cadence.

Resolves: #105

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
