### PR TITLE
cephfs: Support creating mount from an existing rados connection

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -13,6 +13,7 @@ import (
 	"unsafe"
 
 	"github.com/ceph/go-ceph/errutil"
+	"github.com/ceph/go-ceph/rados"
 )
 
 type CephFSError int
@@ -41,6 +42,20 @@ type MountInfo struct {
 func CreateMount() (*MountInfo, error) {
 	mount := &MountInfo{}
 	ret := C.ceph_create(&mount.mount, nil)
+	if ret != 0 {
+		return nil, getError(ret)
+	}
+	return mount, nil
+}
+
+// CreateFromRados creates a mount handle using an existing rados cluster
+// connection.
+//
+// Implements:
+//  int ceph_create_from_rados(struct ceph_mount_info **cmount, rados_t cluster);
+func CreateFromRados(conn *rados.Conn) (*MountInfo, error) {
+	mount := &MountInfo{}
+	ret := C.ceph_create_from_rados(&mount.mount, C.rados_t(conn.Cluster()))
 	if ret != 0 {
 		return nil, getError(ret)
 	}

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -30,6 +30,14 @@ type Conn struct {
 	connected bool
 }
 
+// ClusterRef represents a fundamental RADOS cluster connection.
+type ClusterRef C.rados_t
+
+// Cluster returns the underlying RADOS cluster reference for this Conn.
+func (c *Conn) Cluster() ClusterRef {
+	return ClusterRef(c.cluster)
+}
+
 // PingMonitor sends a ping to a monitor and returns the reply.
 func (c *Conn) PingMonitor(id string) (string, error) {
 	c_id := C.CString(id)


### PR DESCRIPTION
These changes wrap the rados and cephfs apis needed to use an existing rados connection to establish a cephfs mount.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
