### PR TITLE
add doc comments for all sub-packages with exported funcs

### DIFF
--- a/cephfs/doc.go
+++ b/cephfs/doc.go
@@ -1,0 +1,4 @@
+/*
+Package cephfs contains a set of wrappers around Ceph's libcephfs API.
+*/
+package cephfs

--- a/errutil/strerror.go
+++ b/errutil/strerror.go
@@ -1,3 +1,7 @@
+/*
+Package errutil provides common functions for dealing with error conditions for
+all ceph api wrappers.
+*/
 package errutil
 
 /* force XSI-complaint strerror_r() */


### PR DESCRIPTION

Add doc comments for errutil and cephfs which were lacking top-level doc comments.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code