### PR TITLE
cephfs: add MountWithRoot to implement the root arg to ceph_mount

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -91,6 +91,17 @@ func (mount *MountInfo) Mount() error {
 	return getError(ret)
 }
 
+// MountWithRoot mounts the file system using the path provided for the root of
+// the mount. This establishes a connection capable of I/O.
+//
+// Implements:
+//  int ceph_mount(struct ceph_mount_info *cmount, const char *root);
+func (mount *MountInfo) MountWithRoot(root string) error {
+	croot := C.CString(root)
+	defer C.free(unsafe.Pointer(croot))
+	return getError(C.ceph_mount(mount.mount, croot))
+}
+
 // Unmount the file system.
 //
 // Implements:

--- a/cephfs/conn_nautilus.go
+++ b/cephfs/conn_nautilus.go
@@ -1,0 +1,30 @@
+// +build !luminous,!mimic
+
+package cephfs
+
+/*
+#cgo LDFLAGS: -lcephfs
+#cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
+#include <cephfs/libcephfs.h>
+*/
+import "C"
+
+// Some general connectivity and mounting functions are new in
+// Ceph Nautilus.
+
+// GetFsCid returns the cluster ID for a mounted ceph file system.
+// If the object does not refer to a mounted file system, an error
+// will be returned.
+//
+// Note:
+//  Only supported in Ceph Nautilus and newer.
+//
+// Implements:
+//  int64_t ceph_get_fs_cid(struct ceph_mount_info *cmount);
+func (mount *MountInfo) GetFsCid() (int64, error) {
+	ret := C.ceph_get_fs_cid(mount.mount)
+	if ret < 0 {
+		return 0, getError(C.int(ret))
+	}
+	return int64(ret), nil
+}

--- a/cephfs/conn_nautilus_test.go
+++ b/cephfs/conn_nautilus_test.go
@@ -1,0 +1,32 @@
+// +build !luminous,!mimic
+
+package cephfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFsCid(t *testing.T) {
+	t.Run("unmounted", func(t *testing.T) {
+		mount, err := CreateMount()
+		require.NoError(t, err)
+		require.NotNil(t, mount)
+
+		err = mount.ReadDefaultConfigFile()
+		require.NoError(t, err)
+
+		cid, err := mount.GetFsCid()
+		assert.Error(t, err)
+		assert.Equal(t, cid, int64(0))
+	})
+	t.Run("mounted", func(t *testing.T) {
+		mount := fsConnect(t)
+
+		cid, err := mount.GetFsCid()
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, cid, int64(0))
+	})
+}


### PR DESCRIPTION
NOTE: This is based on the patches in PR #182. Please review/merge that first.

The existing Mount() method did not provide a way to access the root
path argument to ceph_mount. This new function allows the caller to
specify an alternate root dir for the mount.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
