### PR TITLE
Makefile: Fix CONTAINER_OPTS for Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_CI_IMAGE = go-ceph-ci
 CONTAINER_CMD := docker
-CONTAINER_OPTS := --security-opt $(shell grep -q selinux /sys/kernel/security/lsm && echo "label=disabled" || echo "apparmor:unconfined")
+CONTAINER_OPTS := --security-opt $(shell grep -q selinux /sys/kernel/security/lsm && echo "label=disable" || echo "apparmor:unconfined")
 CONTAINER_CONFIG_DIR := testing/containers/ceph
 VOLUME_FLAGS := 
 CEPH_VERSION := nautilus


### PR DESCRIPTION
make test-container is failing on Fedora based distribution because of bad label option "disabled".
Change label option to "disable"

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
