### PR TITLE
build: compile all go files with "make"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifeq ($(SELINUX),Enforcing)
 endif
 
 build:
-	go build -v
+	go build -v $(shell go list ./... | grep -v /contrib)
 fmt:
 	go fmt ./...
 test:


### PR DESCRIPTION
No need to compile the files under the contrib/ directory.

Currently, running 'make' does not do anything useful.