### PR TITLE
cephfs: allow creating mount with an id

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -38,14 +38,26 @@ type MountInfo struct {
 	mount *C.struct_ceph_mount_info
 }
 
-// CreateMount creates a mount handle for interacting with Ceph.
-func CreateMount() (*MountInfo, error) {
+func createMount(id *C.char) (*MountInfo, error) {
 	mount := &MountInfo{}
-	ret := C.ceph_create(&mount.mount, nil)
+	ret := C.ceph_create(&mount.mount, id)
 	if ret != 0 {
 		return nil, getError(ret)
 	}
 	return mount, nil
+}
+
+// CreateMount creates a mount handle for interacting with Ceph.
+func CreateMount() (*MountInfo, error) {
+	return createMount(nil)
+}
+
+// CreateMountWithId creates a mount handle for interacting with Ceph.
+// The caller can specify a unique id that will identify this client.
+func CreateMountWithId(id string) (*MountInfo, error) {
+	cid := C.CString(id)
+	defer C.free(unsafe.Pointer(cid))
+	return createMount(cid)
 }
 
 // CreateFromRados creates a mount handle using an existing rados cluster

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -221,3 +221,18 @@ func TestCreateFromRados(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, mount)
 }
+
+func TestCreateMountWithId(t *testing.T) {
+	// TODO: the entity_id is visible w/in the 'session ls' output
+	// of mds. Consider running the equivalent api call and checking
+	// that the string is set.
+	mount, err := CreateMountWithId("bob")
+	assert.NoError(t, err)
+	assert.NotNil(t, mount)
+
+	err = mount.ReadDefaultConfigFile()
+	assert.NoError(t, err)
+
+	err = mount.Mount()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
The ceph api function supports passing a string to identify the
client doing the mount. Expose that aspect of the api with a
new function CreateMountWithId.

Follow up PRs that add wrappers for mds command functions and more extensive verification of the feature to follow.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
