### PR TITLE
rados: add Create() function to create new objects

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -686,7 +686,7 @@ func (iter *Iter) Namespace() string {
 
 // Err checks whether the iterator has encountered an error.
 func (iter *Iter) Err() error {
-	if iter.err == RadosErrorNotFound {
+	if iter.err == ErrNotFound {
 		return nil
 	}
 	return iter.err

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -34,6 +34,8 @@ var (
 	RadosErrorNotFound = RadosError(-C.ENOENT)
 	// RadosErrorPermissionDenied indicates a permissions issue.
 	RadosErrorPermissionDenied = RadosError(-C.EPERM)
+	// ErrObjectExists indicates that an exclusive object creation failed.
+	ErrObjectExists = RadosError(-C.EEXIST)
 )
 
 func getRadosError(err int) error {

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -26,16 +26,33 @@ func (e RadosError) Error() string {
 	return fmt.Sprintf("rados: ret=%d, %s", errno, s)
 }
 
-var (
-	// RadosAllNamespaces is used to reset a selected namespace to all namespaces. See the IOContext SetNamespace function.
-	RadosAllNamespaces = C.LIBRADOS_ALL_NSPACES
+const (
+	// AllNamespaces is used to reset a selected namespace to all
+	// namespaces. See the IOContext SetNamespace function.
+	AllNamespaces = C.LIBRADOS_ALL_NSPACES
 
-	// RadosErrorNotFound indicates a missing resource.
-	RadosErrorNotFound = RadosError(-C.ENOENT)
-	// RadosErrorPermissionDenied indicates a permissions issue.
-	RadosErrorPermissionDenied = RadosError(-C.EPERM)
+	// ErrNotFound indicates a missing resource.
+	ErrNotFound = RadosError(-C.ENOENT)
+	// ErrPermissionDenied indicates a permissions issue.
+	ErrPermissionDenied = RadosError(-C.EPERM)
 	// ErrObjectExists indicates that an exclusive object creation failed.
 	ErrObjectExists = RadosError(-C.EEXIST)
+
+	// FIXME: for backwards compatibility
+
+	// RadosAllNamespaces is used to reset a selected namespace to all
+	// namespaces. See the IOContext SetNamespace function.
+	//
+	// Deprecated: use AllNamespaces instead
+	RadosAllNamespaces = AllNamespaces
+	// RadosErrorNotFound indicates a missing resource.
+	//
+	// Deprecated: use ErrNotFound instead
+	RadosErrorNotFound = ErrNotFound
+	// RadosErrorPermissionDenied indicates a permissions issue.
+	//
+	// Deprecated: use ErrPermissionDenied instead
+	RadosErrorPermissionDenied = ErrPermissionDenied
 )
 
 func getRadosError(err int) error {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -514,7 +514,7 @@ func (suite *RadosTestSuite) TestReadNotFound() {
 	var bytes []byte
 	oid := suite.GenObjectName()
 	_, err := suite.ioctx.Read(oid, bytes, 0)
-	assert.Equal(suite.T(), err, RadosErrorNotFound)
+	assert.Equal(suite.T(), err, ErrNotFound)
 }
 
 func (suite *RadosTestSuite) TestDeleteNotFound() {
@@ -522,7 +522,7 @@ func (suite *RadosTestSuite) TestDeleteNotFound() {
 
 	oid := suite.GenObjectName()
 	err := suite.ioctx.Delete(oid)
-	assert.Equal(suite.T(), err, RadosErrorNotFound)
+	assert.Equal(suite.T(), err, ErrNotFound)
 }
 
 func (suite *RadosTestSuite) TestStatNotFound() {
@@ -530,7 +530,7 @@ func (suite *RadosTestSuite) TestStatNotFound() {
 
 	oid := suite.GenObjectName()
 	_, err := suite.ioctx.Stat(oid)
-	assert.Equal(suite.T(), err, RadosErrorNotFound)
+	assert.Equal(suite.T(), err, ErrNotFound)
 }
 
 func (suite *RadosTestSuite) TestObjectStat() {
@@ -763,7 +763,7 @@ func (suite *RadosTestSuite) TestObjectIteratorAcrossNamespaces() {
 	objectListNS2 := []string{}
 
 	// populate list of current objects
-	suite.ioctx.SetNamespace(RadosAllNamespaces)
+	suite.ioctx.SetNamespace(AllNamespaces)
 	existingList := []string{}
 	iter, err := suite.ioctx.Iter()
 	assert.NoError(suite.T(), err)
@@ -796,7 +796,7 @@ func (suite *RadosTestSuite) TestObjectIteratorAcrossNamespaces() {
 	}
 	assert.True(suite.T(), len(createdList) == 20)
 
-	suite.ioctx.SetNamespace(RadosAllNamespaces)
+	suite.ioctx.SetNamespace(AllNamespaces)
 	iter, err = suite.ioctx.Iter()
 	assert.NoError(suite.T(), err)
 	rogueList := []string{}
@@ -1033,7 +1033,7 @@ func (suite *RadosTestSuite) TestSetNamespace() {
 	// oid isn't seen in space1 ns
 	suite.ioctx.SetNamespace("space1")
 	stat, err = suite.ioctx.Stat(oid)
-	assert.Equal(suite.T(), err, RadosErrorNotFound)
+	assert.Equal(suite.T(), err, ErrNotFound)
 
 	// create oid2 in space1 ns
 	oid2 := suite.GenObjectName()
@@ -1043,7 +1043,7 @@ func (suite *RadosTestSuite) TestSetNamespace() {
 
 	suite.ioctx.SetNamespace("")
 	stat, err = suite.ioctx.Stat(oid2)
-	assert.Equal(suite.T(), err, RadosErrorNotFound)
+	assert.Equal(suite.T(), err, ErrNotFound)
 
 	stat, err = suite.ioctx.Stat(oid)
 	assert.Equal(suite.T(), uint64(len(bytes_in)), stat.Size)
@@ -1081,7 +1081,7 @@ func (suite *RadosTestSuite) TestListAcrossNamespaces() {
 	assert.EqualValues(suite.T(), 1, nsFoundObjects)
 
 	// count objects in pool
-	suite.ioctx.SetNamespace(RadosAllNamespaces)
+	suite.ioctx.SetNamespace(AllNamespaces)
 	allFoundObjects := 0
 	err = suite.ioctx.ListObjects(func(oid string) {
 		allFoundObjects++
@@ -1184,7 +1184,7 @@ func (suite *RadosTestSuite) TestOmapOnNonexistentObjectError() {
 	suite.SetupConnection()
 	oid := suite.GenObjectName()
 	_, err := suite.ioctx.GetAllOmapValues(oid, "", "", 100)
-	assert.Equal(suite.T(), err, RadosErrorNotFound)
+	assert.Equal(suite.T(), err, ErrNotFound)
 }
 
 func (suite *RadosTestSuite) TestOpenIOContextInvalidPool() {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -447,6 +447,20 @@ func (suite *RadosTestSuite) TestWaitForLatestOSDMap() {
 	assert.NoError(suite.T(), err)
 }
 
+func (suite *RadosTestSuite) TestCreate() {
+	suite.SetupConnection()
+
+	err := suite.ioctx.Create("unique", CreateExclusive)
+	assert.NoError(suite.T(), err)
+
+	err = suite.ioctx.Create("unique", CreateExclusive)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), err, ErrObjectExists)
+
+	err = suite.ioctx.Create("unique", CreateIdempotent)
+	assert.NoError(suite.T(), err)
+}
+
 func (suite *RadosTestSuite) TestReadWrite() {
 	suite.SetupConnection()
 


### PR DESCRIPTION
Ceph-CSI creates new objects without initial data. This is a functionality that is missing in go-ceph at the moment.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
