### PR TITLE
Disable checks for error types with "stuttering" prefixes

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -16,8 +16,12 @@ import (
 	"github.com/ceph/go-ceph/rados"
 )
 
+// revive:disable:exported Temporarily live with stuttering
+
 // CephFSError represents an error condition returned from the CephFS APIs.
 type CephFSError int
+
+// revive:enable:exported
 
 // Error returns the error string for the CephFSError type.
 func (e CephFSError) Error() string {

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -14,8 +14,12 @@ import (
 	"github.com/ceph/go-ceph/internal/errutil"
 )
 
+// revive:disable:exported Temporarily live with stuttering
+
 // RadosError represents an error condition returned from the Ceph RADOS APIs.
 type RadosError int
+
+// revive:enable:exported
 
 // Error returns the error string for the RadosError type.
 func (e RadosError) Error() string {

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -45,8 +45,12 @@ const (
 	NoSnapshot = ""
 )
 
+// revive:disable:exported Temporarily live with stuttering
+
 // RBDError represents an error condition returned from the librbd APIs.
 type RBDError int
+
+// revive:enable:exported
 
 var (
 	// ErrNoIOContext may be returned if an api call requires an IOContext and


### PR DESCRIPTION
Until we (me I suppose) come up with a better approach to the errors in general, I prefer disabling the "stuttering" check for exported items in revive in the code. This gets us closer to changing the check from a warning to an error and not adding any new cases of "stuttering" to the code base.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
