### PR TITLE
Retry support for enlarging buffers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check:
 
 # Do a quick compile only check of the tests and impliclity the
 # library code as well.
-test-binaries: cephfs.test internal/errutil.test rados.test rbd.test
+test-binaries: cephfs.test rados.test rbd.test internal/callbacks.test internal/errutil.test internal/retry.test
 test-bins: test-binaries
 
 %.test: % force_go_build

--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -33,3 +33,9 @@ func getError(e C.int) error {
 	}
 	return CephFSError(e)
 }
+
+// Private errors:
+
+const (
+	errNameTooLong = CephFSError(-C.ENAMETOOLONG)
+)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -176,6 +176,7 @@ test_go_ceph() {
         "cephfs" \
         "internal/callbacks" \
         "internal/errutil" \
+        "internal/retry" \
         "rados" \
         "rbd" \
         )

--- a/internal/retry/example_sizer_test.go
+++ b/internal/retry/example_sizer_test.go
@@ -1,0 +1,56 @@
+package retry
+
+import (
+	"fmt"
+)
+
+var errTooSmall = fmt.Errorf("too small")
+
+func fakeComplexOp(v []string) error {
+	if len(v) < 30 {
+		fmt.Println("too small:", len(v))
+		return errTooSmall
+	}
+	fmt.Println("good size:", len(v))
+	return nil
+}
+
+func ExampleSizer_update() {
+	var err error
+	for sizer := NewSizerEV(1, 128, errTooSmall); sizer.Continue(); err = sizer.Update(err) {
+		buf := make([]string, sizer.Size())
+		// do something complex with buf
+		err = fakeComplexOp(buf)
+	}
+	// Output:
+	// too small: 1
+	// too small: 2
+	// too small: 4
+	// too small: 8
+	// too small: 16
+	// good size: 32
+}
+
+func fakeComplexOp2(v []string, s *int) error {
+	if len(v) < 30 {
+		fmt.Println("too small:", len(v))
+		*s = 30
+		return errTooSmall
+	}
+	fmt.Println("good size:", len(v))
+	return nil
+}
+
+func ExampleSizer_updateWants() {
+	var err error
+	for sizer := NewSizerEV(1, 128, errTooSmall); sizer.Continue(); {
+		size := sizer.Size()
+		buf := make([]string, size)
+		// do something complex with buf
+		err = fakeComplexOp2(buf, &size)
+		err = sizer.UpdateWants(err, size)
+	}
+	// Output:
+	// too small: 1
+	// good size: 30
+}

--- a/internal/retry/sizer.go
+++ b/internal/retry/sizer.go
@@ -16,6 +16,11 @@ type SizerCheckFunc func(error) bool
 // If the check function returns true iteration continues but nil
 // will be returned from the update function, effectively clearing
 // the error state, *unless* the current size now exceeds maxSize.
+//
+// When the Sizer's Update & UpdateWants methods are called the size will be
+// doubled, unless UpdateWants is provided with a size hint that is greater
+// than the current size. Therefore, it is highly recommended to provide start
+// and max size values that are powers of two.
 type Sizer struct {
 	size    int
 	maxSize int

--- a/internal/retry/sizer.go
+++ b/internal/retry/sizer.go
@@ -1,0 +1,87 @@
+package retry
+
+// SizerCheckFunc allows the creator of a Sizer to specify arbitrarily
+// complex checks of the error condition to determine if the size
+// needs to be retried.
+type SizerCheckFunc func(error) bool
+
+// Sizer is used to implement 'resize loops' that hides the complexity
+// of the sizing and error checking away from most of the application.
+//
+// At the end of each iteration call Update or UpdateWants to inform
+// the sizer of the result of the action(s) taken during the iteration.
+// If the error is nil the update functions will return nil and halt
+// the iteration. If the error is non nil but returns false from
+// the check function the same error is returned and iteration will halt.
+// If the check function returns true iteration continues but nil
+// will be returned from the update function, effectively clearing
+// the error state, *unless* the current size now exceeds maxSize.
+type Sizer struct {
+	size    int
+	maxSize int
+	ready   bool
+	again   SizerCheckFunc
+}
+
+// NewSizer returns a new Sizer ready for use.
+// The Sizer will attempt a retry on conditions where the callback
+// function f returns true.
+func NewSizer(startSize, maxSize int, f SizerCheckFunc) *Sizer {
+	return &Sizer{
+		ready:   true,
+		size:    startSize,
+		maxSize: maxSize,
+		again:   f,
+	}
+}
+
+// NewSizerEV returns a new Sizer ready for use that only checks
+// for the exact error value specified.
+func NewSizerEV(startSize, maxSize int, retryOn error) *Sizer {
+	return NewSizer(
+		startSize,
+		maxSize,
+		func(err error) bool { return err == retryOn },
+	)
+}
+
+// Continue returns true if the application should try the desired
+// action.
+func (s *Sizer) Continue() bool {
+	return s.ready
+}
+
+// Size currently specified by the sizer. Only changes when Update or
+// UpdateWants is called, so it is safe to call multiple times within
+// a single iteration.
+func (s *Sizer) Size() int {
+	return s.size
+}
+
+// Update the Sizer with the results of the action taken.
+func (s *Sizer) Update(err error) error {
+	return s.UpdateWants(err, -1)
+}
+
+// UpdateWants updates the Sizer with the results of the action taken and a
+// hint for a possible size for the next iteration.
+func (s *Sizer) UpdateWants(err error, hint int) error {
+	switch {
+	case err == nil:
+		s.ready = false
+		return nil
+	case s.again(err):
+		if hint > s.size {
+			s.size = hint
+		} else {
+			s.size *= 2
+		}
+		if s.size <= s.maxSize {
+			return nil
+		}
+		fallthrough
+	default:
+		s.ready = false
+		return err
+	}
+}

--- a/internal/retry/sizer_test.go
+++ b/internal/retry/sizer_test.go
@@ -1,0 +1,83 @@
+package retry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSizer(t *testing.T) {
+	tooLong := errors.New("too long")
+
+	src := [][]byte{
+		[]byte("foobarbaz"),
+		[]byte("gondwandaland"),
+		[]byte("longer and longer still, not quite done"),
+		[]byte("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."),
+	}
+
+	// mimic a complex-ish data copy call
+	bcopy := func(src []byte, size int) ([]byte, error) {
+		if size < len(src) {
+			return nil, tooLong
+		}
+		dst := make([]byte, size)
+		copy(dst, src)
+		return dst, nil
+	}
+
+	for i, b := range src {
+		t.Run(fmt.Sprintf("update_%d", i), func(t *testing.T) {
+			var err error
+			var out []byte
+			for sizer := NewSizerEV(1, 4096, tooLong); sizer.Continue(); {
+				out, err = bcopy(b, sizer.Size())
+				err = sizer.Update(err)
+			}
+			assert.Equal(t, b, out[:len(b)])
+		})
+	}
+
+	for i, b := range src {
+		t.Run(fmt.Sprintf("updateWants_%d", i), func(t *testing.T) {
+			var tries int
+			var err error
+			var out []byte
+			for sizer := NewSizerEV(1, 4096, tooLong); sizer.Continue(); {
+				tries++
+				out, err = bcopy(b, sizer.Size())
+				err = sizer.UpdateWants(err, len(b))
+			}
+			assert.Equal(t, b, out[:len(b)])
+			assert.Equal(t, len(b), len(out))
+			assert.Equal(t, 2, tries)
+		})
+	}
+
+	t.Run("exceedsMax", func(t *testing.T) {
+		var tries int
+		var err error
+		for sizer := NewSizerEV(1, 1024, tooLong); sizer.Continue(); {
+			tries++
+			err = sizer.Update(tooLong)
+		}
+		assert.Error(t, err)
+		assert.Equal(t, tooLong, err)
+		assert.Equal(t, 11, tries)
+	})
+
+	t.Run("otherError", func(t *testing.T) {
+		var tries int
+		var err error
+		oops := errors.New("foo")
+		for sizer := NewSizerEV(1, 1024, tooLong); sizer.Continue(); {
+			tries++
+			err = sizer.Update(oops)
+		}
+		assert.Error(t, err)
+		assert.Equal(t, oops, err)
+		assert.Equal(t, 1, tries)
+	})
+}

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -35,6 +35,16 @@ func getError(e C.int) error {
 	return RadosError(e)
 }
 
+// getErrorIfNegative converts a ceph return code to error if negative.
+// This is useful for functions that return a usable positive value on
+// success but a negative error number on error.
+func getErrorIfNegative(ret C.int) error {
+	if ret >= 0 {
+		return nil
+	}
+	return getError(ret)
+}
+
 // Public go errors:
 
 var (
@@ -66,4 +76,6 @@ const (
 
 const (
 	errNameTooLong = RadosError(-C.ENAMETOOLONG)
+
+	errRange = RadosError(-C.ERANGE)
 )

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -61,3 +61,9 @@ const (
 	// Deprecated: use ErrPermissionDenied instead
 	RadosErrorPermissionDenied = ErrPermissionDenied
 )
+
+// Private errors:
+
+const (
+	errNameTooLong = RadosError(-C.ENAMETOOLONG)
+)

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -38,6 +38,16 @@ func getError(err C.int) error {
 	}
 }
 
+// getErrorIfNegative converts a ceph return code to error if negative.
+// This is useful for functions that return a usable positive value on
+// success but a negative error number on error.
+func getErrorIfNegative(ret C.int) error {
+	if ret >= 0 {
+		return nil
+	}
+	return getError(ret)
+}
+
 // Public go errors:
 
 var (

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -61,3 +61,9 @@ var (
 	RbdErrorNotFound     = ErrNotFound
 	// revive:enable:exported
 )
+
+// Private errors:
+
+const (
+	errRange = RBDError(-C.ERANGE)
+)

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -11,34 +11,35 @@ package rbd
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
+	"github.com/ceph/go-ceph/internal/retry"
 	"github.com/ceph/go-ceph/rados"
 )
 
 // GetImageNames returns the list of current RBD images.
 func GetImageNames(ioctx *rados.IOContext) ([]string, error) {
-	size := C.size_t(0)
-	ret := C.rbd_list2(cephIoctx(ioctx), nil, &size)
-	if ret < 0 && ret != -C.ERANGE {
-		return nil, RBDError(ret)
-	} else if ret > 0 {
-		return nil, fmt.Errorf("rbd_list2() returned %d names, expected 0", ret)
-	} else if ret == 0 && size == 0 {
-		return nil, nil
+	var (
+		err    error
+		images []C.rbd_image_spec_t
+		size   C.size_t
+	)
+	for sizer := retry.NewSizerEV(32, 4096, errRange); sizer.Continue(); {
+		size = C.size_t(sizer.Size())
+		images = make([]C.rbd_image_spec_t, size)
+		ret := C.rbd_list2(
+			cephIoctx(ioctx),
+			(*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])),
+			&size)
+		err = sizer.UpdateWants(getErrorIfNegative(ret), int(size))
 	}
-
-	// expected: ret == -ERANGE, size contains number of image names
-	images := make([]C.rbd_image_spec_t, size)
-	ret = C.rbd_list2(cephIoctx(ioctx), (*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])), &size)
-	if ret < 0 {
-		return nil, RBDError(ret)
+	if err != nil {
+		return nil, err
 	}
 	defer C.rbd_image_spec_list_cleanup((*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])), size)
 
 	names := make([]string, size)
-	for i, image := range images {
+	for i, image := range images[:size] {
 		names[i] = C.GoString(image.name)
 	}
 	return names, nil


### PR DESCRIPTION
This PR builds upon PR #190 and that change helps justify this work.

Related to #185.

Depends on PR #212. Please review and merge that first.

This PR defines a new internal pkg "internal/retry" and a Sizer type  that can be used to handle common cases where a C-api function wants to fill in a caller-provided buffer but that buffer may be too small for the data it needs to receive. The approach taken treats the Sizer as an "iterator" to be used with a for loop like so:
```go
var err error
for sizer := NewSizerEV(1, 128, errTooSmall); sizer.Continue(); {
    size := sizer.Size()
    buf := make([]string, size)
    // do something complex with buf
    err = fakeComplexOp2(buf, &size)
    err = sizer.UpdateWants(err, size)
}
```
The buffer does not have to be a bytes slice but can be any type that needs to be dynamically allocated by the caller, passed to the ceph api call, and then the API will return an error code indicating that the allocation was too small. The variety of types needed to be handled in this pattern is why I went with an iterator based approach, as well as the variety of variables that the function calls need to access both inside and outside of the loop. My original approach that used callbacks ended up being too inflexible. Plus, in many cases this approach ended up being less code overall.

Note that the retry.Sizer type is pure Go code and doesn't depend on C.

Assorted functions are then converted to use this new helper. More will be converted but I am trying to keep this PR as a thorough as I can to demonstrate the new behavior without converting all functions in one big PR.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
