### PR TITLE
go-ceph: fix typo in doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ and contains no functions.
 
 The "rados" sub-package wraps APIs that handle RADOS specific functions.
 
-The "rdb" sub-package wraps APIs that handle RBD specific functions.
+The "rbd" sub-package wraps APIs that handle RBD specific functions.
 
 The "cephfs" sub-package wraps APIs that handle CephFS specific functions.
 


### PR DESCRIPTION
It's 'rbd' not 'rdb'. :-)