### PR TITLE
[WIP] Implemented cephfs link functions

### DIFF
--- a/cephfs/path.go
+++ b/cephfs/path.go
@@ -44,3 +44,68 @@ func (mount *MountInfo) RemoveDir(path string) error {
 	ret := C.ceph_rmdir(mount.mount, cPath)
 	return getError(ret)
 }
+
+// Link creates a new link to an existing file
+//
+// Implements:
+// int ceph_link (struct ceph_mount_info *cmount, const char *existing,
+//				  const char *newname);
+func (mount *MountInfo) Link(existing, newname string) error {
+	cExisting := C.CString(existing)
+	defer C.free(unsafe.Pointer(cExisting))
+
+	cNewname := C.CString(newname)
+	defer C.free(unsafe.Pointer(cNewname))
+
+	ret := C.ceph_link(mount.mount, cExisting, cNewname)
+	return getError(ret)
+}
+
+// Unlink removes a link to a file (path).
+//
+// Implements:
+// int ceph_unlink(struct ceph_mount_info *cmount, const char *path);
+func (mount *MountInfo) Unlink(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.ceph_unlink(mount.mount, cPath)
+	return getError(ret)
+}
+
+// Symlink creates a symbolic link to an existing path
+//
+// Implements:
+// int ceph_symlink(struct ceph_mount_info *cmount, const char *existing,)
+//					const char *newname);
+func (mount *MountInfo) Symlink(existing, newname string) error {
+	cExisting := C.CString(existing)
+	defer C.free(unsafe.Pointer(cExisting))
+
+	cNewname := C.CString(newname)
+	defer C.free(unsafe.Pointer(cNewname))
+
+	ret := C.ceph_symlink(mount.mount, cExisting, cNewname)
+	return getError(ret)
+}
+
+// Readlink reads value of a symbolic link
+//
+// Implements:
+// int ceph_readlink(struct ceph_mount_info *cmount, const char *path,
+//					 char *buf, int64_t size);
+func (mount *MountInfo) Readlink(path string) (int, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	buf := make([]byte, 4096)
+	ret := C.ceph_readlink(mount.mount,
+		cPath,
+		(*C.char)(unsafe.Pointer(&buf[0])),
+		C.int64_t(len(buf)))
+	if ret < 0 {
+		return 0, getError(ret)
+	}
+
+	return int(ret), nil
+}

--- a/cephfs/path_test.go
+++ b/cephfs/path_test.go
@@ -60,3 +60,201 @@ func TestRemoveDir(t *testing.T) {
 	assert.EqualError(t, err,
 		fmt.Sprintf("stat %s: no such file or directory", localPath))
 }
+
+func TestLink(t *testing.T) {
+	mount := fsConnect(t)
+	defer fsDisconnect(t, mount)
+
+	t.Run("directory operations", func(t *testing.T) {
+		err := mount.Link("/", "/")
+		// Error directory operations not allowed
+		assert.Error(t, err)
+
+		dirname := "/a"
+		err = mount.MakeDir(dirname, 0755)
+		assert.NoError(t, err)
+		defer func() { assert.NoError(t, mount.RemoveDir(dirname)) }()
+
+		err = mount.Link(dirname, "/")
+		// Error, directory operations not allowed
+		assert.Error(t, err)
+
+		filename := "/tmp/file"
+		err = mount.Link(dirname, filename)
+		// Error, directory operations not allowed
+		assert.Error(t, err)
+
+		err = mount.Link(filename, dirname)
+		// Error, file does not exist
+		assert.Error(t, err)
+
+		/*
+			file, _ := os.Create(filename)
+			defer func() {
+				assert.NoError(t, file.Close())
+				assert.NoError(t, mount.Unlink(filename))
+			}()
+			err = mount.Link(filename, dirname)
+			// No Error, file can link to directory
+			assert.NoError(t, err)
+
+			err = mount.Link(filename, dirname)
+			// Error, link already exist
+			assert.Error(t, err)
+		*/
+	})
+
+	t.Run("file operations", func(t *testing.T) {
+		filename1 := "/tmp/file1"
+		err := mount.Link(filename1, "/tmp/hardlnk")
+		// Error, file does not exist
+		assert.Error(t, err)
+		/*
+			file1, _ := os.Create(filename1)
+			defer func() {
+				assert.NoError(t, file1.Close())
+				assert.NoError(t, mount.Unlink(filename1))
+			}()
+			err = mount.Link(filename1, "/tmp/hardlnk")
+			defer assert.NoError(t, mount.Unlink("/tmp/hardlnk"))
+			// No error, normal link operation
+			assert.NoError(t, err)
+			// Verify that link got created
+			_, err = os.Stat("/tmp/hardlnk")
+			assert.NoError(t, err)
+
+			filename2 := "/tmp/file2"
+			file2, _ := os.Create(filename2)
+			defer func() {
+				assert.NoError(t, file2.Close())
+				assert.NoError(t, mount.Unlink(filename2))
+			}()
+			err = mount.Link(filename1, filename2)
+			// Error, destination already exists.
+			assert.Error(t, err)
+		*/
+	})
+}
+
+func TestUnlink(t *testing.T) {
+	mount := fsConnect(t)
+	defer fsDisconnect(t, mount)
+
+	filename := "/tmp/file"
+	err := mount.Unlink(filename)
+	// Error, file does not exist
+	assert.Error(t, err)
+	/*
+		file, _ := os.Create(filename)
+		file.Close()
+		assert.NoError(t, mount.Link(filename, "/tmp/hardlnk"))
+		err = mount.Unlink(filename)
+		// No Error, link will be removed
+		assert.NoError(t, err)
+		err = mount.Unlink("/tmp/hardlnk")
+		// No Error, link will be removed
+		assert.NoError(t, err)
+	*/
+	dirname := "/a"
+	err = mount.MakeDir(dirname, 0755)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, mount.RemoveDir(dirname)) }()
+
+	err = mount.Unlink(dirname)
+	// Error, not permitted on directory
+	assert.Error(t, err)
+}
+
+func TestSymlink(t *testing.T) {
+	mount := fsConnect(t)
+	defer fsDisconnect(t, mount)
+
+	filename1 := "file1"
+	filename2 := "file2"
+
+	err := mount.Symlink(filename1, filename2)
+	defer func() {
+		assert.NoError(t, mount.Unlink(filename2))
+		//assert.NoError(t, mount.Unlink(filename1))
+	}()
+	// Error, file doesn't exist
+	assert.NoError(t, err)
+	/*
+		existingFile := "tmp/existing"
+		existing, _ := os.Create(existingFile)
+		err = mount.Symlink(filename1, existingFile)
+		defer func() {
+			existing.Close()
+			assert.NoError(t, mount.Unlink(existingFile))
+		}()
+		// Error, file already exists
+		assert.Error(t, err)
+	*/
+	// 1. Create a directory
+	// 2. Create a symlink to that directory
+	// 3. Create a file inside symlink.
+	// 4. Ensure that it is a file not a directory
+	dirname := "/a"
+	err = mount.MakeDir(dirname, 0755)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, mount.RemoveDir(dirname)) }()
+
+	err = mount.Symlink(dirname, "symlink")
+	assert.NoError(t, err)
+	/*
+			filename := "tmp/symlink/file"
+			file, _ := os.Create(filename)
+			defer file.Close()
+			var fileInfo os.FileInfo
+			fileInfo, err = os.Stat("/tmp/symlink")
+			assert.EqualError(t, err,
+				fmt.Sprintf("Is Regular: %v", !fileInfo.IsDir()))
+
+		defer func() { assert.NoError(t, mount.Unlink("/tmp/symlink")) }()
+	*/
+}
+
+func TestReadlink(t *testing.T) {
+	mount := fsConnect(t)
+	defer fsDisconnect(t, mount)
+
+	path1 := "path1"
+	_, err := mount.Readlink(path1)
+	// Error, given path is does not exist.
+	assert.Error(t, err)
+
+	/*
+		filename := "file1.txt"
+		file, _ := os.Create(filename)
+		defer func() {
+			assert.NoError(t, mount.Unlink(filename))
+			assert.NoError(t, file.Close())
+		}()
+		_, err = mount.Readlink(filename)
+		// Error, given path is not symbolic link
+		assert.Error(t, err)
+	*/
+	// Symbolic link
+	path2 := "path2"
+	assert.NoError(t, mount.Symlink(path1, path2))
+	defer func() { assert.NoError(t, mount.Unlink(path2)) }()
+	_, err = mount.Readlink(path2)
+	// No Error, path2 is a symbolic link
+	assert.NoError(t, err)
+
+	// Hard link
+	/*
+		path3 := "path3"
+		path4 := "path4"
+		p, _ := os.Create(path3)
+		defer func() {
+			assert.NoError(t, mount.Unlink(path3))
+			assert.NoError(t, p.Close())
+		}()
+		assert.NoError(t, mount.Link(path3, path4))
+		defer func() { assert.NoError(t, mount.Unlink(path4)) }()
+		_, err = mount.Readlink(path4)
+		// Error, path4 is not symbolic link
+		assert.Error(t, err)
+	*/
+}


### PR DESCRIPTION
Implemented cephfs link functions namely:
1. ceph_link() 2. ceph_unlink() 3. ceph_symlink() 4. =ceph_readlink()

Keeping it WIP because:
1. have commented out few unit tests because of the dependency on PR #225 
2. Have to remove Unlink function

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>


## Checklist
- [x] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [x] Standard formatting is applied to Go code
