### PR TITLE
testing: use Go 1.12 from go upstream in ci container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,21 +9,24 @@ RUN apt-get update && apt-get install -y \
 
 ARG CEPH_REPO_URL=https://download.ceph.com/debian-nautilus/
 RUN wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
-RUN apt-add-repository "deb ${CEPH_REPO_URL} xenial main"
+RUN true && \
+  apt-add-repository "deb ${CEPH_REPO_URL} xenial main" && \
+  apt-get update && \
+  apt-get install -y ceph libcephfs-dev librados-dev librbd-dev curl gcc g++
 
-RUN add-apt-repository -y ppa:gophers/archive
-
-RUN apt-get update && apt-get install -y \
-  ceph \
-  libcephfs-dev \
-  librados-dev \
-  librbd-dev \
-  golang-1.10-go
+ENV GOTAR=go1.12.16.linux-amd64.tar.gz
+RUN true && \
+  curl -o /tmp/${GOTAR} https://dl.google.com/go/${GOTAR} && \
+  tar -x -C /opt/ -f /tmp/${GOTAR} && \
+  rm -f /tmp/${GOTAR}
 
 # add user account to test permissions
 RUN groupadd -g 1010 bob
 RUN useradd -u 1010 -g bob -M bob
 
+ENV PATH="${PATH}:/opt/go/bin"
+ENV GOROOT=/opt/go
+ENV GO111MODULE=on
 ENV GOPATH /go
 WORKDIR /go/src/github.com/ceph/go-ceph
 VOLUME /go/src/github.com/ceph/go-ceph

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,8 +55,6 @@ mkdir -p /tmp/ceph
 "${MICRO_OSD_PATH}" /tmp/ceph
 export CEPH_CONF=/tmp/ceph/ceph.conf
 
-export PATH=/usr/lib/go-1.10/bin:$PATH
-
 if [[ ${TEST_RUN} == NONE ]]; then
     echo "skipping test execution"
 else


### PR DESCRIPTION
When building the container image for running tests take the older of
the two current releases from Go upstream. We use the older version
in order to make sure we are testing with something supported but maybe
not everyone is on 1.13 yet.
This also enables the use of go modules to ensure we get the proper
versions of dependencies.

Fixes: #166 
