### PR TITLE
rbd: add better error when attempting to remove opened images

### DIFF
--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -61,6 +61,8 @@ var (
 	ErrSnapshotNoName = errors.New("RBD snapshot does not have a name")
 	// ErrImageNotOpen may be returned if an api call requires an open image handle and one is not provided.
 	ErrImageNotOpen = errors.New("RBD image not open")
+	// ErrImageIsOpen may be returned if an api call requires a closed image handle and one is not provided.
+	ErrImageIsOpen = errors.New("RBD image is open")
 	// ErrNotFound may be returned from an api call when the requested item is
 	// missing.
 	ErrNotFound = errors.New("RBD image not found")

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -38,6 +38,7 @@ const (
 	imageNeedsName uint32 = 1 << iota
 	imageNeedsIOContext
 	imageIsOpen
+	imageIsNotOpen
 	snapshotNeedsName
 
 	// NoSnapshot indicates that no snapshot name is in use (see OpenImage)
@@ -121,6 +122,8 @@ func (image *Image) validate(req uint32) error {
 		return ErrNoIOContext
 	} else if hasBit(req, imageIsOpen) && image.image == nil {
 		return ErrImageNotOpen
+	} else if hasBit(req, imageIsNotOpen) && image.image != nil {
+		return ErrImageIsOpen
 	}
 
 	return nil
@@ -278,7 +281,7 @@ func (image *Image) Clone(snapname string, c_ioctx *rados.IOContext, c_name stri
 // Implements:
 //  int rbd_remove(rados_ioctx_t io, const char *name);
 func (image *Image) Remove() error {
-	if err := image.validate(imageNeedsIOContext | imageNeedsName); err != nil {
+	if err := image.validate(imageNeedsIOContext | imageNeedsName | imageIsNotOpen); err != nil {
 		return err
 	}
 	return RemoveImage(image.ioctx, image.name)

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -263,6 +263,10 @@ func TestDeprecatedImageOpen(t *testing.T) {
 	// writing should fail in read-only mode
 	assert.Error(t, err)
 
+	err = image.Remove()
+	// removing should fail while image is opened
+	assert.Equal(t, err, ErrImageIsOpen)
+
 	err = image.Close()
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Trying to remove an opened read-write image results in an error `Device or resource busy`. This change adds an additional validation case in the `Remove()` method and returns more understandable error.

Signed-off-by: Sven Anderson <sven@redhat.com>

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
