### PR TITLE
Archive html coverage reports generated during ci jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,4 +36,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run test container
-      run: make test-container "CEPH_VERSION=${{ matrix.ceph_version }}"
+      run: make test-container "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
+    - name: Archive coverage results
+      uses: actions/upload-artifact@v1
+      with:
+        name: "go-ceph-coverage-${{ matrix.ceph_version }}"
+        path: "_results/coverage/go-ceph.html"


### PR DESCRIPTION
Make use of the github workflows archive feature to capture the coverage report(s) that are generated when the CI test container runs.

The results dir is currently defaulted to the empty string so there should be no change to the developers workflow. However, if you want to save the results locally you can now set RESULTS_DIR. For example: `make test-container RESULTS_DIR="$PWD/_results"`
