### PR TITLE
rbd: add doc comments to cut down on revive warnings

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -781,6 +781,7 @@ func (image *Image) Write(data []byte) (n int, err error) {
 	return ret, err
 }
 
+// Seek updates the internal file position for the current image.
 func (image *Image) Seek(offset int64, whence int) (int64, error) {
 	switch whence {
 	case SeekSet:

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -74,7 +74,7 @@ var (
 	// revive:enable:exported
 )
 
-//
+// ImageInfo represents the status information for an image.
 type ImageInfo struct {
 	Size              uint64
 	Obj_size          uint64
@@ -85,7 +85,7 @@ type ImageInfo struct {
 	Parent_name       string
 }
 
-//
+// SnapInfo represents the status information for a snapshot.
 type SnapInfo struct {
 	Id   uint64
 	Size uint64

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -99,7 +99,7 @@ type Locker struct {
 	Addr   string
 }
 
-//
+// Image is a handle for an RBD image.
 type Image struct {
 	io.Reader
 	io.Writer

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -92,7 +92,7 @@ type SnapInfo struct {
 	Name string
 }
 
-//
+// Locker provides info about a client that is locking an image.
 type Locker struct {
 	Client string
 	Cookie string

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -800,7 +800,12 @@ func (image *Image) Seek(offset int64, whence int) (int64, error) {
 	return image.offset, nil
 }
 
-// int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
+// Discard the supplied range from the image. The supplied range will be read
+// as zeros once Discard returns. The discarded range will no longer take up
+// space.
+//
+// Implements:
+//  int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
 func (image *Image) Discard(ofs uint64, length uint64) (int, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -878,8 +878,11 @@ func (image *Image) Flush() error {
 	return getError(C.rbd_flush(image.image))
 }
 
-// int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps, int *max_snaps);
-// void rbd_snap_list_end(rbd_snap_info_t *snaps);
+// GetSnapshotNames returns more than just the names of snapshots
+// associated with the rbd image.
+//
+// Implements:
+//  int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps, int *max_snaps);
 func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -866,7 +866,10 @@ func (image *Image) WriteAt(data []byte, off int64) (n int, err error) {
 	return ret, err
 }
 
-// int rbd_flush(rbd_image_t image);
+// Flush all cached writes to storage.
+//
+// Implements:
+//  int rbd_flush(rbd_image_t image);
 func (image *Image) Flush() error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -819,6 +819,7 @@ func (image *Image) Discard(ofs uint64, length uint64) (int, error) {
 	return int(ret), nil
 }
 
+// ReadAt copies data from the image into the supplied buffer.
 func (image *Image) ReadAt(data []byte, off int64) (int, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -845,6 +846,7 @@ func (image *Image) ReadAt(data []byte, off int64) (int, error) {
 	return ret, nil
 }
 
+// WriteAt copies data from the supplied buffer to the image.
 func (image *Image) WriteAt(data []byte, off int64) (n int, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err


### PR DESCRIPTION
Assorted doc comments on functions to reduce the number of warnings produced by revive code checker tool. This continues to get us closer to making this category of checks errors rather than warnings.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
