### PR TITLE
readme: update doc link to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ go test -tags luminous ....
 ## Documentation
 
 Detailed documentation is available at
-<http://godoc.org/github.com/ceph/go-ceph>.
+<https://pkg.go.dev/github.com/ceph/go-ceph>.
 
 ### Connecting to a cluster
 


### PR DESCRIPTION
The older godoc.org encourages the user to use pkg.go.dev instead.
Change our link to point directly there (and use https).

