### PR TITLE
rbd: small fixes to pass static checks

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -23,9 +23,14 @@ import (
 )
 
 const (
-	// Image.Seek() constants
+	// Image.Seek() constants:
+
+	// SeekSet is used with Seek to absolutely position the file.
 	SeekSet = int(C.SEEK_SET)
+	// SeekCur is used with Seek to position the file relatively to the current
+	// position.
 	SeekCur = int(C.SEEK_CUR)
+	// SeekEnd is used with Seek to position the file relatively to the end.
 	SeekEnd = int(C.SEEK_END)
 )
 

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -64,9 +64,10 @@ var (
 	// missing.
 	ErrNotFound = errors.New("RBD image not found")
 
-	// retained for compatibility with old versions
+	// revive:disable:exported for compatibility with old versions
 	RbdErrorImageNotOpen = ErrImageNotOpen
 	RbdErrorNotFound     = ErrNotFound
+	// revive:enable:exported
 )
 
 //

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -45,7 +45,7 @@ const (
 	NoSnapshot = ""
 )
 
-//
+// RBDError represents an error condition returned from the librbd APIs.
 type RBDError int
 
 var (

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -49,11 +49,20 @@ const (
 type RBDError int
 
 var (
-	ErrNoIOContext    = errors.New("RBD image does not have an IOContext")
-	ErrNoName         = errors.New("RBD image does not have a name")
+	// ErrNoIOContext may be returned if an api call requires an IOContext and
+	// it is not provided.
+	ErrNoIOContext = errors.New("RBD image does not have an IOContext")
+	// ErrNoName may be returned if an api call requires a name and it is
+	// not provided.
+	ErrNoName = errors.New("RBD image does not have a name")
+	// ErrSnapshotNoName may be returned if an aip call requires a snapshot
+	// name and it is not provided.
 	ErrSnapshotNoName = errors.New("RBD snapshot does not have a name")
-	ErrImageNotOpen   = errors.New("RBD image not open")
-	ErrNotFound       = errors.New("RBD image not found")
+	// ErrImageNotOpen may be returnened if an api call requires an open image handle and one is not provided.
+	ErrImageNotOpen = errors.New("RBD image not open")
+	// ErrNotFound may be returned from an api call when the requested item is
+	// missing.
+	ErrNotFound = errors.New("RBD image not found")
 
 	// retained for compatibility with old versions
 	RbdErrorImageNotOpen = ErrImageNotOpen

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -552,7 +552,7 @@ func (image *Image) Copy(ioctx *rados.IOContext, destname string) error {
 		cephIoctx(ioctx), c_destname))
 }
 
-// Copy one rbd image to another, using an image handle.
+// Copy2 copies one rbd image to another, using an image handle.
 //
 // Implements:
 //  int rbd_copy2(rbd_image_t src, rbd_image_t dest);


### PR DESCRIPTION
Doc comment improvements in rbd to get us a tad bit closer to enabling more checks from revive as failures rather than warnings.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
