### PR TITLE
Add support for all RBD image-features up to including Nautilus

### DIFF
--- a/rbd/features.go
+++ b/rbd/features.go
@@ -91,6 +91,42 @@ const (
 	RbdFeaturesSingleClient   = uint64(C.RBD_FEATURES_SINGLE_CLIENT)
 )
 
+// FeatureSet is a combination of the bit value for multiple featurs.
+type FeatureSet uint64
+
+var (
+	featureNameToBit = map[string]uint64{
+		FeatureNameLayering:      FeatureLayering,
+		FeatureNameStripingV2:    FeatureStripingV2,
+		FeatureNameExclusiveLock: FeatureExclusiveLock,
+		FeatureNameObjectMap:     FeatureObjectMap,
+		FeatureNameFastDiff:      FeatureFastDiff,
+		FeatureNameDeepFlatten:   FeatureDeepFlatten,
+		FeatureNameJournaling:    FeatureJournaling,
+		FeatureNameDataPool:      FeatureDataPool,
+	}
+)
+
+func FeatureSetFromNames(names []string) FeatureSet {
+	var fs uint64
+	for _, name := range names {
+		fs |= featureNameToBit[name]
+	}
+	return FeatureSet(fs)
+}
+
+func (fs *FeatureSet) Names() []string {
+	names := []string{}
+
+	for name, bit := range featureNameToBit {
+		if (uint64(*fs) & bit) == bit {
+			names = append(names, name)
+		}
+	}
+
+	return names
+}
+
 // GetFeatures returns the features bitmask for the rbd image.
 //
 // Implements:

--- a/rbd/features.go
+++ b/rbd/features.go
@@ -1,0 +1,108 @@
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <rbd/librbd.h>
+import "C"
+
+const (
+	// RBD features, bit values
+
+	// FeatureLayering is the representation of RBD_FEATURE_LAYERING from
+	// librbd
+	FeatureLayering = uint64(C.RBD_FEATURE_LAYERING)
+
+	// FeatureStripingV2 is the representation of RBD_FEATURE_STRIPINGV2
+	// from librbd
+	FeatureStripingV2 = uint64(C.RBD_FEATURE_STRIPINGV2)
+
+	// FeatureExclusiveLock is the representation of
+	// RBD_FEATURE_EXCLUSIVE_LOCK from librbd
+	FeatureExclusiveLock = uint64(C.RBD_FEATURE_EXCLUSIVE_LOCK)
+
+	// FeatureObjectMap is the representation of RBD_FEATURE_OBJECT_MAP
+	// from librbd
+	FeatureObjectMap = uint64(C.RBD_FEATURE_OBJECT_MAP)
+
+	// FeatureFastDiff is the representation of RBD_FEATURE_FAST_DIFF from
+	// librbd
+	FeatureFastDiff = uint64(C.RBD_FEATURE_FAST_DIFF)
+
+	// FeatureDeepFlatten is the representation of RBD_FEATURE_DEEP_FLATTEN
+	// from librbd
+	FeatureDeepFlatten = uint64(C.RBD_FEATURE_DEEP_FLATTEN)
+
+	// FeatureJournaling is the representation of RBD_FEATURE_JOURNALING
+	// from librbd
+	FeatureJournaling = uint64(C.RBD_FEATURE_JOURNALING)
+
+	// FeatureDataPool is the representation of RBD_FEATURE_DATA_POOL from
+	// librbd
+	FeatureDataPool = uint64(C.RBD_FEATURE_DATA_POOL)
+
+	// RBD features, strings
+
+	// FeatureNameLayering is the representation of
+	// RBD_FEATURE_NAME_LAYERING from librbd
+	FeatureNameLayering = C.RBD_FEATURE_NAME_LAYERING
+
+	// FeatureNameStripingV2 is the representation of
+	// RBD_FEATURE_NAME_STRIPINGV2 from librbd
+	FeatureNameStripingV2 = C.RBD_FEATURE_NAME_STRIPINGV2
+
+	// FeatureNameExclusiveLock is the representation of
+	// RBD_FEATURE_NAME_EXCLUSIVE_LOCK from librbd
+	FeatureNameExclusiveLock = C.RBD_FEATURE_NAME_EXCLUSIVE_LOCK
+
+	// FeatureNameObjectMap is the representation of
+	// RBD_FEATURE_NAME_OBJECT_MAP from librbd
+	FeatureNameObjectMap = C.RBD_FEATURE_NAME_OBJECT_MAP
+
+	// FeatureNameFastDiff is the representation of
+	// RBD_FEATURE_NAME_FAST_DIFF from librbd
+	FeatureNameFastDiff = C.RBD_FEATURE_NAME_FAST_DIFF
+
+	// FeatureNameDeepFlatten is the representation of
+	// RBD_FEATURE_NAME_DEEP_FLATTEN from librbd
+	FeatureNameDeepFlatten = C.RBD_FEATURE_NAME_DEEP_FLATTEN
+
+	// FeatureNameJournaling is the representation of
+	// RBD_FEATURE_NAME_JOURNALING from librbd
+	FeatureNameJournaling = C.RBD_FEATURE_NAME_JOURNALING
+
+	// FeatureNameDataPool is the representation of
+	// RBD_FEATURE_NAME_DATA_POOL from librbd
+	FeatureNameDataPool = C.RBD_FEATURE_NAME_DATA_POOL
+
+	// old names for backwards compatibility (unused?)
+	RbdFeatureLayering      = FeatureLayering
+	RbdFeatureStripingV2    = FeatureStripingV2
+	RbdFeatureExclusiveLock = FeatureExclusiveLock
+	RbdFeatureObjectMap     = FeatureObjectMap
+	RbdFeatureFastDiff      = FeatureFastDiff
+	RbdFeatureDeepFlatten   = FeatureDeepFlatten
+	RbdFeatureJournaling    = FeatureJournaling
+	RbdFeatureDataPool      = FeatureDataPool
+
+	// the following are probably really unused?
+	RbdFeaturesDefault        = uint64(C.RBD_FEATURES_DEFAULT)
+	RbdFeaturesIncompatible   = uint64(C.RBD_FEATURES_INCOMPATIBLE)
+	RbdFeaturesRwIncompatible = uint64(C.RBD_FEATURES_RW_INCOMPATIBLE)
+	RbdFeaturesMutable        = uint64(C.RBD_FEATURES_MUTABLE)
+	RbdFeaturesSingleClient   = uint64(C.RBD_FEATURES_SINGLE_CLIENT)
+)
+
+// GetFeatures returns the features bitmask for the rbd image.
+//
+// Implements:
+//  int rbd_get_features(rbd_image_t image, uint64_t *features);
+func (image *Image) GetFeatures() (features uint64, err error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return 0, err
+	}
+
+	if ret := C.rbd_get_features(image.image, (*C.uint64_t)(&features)); ret < 0 {
+		return 0, RBDError(ret)
+	}
+
+	return features, nil
+}

--- a/rbd/features.go
+++ b/rbd/features.go
@@ -106,3 +106,20 @@ func (image *Image) GetFeatures() (features uint64, err error) {
 
 	return features, nil
 }
+
+// UpdateFeatures updates the features on the Image.
+//
+// Implements:
+//   int rbd_update_features(rbd_image_t image, uint64_t features,
+//                           uint8_t enabled);
+func (image *Image) UpdateFeatures(features uint64, enabled bool) error {
+	if image.image == nil {
+		return RbdErrorImageNotOpen
+	}
+
+	cEnabled := C.uint8_t(0)
+	if enabled {
+		cEnabled = 1
+	}
+	return getError(C.rbd_update_features(image.image, C.uint64_t(features), cEnabled))
+}

--- a/rbd/features_mimic.go
+++ b/rbd/features_mimic.go
@@ -1,0 +1,16 @@
+// +build !luminous
+
+package rbd
+
+// #include <rbd/librbd.h>
+import "C"
+
+const (
+	// FeatureOperations is the representation of RBD_FEATURE_OPERATIONS
+	// from librbd
+	FeatureOperations = uint64(C.RBD_FEATURE_OPERATIONS)
+
+	// FeatureNameOperations is the representation of
+	// RBD_FEATURE_NAME_OPERATIONS from librbd
+	FeatureNameOperations = C.RBD_FEATURE_NAME_OPERATIONS
+)

--- a/rbd/features_mimic.go
+++ b/rbd/features_mimic.go
@@ -14,3 +14,7 @@ const (
 	// RBD_FEATURE_NAME_OPERATIONS from librbd
 	FeatureNameOperations = C.RBD_FEATURE_NAME_OPERATIONS
 )
+
+func init() {
+	featureNameToBit[FeatureNameOperations] = FeatureOperations
+}

--- a/rbd/features_mimic_test.go
+++ b/rbd/features_mimic_test.go
@@ -1,0 +1,15 @@
+// +build !luminous
+
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFeaturesInMimic(t *testing.T) {
+	f, ok := featureNameToBit[FeatureNameOperations]
+	assert.True(t, ok)
+	assert.Equal(t, f, FeatureOperations)
+}

--- a/rbd/features_nautilus.go
+++ b/rbd/features_nautilus.go
@@ -14,3 +14,7 @@ const (
 	// RBD_FEATURE_NAME_MIGRATING from librbd
 	FeatureNameMigrating = C.RBD_FEATURE_NAME_MIGRATING
 )
+
+func init() {
+	featureNameToBit[FeatureNameMigrating] = FeatureMigrating
+}

--- a/rbd/features_nautilus.go
+++ b/rbd/features_nautilus.go
@@ -1,0 +1,16 @@
+// +build !luminous,!mimic
+
+package rbd
+
+// #include <rbd/librbd.h>
+import "C"
+
+const (
+	// FeatureMigrating is the representation of RBD_FEATURE_MIGRATING from
+	// librbd
+	FeatureMigrating = uint64(C.RBD_FEATURE_MIGRATING)
+
+	// FeatureNameMigrating is the representation of
+	// RBD_FEATURE_NAME_MIGRATING from librbd
+	FeatureNameMigrating = C.RBD_FEATURE_NAME_MIGRATING
+)

--- a/rbd/features_nautilus_test.go
+++ b/rbd/features_nautilus_test.go
@@ -1,0 +1,15 @@
+// +build !luminous,!mimic
+
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFeaturesInNautilus(t *testing.T) {
+	f, ok := featureNameToBit[FeatureNameMigrating]
+	assert.True(t, ok)
+	assert.Equal(t, f, FeatureMigrating)
+}

--- a/rbd/features_test.go
+++ b/rbd/features_test.go
@@ -1,6 +1,7 @@
 package rbd
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,26 @@ func TestGetFeatures(t *testing.T) {
 		assert.True(t, hasLayering, "FeatureLayering is not set")
 		assert.True(t, hasStripingV2, "FeatureStripingV2 is not set")
 	})
+
+	t.Run("compareFeatureSet", func(t *testing.T) {
+		fs := FeatureSet(features)
+		assert.Contains(t, fs.Names(), FeatureNameLayering)
+		assert.Contains(t, fs.Names(), FeatureNameStripingV2)
+	})
+}
+
+func TestFeatureSet(t *testing.T) {
+	fsBits := FeatureSet(FeatureExclusiveLock | FeatureDeepFlatten)
+	fsNames := FeatureSetFromNames([]string{FeatureNameExclusiveLock, FeatureNameDeepFlatten})
+	assert.Equal(t, fsBits, fsNames)
+
+	fsBitsSorted := fsBits.Names()
+	sort.Strings(fsBitsSorted)
+
+	fsNamesSorted := fsNames.Names()
+	sort.Strings(fsNamesSorted)
+
+	assert.Equal(t, fsBitsSorted, fsNamesSorted)
 }
 
 func TestUpdateFeatures(t *testing.T) {

--- a/rbd/features_test.go
+++ b/rbd/features_test.go
@@ -1,0 +1,52 @@
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFeatures(t *testing.T) {
+	conn := radosConnect(t)
+	require.NotNil(t, conn)
+	defer conn.Shutdown()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	require.NoError(t, err)
+	defer conn.DeletePool(poolname)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+	defer ioctx.Destroy()
+
+	name := GetUUID()
+
+	options := NewRbdImageOptions()
+	err = options.SetUint64(RbdImageOptionFeatures, FeatureLayering|FeatureStripingV2)
+	require.NoError(t, err)
+	// FeatureStripingV2 only works with additional arguments
+	err = options.SetUint64(RbdImageOptionStripeUnit, 1024*1024)
+	require.NoError(t, err)
+	err = options.SetUint64(RbdImageOptionStripeCount, 4)
+	require.NoError(t, err)
+
+	err = CreateImage(ioctx, name, 16*1024*1024, options)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, RemoveImage(ioctx, name)) }()
+
+	image, err := OpenImageReadOnly(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, image.Close()) }()
+
+	features, err := image.GetFeatures()
+	assert.NoError(t, err)
+
+	t.Run("compareBits", func(t *testing.T) {
+		hasLayering := (features & FeatureLayering) == FeatureLayering
+		hasStripingV2 := (features & FeatureStripingV2) == FeatureStripingV2
+		assert.True(t, hasLayering, "FeatureLayering is not set")
+		assert.True(t, hasStripingV2, "FeatureStripingV2 is not set")
+	})
+}

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -8,7 +8,6 @@ package rbd
 // #include <stdlib.h>
 // #include <rados/librados.h>
 // #include <rbd/librbd.h>
-// #include <rbd/features.h>
 import "C"
 
 import (
@@ -24,31 +23,6 @@ import (
 )
 
 const (
-	// RBD features.
-	RbdFeatureLayering      = uint64(C.RBD_FEATURE_LAYERING)
-	RbdFeatureStripingV2    = uint64(C.RBD_FEATURE_STRIPINGV2)
-	RbdFeatureExclusiveLock = uint64(C.RBD_FEATURE_EXCLUSIVE_LOCK)
-	RbdFeatureObjectMap     = uint64(C.RBD_FEATURE_OBJECT_MAP)
-	RbdFeatureFastDiff      = uint64(C.RBD_FEATURE_FAST_DIFF)
-	RbdFeatureDeepFlatten   = uint64(C.RBD_FEATURE_DEEP_FLATTEN)
-	RbdFeatureJournaling    = uint64(C.RBD_FEATURE_JOURNALING)
-	RbdFeatureDataPool      = uint64(C.RBD_FEATURE_DATA_POOL)
-
-	RbdFeaturesDefault = uint64(C.RBD_FEATURES_DEFAULT)
-
-	// Features that make an image inaccessible for read or write by clients that don't understand
-	// them.
-	RbdFeaturesIncompatible = uint64(C.RBD_FEATURES_INCOMPATIBLE)
-
-	// Features that make an image unwritable by clients that don't understand them.
-	RbdFeaturesRwIncompatible = uint64(C.RBD_FEATURES_RW_INCOMPATIBLE)
-
-	// Features that may be dynamically enabled or disabled.
-	RbdFeaturesMutable = uint64(C.RBD_FEATURES_MUTABLE)
-
-	// Features that only work when used with a single client using the image for writes.
-	RbdFeaturesSingleClient = uint64(C.RBD_FEATURES_SINGLE_CLIENT)
-
 	// Image.Seek() constants
 	SeekSet = int(C.SEEK_SET)
 	SeekCur = int(C.SEEK_CUR)
@@ -521,22 +495,6 @@ func (image *Image) GetSize() (size uint64, err error) {
 	}
 
 	return size, nil
-}
-
-// GetFeatures returns the features bitmask for the rbd image.
-//
-// Implements:
-//  int rbd_get_features(rbd_image_t image, uint64_t *features);
-func (image *Image) GetFeatures() (features uint64, err error) {
-	if err := image.validate(imageIsOpen); err != nil {
-		return 0, err
-	}
-
-	if ret := C.rbd_get_features(image.image, (*C.uint64_t)(&features)); ret < 0 {
-		return 0, RBDError(ret)
-	}
-
-	return features, nil
 }
 
 // GetStripeUnit returns the stripe-unit value for the rbd image.

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -82,14 +82,14 @@ func TestImageCreate(t *testing.T) {
 
 	name = GetUUID()
 	image, err = Create(ioctx, name, testImageSize, testImageOrder,
-		RbdFeatureLayering|RbdFeatureStripingV2)
+		FeatureLayering|FeatureStripingV2)
 	assert.NoError(t, err)
 	err = image.Remove()
 	assert.NoError(t, err)
 
 	name = GetUUID()
 	image, err = Create(ioctx, name, testImageSize, testImageOrder,
-		RbdFeatureLayering|RbdFeatureStripingV2, 4096, 2)
+		FeatureLayering|FeatureStripingV2, 4096, 2)
 	assert.NoError(t, err)
 	err = image.Remove()
 	assert.NoError(t, err)
@@ -101,7 +101,7 @@ func TestImageCreate(t *testing.T) {
 
 	// too many arguments
 	_, err = Create(ioctx, name, testImageSize, testImageOrder,
-		RbdFeatureLayering|RbdFeatureStripingV2, 4096, 2, 123)
+		FeatureLayering|FeatureStripingV2, 4096, 2, 123)
 	assert.Error(t, err)
 
 	ioctx.Destroy()
@@ -121,7 +121,7 @@ func TestImageCreate2(t *testing.T) {
 
 	name := GetUUID()
 	image, err := Create2(ioctx, name, testImageSize,
-		RbdFeatureLayering|RbdFeatureStripingV2, testImageOrder)
+		FeatureLayering|FeatureStripingV2, testImageOrder)
 	assert.NoError(t, err)
 	err = image.Remove()
 	assert.NoError(t, err)
@@ -143,7 +143,7 @@ func TestImageCreate3(t *testing.T) {
 
 	name := GetUUID()
 	image, err := Create3(ioctx, name, testImageSize,
-		RbdFeatureLayering|RbdFeatureStripingV2, testImageOrder, 4096, 2)
+		FeatureLayering|FeatureStripingV2, testImageOrder, 4096, 2)
 	assert.NoError(t, err)
 	err = image.Remove()
 	assert.NoError(t, err)
@@ -343,7 +343,7 @@ func TestImageProperties(t *testing.T) {
 	name := GetUUID()
 	reqSize := uint64(1024 * 1024 * 4) // 4MB
 	_, err = Create3(ioctx, name, reqSize,
-		RbdFeatureLayering|RbdFeatureStripingV2, testImageOrder, 4096, 2)
+		FeatureLayering|FeatureStripingV2, testImageOrder, 4096, 2)
 	require.NoError(t, err)
 
 	img, err := OpenImage(ioctx, name, NoSnapshot)
@@ -360,8 +360,8 @@ func TestImageProperties(t *testing.T) {
 	features, err := img.GetFeatures()
 	assert.NoError(t, err)
 	// compare features with the two requested ones
-	assert.Equal(t, features&(RbdFeatureLayering|RbdFeatureStripingV2),
-		RbdFeatureLayering|RbdFeatureStripingV2)
+	assert.Equal(t, features&(FeatureLayering|FeatureStripingV2),
+		FeatureLayering|FeatureStripingV2)
 
 	stripeUnit, err := img.GetStripeUnit()
 	assert.NoError(t, err)


### PR DESCRIPTION
Split the features from `rbd/rbd.go` into its own file. This makes is easier to extend the functionality of feature-bits.
Mimic and Nautilus added more features, so these constants need to be compiled-in on selective base (using build-tags as is done for other things already).
Some features allow being modified after image creation. Support for `rbd_update_features()` has been added for this now too, though `Image.UpdateFeatures()`.

Closes: #183

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
