### PR TITLE
Unify error handling a bit more

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -9,35 +9,10 @@ package cephfs
 import "C"
 
 import (
-	"fmt"
 	"unsafe"
 
-	"github.com/ceph/go-ceph/internal/errutil"
 	"github.com/ceph/go-ceph/rados"
 )
-
-// revive:disable:exported Temporarily live with stuttering
-
-// CephFSError represents an error condition returned from the CephFS APIs.
-type CephFSError int
-
-// revive:enable:exported
-
-// Error returns the error string for the CephFSError type.
-func (e CephFSError) Error() string {
-	errno, s := errutil.FormatErrno(int(e))
-	if s == "" {
-		return fmt.Sprintf("cephfs: ret=%d", errno)
-	}
-	return fmt.Sprintf("cephfs: ret=%d, %s", errno, s)
-}
-
-func getError(e C.int) error {
-	if e == 0 {
-		return nil
-	}
-	return CephFSError(e)
-}
 
 // MountInfo exports ceph's ceph_mount_info from libcephfs.cc
 type MountInfo struct {

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -183,19 +183,6 @@ func TestChown(t *testing.T) {
 
 }
 
-func TestCephFSError(t *testing.T) {
-	err := getError(0)
-	assert.NoError(t, err)
-
-	err = getError(-5) // IO error
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "cephfs: ret=5, Input/output error")
-
-	err = getError(345) // no such errno
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "cephfs: ret=345")
-}
-
 func radosConnect(t *testing.T) *rados.Conn {
 	conn, err := rados.NewConn()
 	require.NoError(t, err)

--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -1,0 +1,35 @@
+package cephfs
+
+/*
+#include <errno.h>
+*/
+import "C"
+
+import (
+	"fmt"
+
+	"github.com/ceph/go-ceph/internal/errutil"
+)
+
+// revive:disable:exported Temporarily live with stuttering
+
+// CephFSError represents an error condition returned from the CephFS APIs.
+type CephFSError int
+
+// revive:enable:exported
+
+// Error returns the error string for the CephFSError type.
+func (e CephFSError) Error() string {
+	errno, s := errutil.FormatErrno(int(e))
+	if s == "" {
+		return fmt.Sprintf("cephfs: ret=%d", errno)
+	}
+	return fmt.Sprintf("cephfs: ret=%d, %s", errno, s)
+}
+
+func getError(e C.int) error {
+	if e == 0 {
+		return nil
+	}
+	return CephFSError(e)
+}

--- a/cephfs/errors_test.go
+++ b/cephfs/errors_test.go
@@ -1,0 +1,20 @@
+package cephfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCephFSError(t *testing.T) {
+	err := getError(0)
+	assert.NoError(t, err)
+
+	err = getError(-5) // IO error
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "cephfs: ret=5, Input/output error")
+
+	err = getError(345) // no such errno
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "cephfs: ret=345")
+}

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -7,13 +7,7 @@ import "C"
 
 import (
 	"bytes"
-	"errors"
 	"unsafe"
-)
-
-var (
-	// ErrNotConnected is returned when functions are called without a RADOS connection
-	ErrNotConnected = errors.New("RADOS not connected")
 )
 
 // ClusterStat represents Ceph cluster statistics.

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -74,14 +74,14 @@ func (c *Conn) ReadConfigFile(path string) error {
 	c_path := C.CString(path)
 	defer C.free(unsafe.Pointer(c_path))
 	ret := C.rados_conf_read_file(c.cluster, c_path)
-	return getRadosError(int(ret))
+	return getError(ret)
 }
 
 // ReadDefaultConfigFile configures the connection using a Ceph configuration
 // file located at default locations.
 func (c *Conn) ReadDefaultConfigFile() error {
 	ret := C.rados_conf_read_file(c.cluster, nil)
-	return getRadosError(int(ret))
+	return getError(ret)
 }
 
 // OpenIOContext creates and returns a new IOContext for the given pool.
@@ -134,7 +134,7 @@ func (c *Conn) SetConfigOption(option, value string) error {
 	defer C.free(unsafe.Pointer(c_opt))
 	defer C.free(unsafe.Pointer(c_val))
 	ret := C.rados_conf_set(c.cluster, c_opt, c_val)
-	return getRadosError(int(ret))
+	return getError(ret)
 }
 
 // GetConfigOption returns the value of the Ceph configuration option
@@ -159,7 +159,7 @@ func (c *Conn) GetConfigOption(name string) (value string, err error) {
 // retrieved.
 func (c *Conn) WaitForLatestOSDMap() error {
 	ret := C.rados_wait_for_latest_osdmap(c.cluster)
-	return getRadosError(int(ret))
+	return getError(ret)
 }
 
 func (c *Conn) ensure_connected() error {
@@ -205,14 +205,14 @@ func (c *Conn) ParseCmdLineArgs(args []string) error {
 	}
 
 	ret := C.rados_conf_parse_argv(c.cluster, argc, &argv[0])
-	return getRadosError(int(ret))
+	return getError(ret)
 }
 
 // ParseDefaultConfigEnv configures the connection from the default Ceph
 // environment variable(s).
 func (c *Conn) ParseDefaultConfigEnv() error {
 	ret := C.rados_conf_parse_env(c.cluster, nil)
-	return getRadosError(int(ret))
+	return getError(ret)
 }
 
 // GetFSID returns the fsid of the cluster as a hexadecimal string. The fsid
@@ -240,8 +240,8 @@ func (c *Conn) GetInstanceID() uint64 {
 func (c *Conn) MakePool(name string) error {
 	c_name := C.CString(name)
 	defer C.free(unsafe.Pointer(c_name))
-	ret := int(C.rados_pool_create(c.cluster, c_name))
-	return getRadosError(int(ret))
+	ret := C.rados_pool_create(c.cluster, c_name)
+	return getError(ret)
 }
 
 // DeletePool deletes a pool and all the data inside the pool.
@@ -251,8 +251,8 @@ func (c *Conn) DeletePool(name string) error {
 	}
 	c_name := C.CString(name)
 	defer C.free(unsafe.Pointer(c_name))
-	ret := int(C.rados_pool_delete(c.cluster, c_name))
-	return getRadosError(int(ret))
+	ret := C.rados_pool_delete(c.cluster, c_name)
+	return getError(ret)
 }
 
 // GetPoolByName returns the ID of the pool with a given name.

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -1,0 +1,63 @@
+package rados
+
+/*
+#include <errno.h>
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ceph/go-ceph/internal/errutil"
+)
+
+// revive:disable:exported Temporarily live with stuttering
+
+// RadosError represents an error condition returned from the Ceph RADOS APIs.
+type RadosError int
+
+// revive:enable:exported
+
+// Error returns the error string for the RadosError type.
+func (e RadosError) Error() string {
+	errno, s := errutil.FormatErrno(int(e))
+	if s == "" {
+		return fmt.Sprintf("rados: ret=%d", errno)
+	}
+	return fmt.Sprintf("rados: ret=%d, %s", errno, s)
+}
+
+func getRadosError(err int) error {
+	if err == 0 {
+		return nil
+	}
+	return RadosError(err)
+}
+
+// Public go errors:
+
+var (
+	// ErrNotConnected is returned when functions are called without a RADOS connection
+	ErrNotConnected = errors.New("RADOS not connected")
+)
+
+// Public RadosErrors:
+
+const (
+	// ErrNotFound indicates a missing resource.
+	ErrNotFound = RadosError(-C.ENOENT)
+	// ErrPermissionDenied indicates a permissions issue.
+	ErrPermissionDenied = RadosError(-C.EPERM)
+	// ErrObjectExists indicates that an exclusive object creation failed.
+	ErrObjectExists = RadosError(-C.EEXIST)
+
+	// RadosErrorNotFound indicates a missing resource.
+	//
+	// Deprecated: use ErrNotFound instead
+	RadosErrorNotFound = ErrNotFound
+	// RadosErrorPermissionDenied indicates a permissions issue.
+	//
+	// Deprecated: use ErrPermissionDenied instead
+	RadosErrorPermissionDenied = ErrPermissionDenied
+)

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -28,11 +28,11 @@ func (e RadosError) Error() string {
 	return fmt.Sprintf("rados: ret=%d, %s", errno, s)
 }
 
-func getRadosError(err int) error {
-	if err == 0 {
+func getError(e C.int) error {
+	if e == 0 {
 		return nil
 	}
-	return RadosError(err)
+	return RadosError(e)
 }
 
 // Public go errors:

--- a/rados/errors_test.go
+++ b/rados/errors_test.go
@@ -1,0 +1,20 @@
+package rados
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRadosError(t *testing.T) {
+	err := getRadosError(0)
+	assert.NoError(t, err)
+
+	err = getRadosError(-5) // IO error
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "rados: ret=5, Input/output error")
+
+	err = getRadosError(345) // no such errno
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "rados: ret=345")
+}

--- a/rados/errors_test.go
+++ b/rados/errors_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestRadosError(t *testing.T) {
-	err := getRadosError(0)
+	err := getError(0)
 	assert.NoError(t, err)
 
-	err = getRadosError(-5) // IO error
+	err = getError(-5) // IO error
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "rados: ret=5, Input/output error")
 
-	err = getRadosError(345) // no such errno
+	err = getError(345) // no such errno
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "rados: ret=345")
 }

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -445,7 +445,7 @@ func (ioctx *IOContext) LockExclusive(oid, name, cookie, desc string, duration t
 	case -C.EEXIST:
 		return int(ret), nil
 	default:
-		return int(ret), RadosError(int(ret))
+		return int(ret), getError(ret)
 	}
 }
 
@@ -496,7 +496,7 @@ func (ioctx *IOContext) LockShared(oid, name, cookie, tag, desc string, duration
 	case -C.EEXIST:
 		return int(ret), nil
 	default:
-		return int(ret), RadosError(int(ret))
+		return int(ret), getError(ret)
 	}
 }
 
@@ -525,7 +525,7 @@ func (ioctx *IOContext) Unlock(oid, name, cookie string) (int, error) {
 	case -C.ENOENT:
 		return int(ret), nil
 	default:
-		return int(ret), RadosError(int(ret))
+		return int(ret), getError(ret)
 	}
 }
 
@@ -582,7 +582,7 @@ func (ioctx *IOContext) ListLockers(oid, name string) (*LockInfo, error) {
 	}
 
 	if ret < 0 {
-		return nil, RadosError(int(ret))
+		return nil, RadosError(ret)
 	}
 	return &LockInfo{int(ret), c_exclusive == 1, C.GoString(c_tag), splitCString(c_clients, c_clients_len), splitCString(c_cookies, c_cookies_len), splitCString(c_addrs, c_addrs_len)}, nil
 }
@@ -618,6 +618,6 @@ func (ioctx *IOContext) BreakLock(oid, name, client, cookie string) (int, error)
 	case -C.EINVAL: // -EINVAL
 		return int(ret), nil
 	default:
-		return int(ret), RadosError(int(ret))
+		return int(ret), getError(ret)
 	}
 }

--- a/rados/object_iter.go
+++ b/rados/object_iter.go
@@ -20,7 +20,7 @@ type IterToken uint32
 func (ioctx *IOContext) Iter() (*Iter, error) {
 	iter := Iter{}
 	if cerr := C.rados_nobjects_list_open(ioctx.ioctx, &iter.ctx); cerr < 0 {
-		return nil, getRadosError(int(cerr))
+		return nil, getError(cerr)
 	}
 	return &iter, nil
 }
@@ -53,7 +53,7 @@ func (iter *Iter) Next() bool {
 	var c_entry *C.char
 	var c_namespace *C.char
 	if cerr := C.rados_nobjects_list_next(iter.ctx, &c_entry, nil, &c_namespace); cerr < 0 {
-		iter.err = getRadosError(int(cerr))
+		iter.err = getError(cerr)
 		return false
 	}
 	iter.entry = C.GoString(c_entry)

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -63,7 +63,7 @@ func (ioctx *IOContext) SetOmap(oid string, pairs map[string][]byte) error {
 	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
 	C.rados_release_write_op(op)
 
-	return getRadosError(int(ret))
+	return getError(ret)
 }
 
 // OmapListFunc is the type of the function called for each omap key
@@ -104,7 +104,7 @@ func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPref
 	ret := C.rados_read_op_operate(op, ioctx.ioctx, c_oid, 0)
 
 	if int(ret) != 0 {
-		return getRadosError(int(ret))
+		return getError(ret)
 	} else if int(c_prval) != 0 {
 		return RadosError(int(c_prval))
 	}
@@ -117,7 +117,7 @@ func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPref
 		ret = C.rados_omap_get_next(c_iter, &c_key, &c_val, &c_len)
 
 		if int(ret) != 0 {
-			return getRadosError(int(ret))
+			return getError(ret)
 		}
 
 		if c_key == nil {
@@ -210,7 +210,7 @@ func (ioctx *IOContext) RmOmapKeys(oid string, keys []string) error {
 	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
 	C.rados_release_write_op(op)
 
-	return getRadosError(int(ret))
+	return getError(ret)
 }
 
 // CleanOmap clears the omap `oid`
@@ -224,5 +224,5 @@ func (ioctx *IOContext) CleanOmap(oid string) error {
 	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
 	C.rados_release_write_op(op)
 
-	return getRadosError(int(ret))
+	return getError(ret)
 }

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -106,7 +106,7 @@ func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPref
 	if int(ret) != 0 {
 		return getError(ret)
 	} else if int(c_prval) != 0 {
-		return RadosError(int(c_prval))
+		return getError(c_prval)
 	}
 
 	for {

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -7,40 +7,14 @@ package rados
 import "C"
 
 import (
-	"fmt"
 	"runtime"
 	"unsafe"
-
-	"github.com/ceph/go-ceph/internal/errutil"
 )
-
-// revive:disable:exported Temporarily live with stuttering
-
-// RadosError represents an error condition returned from the Ceph RADOS APIs.
-type RadosError int
-
-// revive:enable:exported
-
-// Error returns the error string for the RadosError type.
-func (e RadosError) Error() string {
-	errno, s := errutil.FormatErrno(int(e))
-	if s == "" {
-		return fmt.Sprintf("rados: ret=%d", errno)
-	}
-	return fmt.Sprintf("rados: ret=%d, %s", errno, s)
-}
 
 const (
 	// AllNamespaces is used to reset a selected namespace to all
 	// namespaces. See the IOContext SetNamespace function.
 	AllNamespaces = C.LIBRADOS_ALL_NSPACES
-
-	// ErrNotFound indicates a missing resource.
-	ErrNotFound = RadosError(-C.ENOENT)
-	// ErrPermissionDenied indicates a permissions issue.
-	ErrPermissionDenied = RadosError(-C.EPERM)
-	// ErrObjectExists indicates that an exclusive object creation failed.
-	ErrObjectExists = RadosError(-C.EEXIST)
 
 	// FIXME: for backwards compatibility
 
@@ -49,22 +23,7 @@ const (
 	//
 	// Deprecated: use AllNamespaces instead
 	RadosAllNamespaces = AllNamespaces
-	// RadosErrorNotFound indicates a missing resource.
-	//
-	// Deprecated: use ErrNotFound instead
-	RadosErrorNotFound = ErrNotFound
-	// RadosErrorPermissionDenied indicates a permissions issue.
-	//
-	// Deprecated: use ErrPermissionDenied instead
-	RadosErrorPermissionDenied = ErrPermissionDenied
 )
-
-func getRadosError(err int) error {
-	if err == 0 {
-		return nil
-	}
-	return RadosError(err)
-}
 
 // Version returns the major, minor, and patch components of the version of
 // the RADOS library linked against.

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -42,7 +42,7 @@ func newConn(user *C.char) (*Conn, error) {
 	ret := C.rados_create(&conn.cluster, user)
 
 	if ret != 0 {
-		return nil, RadosError(int(ret))
+		return nil, getError(ret)
 	}
 
 	runtime.SetFinalizer(conn, freeConn)
@@ -75,7 +75,7 @@ func NewConnWithClusterAndUser(clusterName string, userName string) (*Conn, erro
 	conn := makeConn()
 	ret := C.rados_create2(&conn.cluster, c_cluster_name, c_name, 0)
 	if ret != 0 {
-		return nil, RadosError(int(ret))
+		return nil, getError(ret)
 	}
 
 	runtime.SetFinalizer(conn, freeConn)

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -1200,16 +1200,3 @@ func (suite *RadosTestSuite) TestOpenIOContextInvalidPool() {
 func TestRadosTestSuite(t *testing.T) {
 	suite.Run(t, new(RadosTestSuite))
 }
-
-func TestRadosError(t *testing.T) {
-	err := getRadosError(0)
-	assert.NoError(t, err)
-
-	err = getRadosError(-5) // IO error
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "rados: ret=5, Input/output error")
-
-	err = getRadosError(345) // no such errno
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "rados: ret=345")
-}

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -1,0 +1,63 @@
+package rbd
+
+/*
+#include <errno.h>
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ceph/go-ceph/internal/errutil"
+)
+
+// revive:disable:exported Temporarily live with stuttering
+
+// RBDError represents an error condition returned from the librbd APIs.
+type RBDError int
+
+// revive:enable:exported
+
+func (e RBDError) Error() string {
+	errno, s := errutil.FormatErrno(int(e))
+	if s == "" {
+		return fmt.Sprintf("rbd: ret=%d", errno)
+	}
+	return fmt.Sprintf("rbd: ret=%d, %s", errno, s)
+}
+
+func getError(err C.int) error {
+	if err != 0 {
+		if err == -C.ENOENT {
+			return ErrNotFound
+		}
+		return RBDError(err)
+	} else {
+		return nil
+	}
+}
+
+// Public go errors:
+
+var (
+	// ErrNoIOContext may be returned if an api call requires an IOContext and
+	// it is not provided.
+	ErrNoIOContext = errors.New("RBD image does not have an IOContext")
+	// ErrNoName may be returned if an api call requires a name and it is
+	// not provided.
+	ErrNoName = errors.New("RBD image does not have a name")
+	// ErrSnapshotNoName may be returned if an aip call requires a snapshot
+	// name and it is not provided.
+	ErrSnapshotNoName = errors.New("RBD snapshot does not have a name")
+	// ErrImageNotOpen may be returnened if an api call requires an open image handle and one is not provided.
+	ErrImageNotOpen = errors.New("RBD image not open")
+	// ErrNotFound may be returned from an api call when the requested item is
+	// missing.
+	ErrNotFound = errors.New("RBD image not found")
+
+	// revive:disable:exported for compatibility with old versions
+	RbdErrorImageNotOpen = ErrImageNotOpen
+	RbdErrorNotFound     = ErrNotFound
+	// revive:enable:exported
+)

--- a/rbd/errors_test.go
+++ b/rbd/errors_test.go
@@ -1,0 +1,20 @@
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRBDError(t *testing.T) {
+	err := getError(0)
+	assert.NoError(t, err)
+
+	err = getError(-39) // NOTEMPTY (image still has a snapshot)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "rbd: ret=39, Directory not empty")
+
+	err = getError(345) // no such errno
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "rbd: ret=345")
+}

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -13,12 +13,10 @@ import "C"
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"time"
 	"unsafe"
 
-	"github.com/ceph/go-ceph/internal/errutil"
 	"github.com/ceph/go-ceph/rados"
 )
 
@@ -43,35 +41,6 @@ const (
 
 	// NoSnapshot indicates that no snapshot name is in use (see OpenImage)
 	NoSnapshot = ""
-)
-
-// revive:disable:exported Temporarily live with stuttering
-
-// RBDError represents an error condition returned from the librbd APIs.
-type RBDError int
-
-// revive:enable:exported
-
-var (
-	// ErrNoIOContext may be returned if an api call requires an IOContext and
-	// it is not provided.
-	ErrNoIOContext = errors.New("RBD image does not have an IOContext")
-	// ErrNoName may be returned if an api call requires a name and it is
-	// not provided.
-	ErrNoName = errors.New("RBD image does not have a name")
-	// ErrSnapshotNoName may be returned if an aip call requires a snapshot
-	// name and it is not provided.
-	ErrSnapshotNoName = errors.New("RBD snapshot does not have a name")
-	// ErrImageNotOpen may be returnened if an api call requires an open image handle and one is not provided.
-	ErrImageNotOpen = errors.New("RBD image not open")
-	// ErrNotFound may be returned from an api call when the requested item is
-	// missing.
-	ErrNotFound = errors.New("RBD image not found")
-
-	// revive:disable:exported for compatibility with old versions
-	RbdErrorImageNotOpen = ErrImageNotOpen
-	RbdErrorNotFound     = ErrNotFound
-	// revive:enable:exported
 )
 
 // ImageInfo represents the status information for an image.
@@ -154,25 +123,6 @@ func (image *Image) validate(req uint32) error {
 	}
 
 	return nil
-}
-
-func (e RBDError) Error() string {
-	errno, s := errutil.FormatErrno(int(e))
-	if s == "" {
-		return fmt.Sprintf("rbd: ret=%d", errno)
-	}
-	return fmt.Sprintf("rbd: ret=%d, %s", errno, s)
-}
-
-func getError(err C.int) error {
-	if err != 0 {
-		if err == -C.ENOENT {
-			return ErrNotFound
-		}
-		return RBDError(err)
-	} else {
-		return nil
-	}
 }
 
 // Version returns the major, minor, and patch level of the librbd library.

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -24,19 +24,6 @@ func GetUUID() string {
 	return uuid.Must(uuid.NewV4()).String()
 }
 
-func TestRBDError(t *testing.T) {
-	err := getError(0)
-	assert.NoError(t, err)
-
-	err = getError(-39) // NOTEMPTY (image still has a snapshot)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "rbd: ret=39, Directory not empty")
-
-	err = getError(345) // no such errno
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "rbd: ret=345")
-}
-
 func TestVersion(t *testing.T) {
 	var major, minor, patch = Version()
 	assert.False(t, major < 0 || major > 1000, "invalid major")


### PR DESCRIPTION
Move errors and error types and error functions into a per-package "errors.go" file, for rados, rbd, and cephfs.

Clean up and make the usage more consistent across the 3 packages.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
