### PR TITLE
rbd: move snapshot related functionality to a new file

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -93,12 +93,6 @@ type Image struct {
 	image  C.rbd_image_t
 }
 
-//
-type Snapshot struct {
-	image *Image
-	name  string
-}
-
 // TrashInfo contains information about trashed RBDs.
 type TrashInfo struct {
 	Id               string    // Id string, required to remove / restore trashed RBDs.
@@ -133,19 +127,6 @@ func (image *Image) validate(req uint32) error {
 		return ErrNoIOContext
 	} else if hasBit(req, imageIsOpen) && image.image == nil {
 		return ErrImageNotOpen
-	}
-
-	return nil
-}
-
-// validate the attributes listed in the req bitmask, and return an error in
-// case the attribute is not set
-// Calls snapshot.image.validate(req) to validate the image attributes.
-func (snapshot *Snapshot) validate(req uint32) error {
-	if hasBit(req, snapshotNeedsName) && snapshot.name == "" {
-		return ErrSnapshotNoName
-	} else if snapshot.image != nil {
-		return snapshot.image.validate(req)
 	}
 
 	return nil
@@ -892,34 +873,6 @@ func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 	return snaps[:len(snaps)-1], nil
 }
 
-// int rbd_snap_create(rbd_image_t image, const char *snapname);
-func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
-	if err := image.validate(imageIsOpen); err != nil {
-		return nil, err
-	}
-
-	c_snapname := C.CString(snapname)
-	defer C.free(unsafe.Pointer(c_snapname))
-
-	ret := C.rbd_snap_create(image.image, c_snapname)
-	if ret < 0 {
-		return nil, RBDError(ret)
-	}
-
-	return &Snapshot{
-		image: image,
-		name:  snapname,
-	}, nil
-}
-
-//
-func (image *Image) GetSnapshot(snapname string) *Snapshot {
-	return &Snapshot{
-		image: image,
-		name:  snapname,
-	}
-}
-
 // int rbd_metadata_get(rbd_image_t image, const char *key, char *value, size_t *vallen)
 func (image *Image) GetMetadata(key string) (string, error) {
 	if err := image.validate(imageIsOpen); err != nil {
@@ -1007,89 +960,6 @@ func (image *Image) GetId() (string, error) {
 		id := C.GoString((*C.char)(unsafe.Pointer(&buf[0])))
 		return id, nil
 	}
-}
-
-// int rbd_snap_remove(rbd_image_t image, const char *snapname);
-func (snapshot *Snapshot) Remove() error {
-	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
-		return err
-	}
-
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
-
-	return getError(C.rbd_snap_remove(snapshot.image.image, c_snapname))
-}
-
-// int rbd_snap_rollback(rbd_image_t image, const char *snapname);
-// int rbd_snap_rollback_with_progress(rbd_image_t image, const char *snapname,
-//                  librbd_progress_fn_t cb, void *cbdata);
-func (snapshot *Snapshot) Rollback() error {
-	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
-		return err
-	}
-
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
-
-	return getError(C.rbd_snap_rollback(snapshot.image.image, c_snapname))
-}
-
-// int rbd_snap_protect(rbd_image_t image, const char *snap_name);
-func (snapshot *Snapshot) Protect() error {
-	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
-		return err
-	}
-
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
-
-	return getError(C.rbd_snap_protect(snapshot.image.image, c_snapname))
-}
-
-// int rbd_snap_unprotect(rbd_image_t image, const char *snap_name);
-func (snapshot *Snapshot) Unprotect() error {
-	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
-		return err
-	}
-
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
-
-	return getError(C.rbd_snap_unprotect(snapshot.image.image, c_snapname))
-}
-
-// int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
-//               int *is_protected);
-func (snapshot *Snapshot) IsProtected() (bool, error) {
-	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
-		return false, err
-	}
-
-	var c_is_protected C.int
-
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
-
-	ret := C.rbd_snap_is_protected(snapshot.image.image, c_snapname,
-		&c_is_protected)
-	if ret < 0 {
-		return false, RBDError(ret)
-	}
-
-	return c_is_protected != 0, nil
-}
-
-// int rbd_snap_set(rbd_image_t image, const char *snapname);
-func (snapshot *Snapshot) Set() error {
-	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
-		return err
-	}
-
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
-
-	return getError(C.rbd_snap_set(snapshot.image.image, c_snapname))
 }
 
 // GetTrashList returns a slice of TrashInfo structs, containing information about all RBD images

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -839,54 +839,6 @@ func TestImageCopy(t *testing.T) {
 	conn.Shutdown()
 }
 
-func TestCreateSnapshot(t *testing.T) {
-	conn := radosConnect(t)
-
-	poolname := GetUUID()
-	err := conn.MakePool(poolname)
-	assert.NoError(t, err)
-
-	ioctx, err := conn.OpenIOContext(poolname)
-	require.NoError(t, err)
-
-	name := GetUUID()
-	err = quickCreate(ioctx, name, testImageSize, testImageOrder)
-	assert.NoError(t, err)
-
-	img, err := OpenImage(ioctx, name, NoSnapshot)
-	assert.NoError(t, err)
-
-	_, err = img.CreateSnapshot("mysnap")
-	assert.NoError(t, err)
-
-	err = img.Close()
-	assert.NoError(t, err)
-
-	snapImage, err := OpenImage(ioctx, name, "mysnap")
-	assert.NoError(t, err)
-
-	err = snapImage.Close()
-	assert.NoError(t, err)
-
-	img2, err := OpenImage(ioctx, name, NoSnapshot)
-	assert.NoError(t, err)
-
-	snapshot := img2.GetSnapshot("mysnap")
-
-	err = snapshot.Remove()
-	assert.NoError(t, err)
-
-	err = img2.Close()
-	assert.NoError(t, err)
-
-	err = img.Remove()
-	assert.NoError(t, err)
-
-	ioctx.Destroy()
-	conn.DeletePool(poolname)
-	conn.Shutdown()
-}
-
 func TestParentInfo(t *testing.T) {
 	conn := radosConnect(t)
 
@@ -1089,57 +1041,6 @@ func TestNotFound(t *testing.T) {
 	img, err := OpenImage(ioctx, name, NoSnapshot)
 	assert.Equal(t, err, ErrNotFound)
 	assert.Nil(t, img)
-
-	ioctx.Destroy()
-	conn.DeletePool(poolname)
-	conn.Shutdown()
-}
-
-func TestErrorSnapshotNoName(t *testing.T) {
-	conn := radosConnect(t)
-
-	poolname := GetUUID()
-	err := conn.MakePool(poolname)
-	assert.NoError(t, err)
-
-	ioctx, err := conn.OpenIOContext(poolname)
-	require.NoError(t, err)
-
-	name := GetUUID()
-	err = quickCreate(ioctx, name, testImageSize, testImageOrder)
-	assert.NoError(t, err)
-
-	img, err := OpenImage(ioctx, name, NoSnapshot)
-	assert.NoError(t, err)
-
-	// this actually works for some reason?!
-	snapshot, err := img.CreateSnapshot("")
-	assert.NoError(t, err)
-
-	err = img.Close()
-	assert.NoError(t, err)
-
-	err = snapshot.Remove()
-	assert.Equal(t, err, ErrSnapshotNoName)
-
-	err = snapshot.Rollback()
-	assert.Equal(t, err, ErrSnapshotNoName)
-
-	err = snapshot.Protect()
-	assert.Equal(t, err, ErrSnapshotNoName)
-
-	err = snapshot.Unprotect()
-	assert.Equal(t, err, ErrSnapshotNoName)
-
-	_, err = snapshot.IsProtected()
-	assert.Equal(t, err, ErrSnapshotNoName)
-
-	err = snapshot.Set()
-	assert.Equal(t, err, ErrSnapshotNoName)
-
-	// image can not be removed as the snapshot still exists
-	// err = img.Remove()
-	// assert.NoError(t, err)
 
 	ioctx.Destroy()
 	conn.DeletePool(poolname)

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -9,13 +9,17 @@ import (
 	"unsafe"
 )
 
-//
+// Snapshot represents a snapshot on a particular rbd image.
 type Snapshot struct {
 	image *Image
 	name  string
 }
 
-// int rbd_snap_create(rbd_image_t image, const char *snapname);
+// CreateSnapshot returns a new Snapshot objects after creating
+// a snapshot of the rbd image.
+//
+// Implements:
+//  int rbd_snap_create(rbd_image_t image, const char *snapname);
 func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err
@@ -48,7 +52,8 @@ func (snapshot *Snapshot) validate(req uint32) error {
 	return nil
 }
 
-//
+// GetSnapshot constructs a snapshot object for the image given
+// the snap name. It does not validate that this snapshot exists.
 func (image *Image) GetSnapshot(snapname string) *Snapshot {
 	return &Snapshot{
 		image: image,
@@ -56,7 +61,10 @@ func (image *Image) GetSnapshot(snapname string) *Snapshot {
 	}
 }
 
-// int rbd_snap_remove(rbd_image_t image, const char *snapname);
+// Remove the snapshot from the connected rbd image.
+//
+// Implements:
+//  int rbd_snap_remove(rbd_image_t image, const char *snapname);
 func (snapshot *Snapshot) Remove() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -68,9 +76,10 @@ func (snapshot *Snapshot) Remove() error {
 	return getError(C.rbd_snap_remove(snapshot.image.image, c_snapname))
 }
 
-// int rbd_snap_rollback(rbd_image_t image, const char *snapname);
-// int rbd_snap_rollback_with_progress(rbd_image_t image, const char *snapname,
-//                  librbd_progress_fn_t cb, void *cbdata);
+// Rollback the image to the snapshot.
+//
+// Implements:
+//  int rbd_snap_rollback(rbd_image_t image, const char *snapname);
 func (snapshot *Snapshot) Rollback() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -82,7 +91,10 @@ func (snapshot *Snapshot) Rollback() error {
 	return getError(C.rbd_snap_rollback(snapshot.image.image, c_snapname))
 }
 
-// int rbd_snap_protect(rbd_image_t image, const char *snap_name);
+// Protect a snapshot from unwanted deletion.
+//
+// Implements:
+//  int rbd_snap_protect(rbd_image_t image, const char *snap_name);
 func (snapshot *Snapshot) Protect() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -94,7 +106,10 @@ func (snapshot *Snapshot) Protect() error {
 	return getError(C.rbd_snap_protect(snapshot.image.image, c_snapname))
 }
 
-// int rbd_snap_unprotect(rbd_image_t image, const char *snap_name);
+// Unprotect stops protecting the snapshot.
+//
+// Implements:
+//  int rbd_snap_unprotect(rbd_image_t image, const char *snap_name);
 func (snapshot *Snapshot) Unprotect() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -106,7 +121,10 @@ func (snapshot *Snapshot) Unprotect() error {
 	return getError(C.rbd_snap_unprotect(snapshot.image.image, c_snapname))
 }
 
-// int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
+// IsProtected returns true if the snapshot is currently protected.
+//
+// Implements:
+//  int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
 //               int *is_protected);
 func (snapshot *Snapshot) IsProtected() (bool, error) {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
@@ -127,7 +145,11 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 	return c_is_protected != 0, nil
 }
 
-// int rbd_snap_set(rbd_image_t image, const char *snapname);
+// Set updates the rbd image (not the Snapshot) such that the snapshot
+// is the source of readable data.
+//
+// Implements:
+//  int rbd_snap_set(rbd_image_t image, const char *snapname);
 func (snapshot *Snapshot) Set() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -1,0 +1,140 @@
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <stdlib.h>
+// #include <rbd/librbd.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+//
+type Snapshot struct {
+	image *Image
+	name  string
+}
+
+// int rbd_snap_create(rbd_image_t image, const char *snapname);
+func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return nil, err
+	}
+
+	c_snapname := C.CString(snapname)
+	defer C.free(unsafe.Pointer(c_snapname))
+
+	ret := C.rbd_snap_create(image.image, c_snapname)
+	if ret < 0 {
+		return nil, RBDError(ret)
+	}
+
+	return &Snapshot{
+		image: image,
+		name:  snapname,
+	}, nil
+}
+
+// validate the attributes listed in the req bitmask, and return an error in
+// case the attribute is not set
+// Calls snapshot.image.validate(req) to validate the image attributes.
+func (snapshot *Snapshot) validate(req uint32) error {
+	if hasBit(req, snapshotNeedsName) && snapshot.name == "" {
+		return ErrSnapshotNoName
+	} else if snapshot.image != nil {
+		return snapshot.image.validate(req)
+	}
+
+	return nil
+}
+
+//
+func (image *Image) GetSnapshot(snapname string) *Snapshot {
+	return &Snapshot{
+		image: image,
+		name:  snapname,
+	}
+}
+
+// int rbd_snap_remove(rbd_image_t image, const char *snapname);
+func (snapshot *Snapshot) Remove() error {
+	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
+		return err
+	}
+
+	c_snapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(c_snapname))
+
+	return getError(C.rbd_snap_remove(snapshot.image.image, c_snapname))
+}
+
+// int rbd_snap_rollback(rbd_image_t image, const char *snapname);
+// int rbd_snap_rollback_with_progress(rbd_image_t image, const char *snapname,
+//                  librbd_progress_fn_t cb, void *cbdata);
+func (snapshot *Snapshot) Rollback() error {
+	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
+		return err
+	}
+
+	c_snapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(c_snapname))
+
+	return getError(C.rbd_snap_rollback(snapshot.image.image, c_snapname))
+}
+
+// int rbd_snap_protect(rbd_image_t image, const char *snap_name);
+func (snapshot *Snapshot) Protect() error {
+	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
+		return err
+	}
+
+	c_snapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(c_snapname))
+
+	return getError(C.rbd_snap_protect(snapshot.image.image, c_snapname))
+}
+
+// int rbd_snap_unprotect(rbd_image_t image, const char *snap_name);
+func (snapshot *Snapshot) Unprotect() error {
+	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
+		return err
+	}
+
+	c_snapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(c_snapname))
+
+	return getError(C.rbd_snap_unprotect(snapshot.image.image, c_snapname))
+}
+
+// int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
+//               int *is_protected);
+func (snapshot *Snapshot) IsProtected() (bool, error) {
+	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
+		return false, err
+	}
+
+	var c_is_protected C.int
+
+	c_snapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(c_snapname))
+
+	ret := C.rbd_snap_is_protected(snapshot.image.image, c_snapname,
+		&c_is_protected)
+	if ret < 0 {
+		return false, RBDError(ret)
+	}
+
+	return c_is_protected != 0, nil
+}
+
+// int rbd_snap_set(rbd_image_t image, const char *snapname);
+func (snapshot *Snapshot) Set() error {
+	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
+		return err
+	}
+
+	c_snapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(c_snapname))
+
+	return getError(C.rbd_snap_set(snapshot.image.image, c_snapname))
+}

--- a/rbd/snapshot_test.go
+++ b/rbd/snapshot_test.go
@@ -1,0 +1,107 @@
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateSnapshot(t *testing.T) {
+	conn := radosConnect(t)
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+
+	name := GetUUID()
+	err = quickCreate(ioctx, name, testImageSize, testImageOrder)
+	assert.NoError(t, err)
+
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+
+	_, err = img.CreateSnapshot("mysnap")
+	assert.NoError(t, err)
+
+	err = img.Close()
+	assert.NoError(t, err)
+
+	snapImage, err := OpenImage(ioctx, name, "mysnap")
+	assert.NoError(t, err)
+
+	err = snapImage.Close()
+	assert.NoError(t, err)
+
+	img2, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+
+	snapshot := img2.GetSnapshot("mysnap")
+
+	err = snapshot.Remove()
+	assert.NoError(t, err)
+
+	err = img2.Close()
+	assert.NoError(t, err)
+
+	err = img.Remove()
+	assert.NoError(t, err)
+
+	ioctx.Destroy()
+	conn.DeletePool(poolname)
+	conn.Shutdown()
+}
+
+func TestErrorSnapshotNoName(t *testing.T) {
+	conn := radosConnect(t)
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+
+	name := GetUUID()
+	err = quickCreate(ioctx, name, testImageSize, testImageOrder)
+	assert.NoError(t, err)
+
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+
+	// this actually works for some reason?!
+	snapshot, err := img.CreateSnapshot("")
+	assert.NoError(t, err)
+
+	err = img.Close()
+	assert.NoError(t, err)
+
+	err = snapshot.Remove()
+	assert.Equal(t, err, ErrSnapshotNoName)
+
+	err = snapshot.Rollback()
+	assert.Equal(t, err, ErrSnapshotNoName)
+
+	err = snapshot.Protect()
+	assert.Equal(t, err, ErrSnapshotNoName)
+
+	err = snapshot.Unprotect()
+	assert.Equal(t, err, ErrSnapshotNoName)
+
+	_, err = snapshot.IsProtected()
+	assert.Equal(t, err, ErrSnapshotNoName)
+
+	err = snapshot.Set()
+	assert.Equal(t, err, ErrSnapshotNoName)
+
+	// image can not be removed as the snapshot still exists
+	// err = img.Remove()
+	// assert.NoError(t, err)
+
+	ioctx.Destroy()
+	conn.DeletePool(poolname)
+	conn.Shutdown()
+}


### PR DESCRIPTION
No functionality change.
First commit just moves the functions and types.
Second commit adds missing doc comments for many of the items in the new file.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
