### PR TITLE
rbd: Add tests for Image.WriteAt() and Image.ReadAt()

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -955,7 +955,7 @@ func (image *Image) Discard(ofs uint64, length uint64) (int, error) {
 	return int(ret), nil
 }
 
-func (image *Image) ReadAt(data []byte, off int64) (n int, err error) {
+func (image *Image) ReadAt(data []byte, off int64) (int, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
 	}
@@ -974,7 +974,7 @@ func (image *Image) ReadAt(data []byte, off int64) (n int, err error) {
 		return 0, RBDError(ret)
 	}
 
-	if ret < n {
+	if ret < len(data) {
 		return ret, io.EOF
 	}
 

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -557,8 +557,14 @@ func TestIOReaderWriter(t *testing.T) {
 	_, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)
 
+	// reading 0 bytes should succeed
+	nil_bytes := make([]byte, 0)
+	n_out, err := img.Read(nil_bytes)
+	assert.Equal(t, n_out, 0)
+	assert.NoError(t, err)
+
 	bytes_out := make([]byte, len(bytes_in))
-	n_out, err := img.Read(bytes_out)
+	n_out, err = img.Read(bytes_out)
 
 	assert.Equal(t, n_out, len(bytes_in))
 	assert.Equal(t, bytes_in, bytes_out)


### PR DESCRIPTION
It seems that `WriteAt()` and `ReadAt()` did not have any test cases.

`ReadAt()` should return the number of bytes that have been read. In case the number of bytes is fewer than the number of bytes requested, `io.EOF` is returned. **This was not the case, and this PR contains a bugfix for that.**

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
