### PR TITLE
Fix "go vet" errors and then enable vet in tests

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -90,9 +90,10 @@ type IOContext struct {
 	ioctx C.rados_ioctx_t
 }
 
-// Pointer returns a uintptr representation of the IOContext.
-func (ioctx *IOContext) Pointer() uintptr {
-	return uintptr(ioctx.ioctx)
+// Pointer returns a pointer reference to an internal structure.
+// This function should NOT be used outside of go-ceph itself.
+func (ioctx *IOContext) Pointer() unsafe.Pointer {
+	return unsafe.Pointer(ioctx.ioctx)
 }
 
 // SetNamespace sets the namespace for objects within this IO context (pool).

--- a/rbd/diff_iterate.go
+++ b/rbd/diff_iterate.go
@@ -95,7 +95,6 @@ const (
 //                        int (*cb)(uint64_t, size_t, int, void *),
 //                        void *arg);
 func (image *Image) DiffIterate(config DiffIterateConfig) error {
-
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
 	}

--- a/rbd/diff_iterate.go
+++ b/rbd/diff_iterate.go
@@ -17,8 +17,8 @@ static inline int wrap_rbd_diff_iterate2(
 			uint64_t ofs, uint64_t len,
 			uint8_t include_parent, uint8_t whole_object,
 			void *cb,
-			void *arg) {
-	return rbd_diff_iterate2(image, fromsnapname, ofs, len, include_parent, whole_object, cb, arg);
+			uintptr_t arg) {
+	return rbd_diff_iterate2(image, fromsnapname, ofs, len, include_parent, whole_object, cb, (void*)arg);
 }
 */
 import "C"
@@ -120,7 +120,7 @@ func (image *Image) DiffIterate(config DiffIterateConfig) error {
 		C.uint8_t(config.IncludeParent),
 		C.uint8_t(config.WholeObject),
 		C.callDiffIterateCallback,
-		unsafe.Pointer(uintptr(cbIndex)))
+		C.uintptr_t(cbIndex))
 
 	return getError(ret)
 }

--- a/rbd/rbd_mimic.go
+++ b/rbd/rbd_mimic.go
@@ -23,7 +23,7 @@ func GetImageNames(ioctx *rados.IOContext) (names []string, err error) {
 	buf := make([]byte, 4096)
 	for {
 		size := C.size_t(len(buf))
-		ret := C.rbd_list(C.rados_ioctx_t(ioctx.Pointer()),
+		ret := C.rbd_list(cephIoctx(ioctx),
 			(*C.char)(unsafe.Pointer(&buf[0])), &size)
 		if ret == -C.ERANGE {
 			buf = make([]byte, size)

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -20,7 +20,7 @@ import (
 // GetImageNames returns the list of current RBD images.
 func GetImageNames(ioctx *rados.IOContext) ([]string, error) {
 	size := C.size_t(0)
-	ret := C.rbd_list2(C.rados_ioctx_t(ioctx.Pointer()), nil, &size)
+	ret := C.rbd_list2(cephIoctx(ioctx), nil, &size)
 	if ret < 0 && ret != -C.ERANGE {
 		return nil, RBDError(ret)
 	} else if ret > 0 {
@@ -31,7 +31,7 @@ func GetImageNames(ioctx *rados.IOContext) ([]string, error) {
 
 	// expected: ret == -ERANGE, size contains number of image names
 	images := make([]C.rbd_image_spec_t, size)
-	ret = C.rbd_list2(C.rados_ioctx_t(ioctx.Pointer()), (*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])), &size)
+	ret = C.rbd_list2(cephIoctx(ioctx), (*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])), &size)
 	if ret < 0 {
 		return nil, RBDError(ret)
 	}


### PR DESCRIPTION
These changes first fix some outstanding issues with go vet, all of which pertain to converting from a uintptr type to an unsafe.Pointer / pointer. While I don't 100% understand why its bad enough to warn with go vet but not break the compile :-)

 I would rather get go vet working to prevent future issues like a similar conversion in the newly added diff_iterate support. A helper function is added to rbd to aid with any future functions and to avoid having to mess with a lot of calls if we have to tweak this again.

Finally, we enable go vet in the `entrypoint.sh` script on a per-package basis. It is run prior to the go tests but will still run the tests even in vet fails (either failing will fail the overall script).

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
