### PR TITLE
Fix Read() to return io.EOF on short read

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -876,7 +876,7 @@ func (image *Image) BreakLock(client string, cookie string) error {
 //              const char *fromsnapname,
 //              uint64_t ofs, uint64_t len,
 //              int (*cb)(uint64_t, size_t, int, void *), void *arg);
-func (image *Image) Read(data []byte) (n int, err error) {
+func (image *Image) Read(data []byte) (int, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
 	}
@@ -896,7 +896,7 @@ func (image *Image) Read(data []byte) (n int, err error) {
 	}
 
 	image.offset += int64(ret)
-	if ret < n {
+	if ret < len(data) {
 		return ret, io.EOF
 	}
 

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -569,6 +569,35 @@ func TestIOReaderWriter(t *testing.T) {
 	assert.Equal(t, n_out, len(bytes_in))
 	assert.Equal(t, bytes_in, bytes_out)
 
+	// write some data at the end of the image
+	offset := int64(stats.Size) - int64(len(bytes_in))
+
+	_, err = img.Seek(offset, SeekSet)
+	assert.NoError(t, err)
+
+	n_out, err = img.Write(bytes_in)
+	assert.Equal(t, len(bytes_in), n_out)
+	assert.NoError(t, err)
+
+	_, err = img.Seek(offset, SeekSet)
+	assert.NoError(t, err)
+
+	bytes_out = make([]byte, len(bytes_in))
+	n_out, err = img.Read(bytes_out)
+	assert.Equal(t, n_out, len(bytes_in))
+	assert.Equal(t, bytes_in, bytes_out)
+	assert.NoError(t, err)
+
+	// reading after EOF (needs to be large enough to hit EOF)
+	_, err = img.Seek(offset, SeekSet)
+	assert.NoError(t, err)
+
+	bytes_in = make([]byte, len(bytes_out)+256)
+	n_out, err = img.Read(bytes_in)
+	assert.Equal(t, n_out, len(bytes_out))
+	assert.Equal(t, bytes_in[0:len(bytes_out)], bytes_out)
+	assert.Equal(t, io.EOF, err)
+
 	err = img.Close()
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Similar to the problem found in `ReadAt()` (#154), `Read()` does not return `io.EOF` on a short read.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
