### PR TITLE
Enable additional revive checks

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -24,7 +24,7 @@ warningCode = 0
 [rule.receiver-naming]
 [rule.time-naming]
 [rule.unexported-return]
-#[rule.indent-error-flow]
+[rule.indent-error-flow]
 [rule.errorf]
 [rule.empty-block]
 [rule.superfluous-else]

--- a/.revive.toml
+++ b/.revive.toml
@@ -37,3 +37,8 @@ warningCode = 0
 [rule.constant-logical-expr]
 [rule.unnecessary-stmt]
 [rule.unused-receiver]
+
+[rule.argument-limit]
+  arguments = [7]
+[rule.function-result-limit]
+  arguments = [3]

--- a/.revive.toml
+++ b/.revive.toml
@@ -42,3 +42,7 @@ warningCode = 0
   arguments = [7]
 [rule.function-result-limit]
   arguments = [3]
+
+[rule.unhandled-error]
+  # functions to ignore unhandled errors on
+  arguments = ["fmt.Printf", "fmt.Println"]

--- a/.revive.toml
+++ b/.revive.toml
@@ -31,3 +31,9 @@ warningCode = 0
 [rule.unused-parameter]
 [rule.unreachable-code]
 [rule.redefines-builtin-id]
+
+[rule.atomic]
+[rule.bool-literal-in-expr]
+[rule.constant-logical-expr]
+[rule.unnecessary-stmt]
+[rule.unused-receiver]

--- a/package_test.go
+++ b/package_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestImports(t *testing.T) {
-	if assert.Equal(t, 1, 1) != true {
+	if !assert.Equal(t, 1, 1) {
 		t.Error("Something is wrong.")
 	}
 }

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -193,7 +193,11 @@ func (suite *RadosTestSuite) TestReadConfigFile() {
 
 	// create conf file that changes log_file conf option
 	file, err := ioutil.TempFile("/tmp", "go-rados")
-	assert.NoError(suite.T(), err)
+	require.NoError(suite.T(), err)
+	defer func() {
+		assert.NoError(suite.T(), file.Close())
+		assert.NoError(suite.T(), os.Remove(file.Name()))
+	}()
 
 	next_val := prev_val + 1
 	conf := fmt.Sprintf("[global]\nlog_max_new = %d\n", next_val)
@@ -213,9 +217,6 @@ func (suite *RadosTestSuite) TestReadConfigFile() {
 
 	assert.NotEqual(suite.T(), prev_str, curr_str)
 	assert.Equal(suite.T(), curr_val, prev_val+1)
-
-	file.Close()
-	os.Remove(file.Name())
 }
 
 func (suite *RadosTestSuite) TestGetClusterStats() {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -230,7 +230,8 @@ func (suite *RadosTestSuite) TestGetClusterStats() {
 	buf := make([]byte, 1<<20)
 	for i := 0; i < 10; i++ {
 		objname := suite.GenObjectName()
-		suite.ioctx.Write(objname, buf, 0)
+		err = suite.ioctx.Write(objname, buf, 0)
+		assert.NoError(suite.T(), err)
 	}
 
 	// wait a while for the stats to change
@@ -560,7 +561,8 @@ func (suite *RadosTestSuite) TestGetPoolStats() {
 	buf := make([]byte, 1<<20)
 	for i := 0; i < 10; i++ {
 		oid := suite.GenObjectName()
-		suite.ioctx.Write(oid, buf, 0)
+		err = suite.ioctx.Write(oid, buf, 0)
+		assert.NoError(suite.T(), err)
 	}
 
 	// wait a while for the stats to change

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -64,7 +64,8 @@ func (suite *RadosTestSuite) SetupTest() {
 	conn, err := NewConn()
 	require.NoError(suite.T(), err)
 	suite.conn = conn
-	suite.conn.ReadDefaultConfigFile()
+	err = suite.conn.ReadDefaultConfigFile()
+	require.NoError(suite.T(), err)
 }
 
 func (suite *RadosTestSuite) SetupConnection() {
@@ -105,7 +106,8 @@ func (suite *RadosTestSuite) TearDownSuite() {
 	require.NoError(suite.T(), err)
 	defer conn.Shutdown()
 
-	conn.ReadDefaultConfigFile()
+	err = conn.ReadDefaultConfigFile()
+	require.NoError(suite.T(), err)
 
 	if err = conn.Connect(); assert.NoError(suite.T(), err) {
 		err = conn.DeletePool(suite.pool)

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -413,7 +413,8 @@ func (suite *RadosTestSuite) TestGetLargePoolList() {
 
 	defer func(origPools []string) {
 		for _, name := range names {
-			suite.conn.DeletePool(name)
+			err := suite.conn.DeletePool(name)
+			assert.NoError(suite.T(), err)
 		}
 		cleanPools, err := suite.conn.ListPools()
 		assert.NoError(suite.T(), err)

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -33,9 +33,8 @@ func getError(err C.int) error {
 			return ErrNotFound
 		}
 		return RBDError(err)
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // Public go errors:

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -535,7 +535,7 @@ func TestIOReaderWriter(t *testing.T) {
 	assert.NoError(t, err)
 
 	encoder := json.NewEncoder(img)
-	encoder.Encode(stats)
+	assert.NoError(t, encoder.Encode(stats))
 
 	err = img.Flush()
 	assert.NoError(t, err)
@@ -545,7 +545,7 @@ func TestIOReaderWriter(t *testing.T) {
 
 	var stats2 *ImageInfo
 	decoder := json.NewDecoder(img)
-	decoder.Decode(&stats2)
+	assert.NoError(t, decoder.Decode(&stats2))
 
 	assert.Equal(t, &stats, &stats2)
 


### PR DESCRIPTION
I scanned through some of the other revive rules we weren't using and, after fixing issues found by the tool, enabled these rules in the configuration. I think these rules should be fairly uncontroversial. Nearly all of the issues found and fixed were in the test code.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
