### PR TITLE
Add a container image for debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,4 @@
-FROM ubuntu:xenial
-
-RUN apt-get update && apt-get install -y \
-  apt-transport-https \
-  git \
-  software-properties-common \
-  uuid-runtime \
-  wget
-
-ARG CEPH_REPO_URL=https://download.ceph.com/debian-nautilus/
-RUN wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
-RUN true && \
-  apt-add-repository "deb ${CEPH_REPO_URL} xenial main" && \
-  apt-get update && \
-  apt-get install -y ceph libcephfs-dev librados-dev librbd-dev curl gcc g++
-
-ENV GOTAR=go1.12.16.linux-amd64.tar.gz
-RUN true && \
-  curl -o /tmp/${GOTAR} https://dl.google.com/go/${GOTAR} && \
-  tar -x -C /opt/ -f /tmp/${GOTAR} && \
-  rm -f /tmp/${GOTAR}
-
-# add user account to test permissions
-RUN groupadd -g 1010 bob
-RUN useradd -u 1010 -g bob -M bob
-
-ENV PATH="${PATH}:/opt/go/bin"
-ENV GOROOT=/opt/go
-ENV GO111MODULE=on
-ENV GOPATH /go
-WORKDIR /go/src/github.com/ceph/go-ceph
-VOLUME /go/src/github.com/ceph/go-ceph
+FROM go-ceph-tmp
 
 COPY micro-osd.sh /
 COPY entrypoint.sh /

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,32 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install -y \
+  apt-transport-https \
+  git \
+  software-properties-common \
+  uuid-runtime \
+  wget
+
+ARG CEPH_REPO_URL=https://download.ceph.com/debian-nautilus/
+RUN wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add -
+RUN true && \
+  apt-add-repository "deb ${CEPH_REPO_URL} xenial main" && \
+  apt-get update && \
+  apt-get install -y ceph libcephfs-dev librados-dev librbd-dev curl gcc g++
+
+ENV GOTAR=go1.12.16.linux-amd64.tar.gz
+RUN true && \
+  curl -o /tmp/${GOTAR} https://dl.google.com/go/${GOTAR} && \
+  tar -x -C /opt/ -f /tmp/${GOTAR} && \
+  rm -f /tmp/${GOTAR}
+
+# add user account to test permissions
+RUN groupadd -g 1010 bob
+RUN useradd -u 1010 -g bob -M bob
+
+ENV PATH="${PATH}:/opt/go/bin"
+ENV GOROOT=/opt/go
+ENV GO111MODULE=on
+ENV GOPATH /go
+WORKDIR /go/src/github.com/ceph/go-ceph
+VOLUME /go/src/github.com/ceph/go-ceph

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,11 @@
+FROM go-ceph-base
+
+RUN apt-get update && apt-get install -y \
+  gdb \
+  ceph-base-dbg \
+  ceph-common-dbg \
+  librados2-dbg \
+  libradosstriper1-dbg \
+  librbd1-dbg
+
+RUN go get github.com/go-delve/delve/cmd/dlv

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DOCKER_CI_IMAGE = go-ceph-ci
+DOCKER_DEBUG_IMAGE = go-ceph-debug
 CONTAINER_CMD := docker
 CONTAINER_OPTS := --security-opt $(shell grep -q selinux /sys/kernel/security/lsm && echo "label=disabled" || echo "apparmor:unconfined")
 VOLUME_FLAGS := 
@@ -18,9 +19,21 @@ test:
 test-docker: .build-docker
 	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm -it -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(DOCKER_CI_IMAGE)
 
-.build-docker: Dockerfile entrypoint.sh
+test-docker-debug: .build-docker-debug
+	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm -it -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(DOCKER_DEBUG_IMAGE)
+
+.build-docker: Dockerfile Dockerfile.base entrypoint.sh micro-osd.sh
+	$(CONTAINER_CMD) build -t go-ceph-tmp -f Dockerfile.base .
 	$(CONTAINER_CMD) build -t $(DOCKER_CI_IMAGE) .
+	$(CONTAINER_CMD) rmi go-ceph-tmp
 	@$(CONTAINER_CMD) inspect -f '{{.Id}}' $(DOCKER_CI_IMAGE) > .build-docker
+
+.build-docker-debug: Dockerfile Dockerfile.base Dockerfile.debug entrypoint.sh micro-osd.sh
+	$(CONTAINER_CMD) build -t go-ceph-base -f Dockerfile.base .
+	$(CONTAINER_CMD) build -t go-ceph-tmp -f Dockerfile.debug .
+	$(CONTAINER_CMD) build -t $(DOCKER_DEBUG_IMAGE) .
+	$(CONTAINER_CMD) rmi go-ceph-tmp
+	@$(CONTAINER_CMD) inspect -f '{{.Id}}' $(DOCKER_DEBUG_IMAGE) > .build-docker-debug
 
 check:
 	# Configure project's revive checks using .revive.toml


### PR DESCRIPTION
This change adds another container image target with debugging tools
and packages installed (gdb and delve). For now the tests can be run
in the debug container instead of the ci container with the
`test-docker-debug` target, or it can be used directly with the
docker cli. An extension to `entrypoint.sh` to run the tests directly
in the different debuggers might be added in a separate change.

Signed-off-by: Sven Anderson <sven@redhat.com>