### PR TITLE
[go report]: Improved go report card.

### DIFF
--- a/cephfs/permissions_test.go
+++ b/cephfs/permissions_test.go
@@ -14,12 +14,12 @@ func TestChmodDir(t *testing.T) {
 	useMount(t)
 
 	dirname := "two"
-	var stats_before uint32 = 0755
-	var stats_after uint32 = 0700
+	var statsBefore uint32 = 0755
+	var statsAfter uint32 = 0700
 	mount := fsConnect(t)
 	defer fsDisconnect(t, mount)
 
-	err := mount.MakeDir(dirname, stats_before)
+	err := mount.MakeDir(dirname, statsBefore)
 	assert.NoError(t, err)
 	defer mount.RemoveDir(dirname)
 
@@ -30,16 +30,17 @@ func TestChmodDir(t *testing.T) {
 	stats, err := os.Stat(path.Join(CephMountDir, dirname))
 	require.NoError(t, err)
 
-	assert.Equal(t, uint32(stats.Mode().Perm()), stats_before)
+	assert.Equal(t, uint32(stats.Mode().Perm()), statsBefore)
 
-	err = mount.Chmod(dirname, stats_after)
+	err = mount.Chmod(dirname, statsAfter)
 	assert.NoError(t, err)
 
 	stats, err = os.Stat(path.Join(CephMountDir, dirname))
-	assert.Equal(t, uint32(stats.Mode().Perm()), stats_after)
+	assert.Equal(t, uint32(stats.Mode().Perm()), statsAfter)
+	assert.NoError(t, err)
 }
 
-// Not cross-platform, go's os does not specifiy Sys return type
+// Not cross-platform, go's os does not specify Sys return type
 func TestChown(t *testing.T) {
 	useMount(t)
 

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -36,13 +36,13 @@ func (c *Conn) Cluster() ClusterRef {
 
 // PingMonitor sends a ping to a monitor and returns the reply.
 func (c *Conn) PingMonitor(id string) (string, error) {
-	c_id := C.CString(id)
-	defer C.free(unsafe.Pointer(c_id))
+	cID := C.CString(id)
+	defer C.free(unsafe.Pointer(cID))
 
 	var strlen C.size_t
 	var strout *C.char
 
-	ret := C.rados_ping_monitor(c.cluster, c_id, &strout, &strlen)
+	ret := C.rados_ping_monitor(c.cluster, cID, &strout, &strlen)
 	defer C.rados_buffer_free(strout)
 
 	if ret == 0 {
@@ -65,7 +65,7 @@ func (c *Conn) Connect() error {
 
 // Shutdown disconnects from the cluster.
 func (c *Conn) Shutdown() {
-	if err := c.ensure_connected(); err != nil {
+	if err := c.ensureConnected(); err != nil {
 		return
 	}
 	freeConn(c)
@@ -73,9 +73,9 @@ func (c *Conn) Shutdown() {
 
 // ReadConfigFile configures the connection using a Ceph configuration file.
 func (c *Conn) ReadConfigFile(path string) error {
-	c_path := C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
-	ret := C.rados_conf_read_file(c.cluster, c_path)
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	ret := C.rados_conf_read_file(c.cluster, cPath)
 	return getError(ret)
 }
 
@@ -92,10 +92,10 @@ func (c *Conn) ReadDefaultConfigFile() error {
 //  int rados_ioctx_create(rados_t cluster, const char *pool_name,
 //                         rados_ioctx_t *ioctx);
 func (c *Conn) OpenIOContext(pool string) (*IOContext, error) {
-	c_pool := C.CString(pool)
-	defer C.free(unsafe.Pointer(c_pool))
+	cPool := C.CString(pool)
+	defer C.free(unsafe.Pointer(cPool))
 	ioctx := &IOContext{}
-	ret := C.rados_ioctx_create(c.cluster, c_pool, &ioctx.ioctx)
+	ret := C.rados_ioctx_create(c.cluster, cPool, &ioctx.ioctx)
 	if ret == 0 {
 		return ioctx, nil
 	}
@@ -132,10 +132,10 @@ func (c *Conn) ListPools() (names []string, err error) {
 // SetConfigOption sets the value of the configuration option identified by
 // the given name.
 func (c *Conn) SetConfigOption(option, value string) error {
-	c_opt, c_val := C.CString(option), C.CString(value)
-	defer C.free(unsafe.Pointer(c_opt))
-	defer C.free(unsafe.Pointer(c_val))
-	ret := C.rados_conf_set(c.cluster, c_opt, c_val)
+	cOpt, cVal := C.CString(option), C.CString(value)
+	defer C.free(unsafe.Pointer(cOpt))
+	defer C.free(unsafe.Pointer(cVal))
+	ret := C.rados_conf_set(c.cluster, cOpt, cVal)
 	return getError(ret)
 }
 
@@ -171,7 +171,7 @@ func (c *Conn) WaitForLatestOSDMap() error {
 	return getError(ret)
 }
 
-func (c *Conn) ensure_connected() error {
+func (c *Conn) ensureConnected() error {
 	if c.connected {
 		return nil
 	}
@@ -181,19 +181,19 @@ func (c *Conn) ensure_connected() error {
 // GetClusterStats returns statistics about the cluster associated with the
 // connection.
 func (c *Conn) GetClusterStats() (stat ClusterStat, err error) {
-	if err := c.ensure_connected(); err != nil {
+	if err := c.ensureConnected(); err != nil {
 		return ClusterStat{}, err
 	}
-	c_stat := C.struct_rados_cluster_stat_t{}
-	ret := C.rados_cluster_stat(c.cluster, &c_stat)
+	cStat := C.struct_rados_cluster_stat_t{}
+	ret := C.rados_cluster_stat(c.cluster, &cStat)
 	if ret < 0 {
 		return ClusterStat{}, getError(ret)
 	}
 	return ClusterStat{
-		Kb:          uint64(c_stat.kb),
-		Kb_used:     uint64(c_stat.kb_used),
-		Kb_avail:    uint64(c_stat.kb_avail),
-		Num_objects: uint64(c_stat.num_objects),
+		Kb:          uint64(cStat.kb),
+		Kb_used:     uint64(cStat.kb_used),
+		Kb_avail:    uint64(cStat.kb_avail),
+		Num_objects: uint64(cStat.num_objects),
 	}, nil
 }
 
@@ -247,31 +247,31 @@ func (c *Conn) GetInstanceID() uint64 {
 
 // MakePool creates a new pool with default settings.
 func (c *Conn) MakePool(name string) error {
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
-	ret := C.rados_pool_create(c.cluster, c_name)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	ret := C.rados_pool_create(c.cluster, cName)
 	return getError(ret)
 }
 
 // DeletePool deletes a pool and all the data inside the pool.
 func (c *Conn) DeletePool(name string) error {
-	if err := c.ensure_connected(); err != nil {
+	if err := c.ensureConnected(); err != nil {
 		return err
 	}
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
-	ret := C.rados_pool_delete(c.cluster, c_name)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	ret := C.rados_pool_delete(c.cluster, cName)
 	return getError(ret)
 }
 
 // GetPoolByName returns the ID of the pool with a given name.
 func (c *Conn) GetPoolByName(name string) (int64, error) {
-	if err := c.ensure_connected(); err != nil {
+	if err := c.ensureConnected(); err != nil {
 		return 0, err
 	}
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
-	ret := int64(C.rados_pool_lookup(c.cluster, c_name))
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	ret := int64(C.rados_pool_lookup(c.cluster, cName))
 	if ret < 0 {
 		return 0, RadosError(ret)
 	}
@@ -281,11 +281,11 @@ func (c *Conn) GetPoolByName(name string) (int64, error) {
 // GetPoolByID returns the name of a pool by a given ID.
 func (c *Conn) GetPoolByID(id int64) (string, error) {
 	buf := make([]byte, 4096)
-	if err := c.ensure_connected(); err != nil {
+	if err := c.ensureConnected(); err != nil {
 		return "", err
 	}
-	c_id := C.int64_t(id)
-	ret := int(C.rados_pool_reverse_lookup(c.cluster, c_id, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf))))
+	cID := C.int64_t(id)
+	ret := int(C.rados_pool_reverse_lookup(c.cluster, cID, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf))))
 	if ret < 0 {
 		return "", RadosError(ret)
 	}

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -101,12 +101,12 @@ func (ioctx *IOContext) Pointer() unsafe.Pointer {
 // SetNamespace sets the namespace for objects within this IO context (pool).
 // Setting namespace to a empty or zero length string sets the pool to the default namespace.
 func (ioctx *IOContext) SetNamespace(namespace string) {
-	var c_ns *C.char
+	var cNs *C.char
 	if len(namespace) > 0 {
-		c_ns = C.CString(namespace)
-		defer C.free(unsafe.Pointer(c_ns))
+		cNs = C.CString(namespace)
+		defer C.free(unsafe.Pointer(cNs))
 	}
-	C.rados_ioctx_set_namespace(ioctx.ioctx, c_ns)
+	C.rados_ioctx_set_namespace(ioctx.ioctx, cNs)
 }
 
 // Create a new object with key oid.
@@ -115,12 +115,12 @@ func (ioctx *IOContext) SetNamespace(namespace string) {
 //  void rados_write_op_create(rados_write_op_t write_op, int exclusive,
 //                             const char* category)
 func (ioctx *IOContext) Create(oid string, exclusive CreateOption) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
 	op := C.rados_create_write_op()
 	C.rados_write_op_create(op, C.int(exclusive), nil)
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
+	ret := C.rados_write_op_operate(op, ioctx.ioctx, cOid, nil, 0)
 	C.rados_release_write_op(op)
 
 	return getError(ret)
@@ -129,15 +129,15 @@ func (ioctx *IOContext) Create(oid string, exclusive CreateOption) error {
 // Write writes len(data) bytes to the object with key oid starting at byte
 // offset offset. It returns an error, if any.
 func (ioctx *IOContext) Write(oid string, data []byte, offset uint64) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
 	dataPointer := unsafe.Pointer(nil)
 	if len(data) > 0 {
 		dataPointer = unsafe.Pointer(&data[0])
 	}
 
-	ret := C.rados_write(ioctx.ioctx, c_oid,
+	ret := C.rados_write(ioctx.ioctx, cOid,
 		(*C.char)(dataPointer),
 		(C.size_t)(len(data)),
 		(C.uint64_t)(offset))
@@ -149,10 +149,10 @@ func (ioctx *IOContext) Write(oid string, data []byte, offset uint64) error {
 // The object is filled with the provided data. If the object exists,
 // it is atomically truncated and then written. It returns an error, if any.
 func (ioctx *IOContext) WriteFull(oid string, data []byte) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
-	ret := C.rados_write_full(ioctx.ioctx, c_oid,
+	ret := C.rados_write_full(ioctx.ioctx, cOid,
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
 	return getError(ret)
@@ -162,10 +162,10 @@ func (ioctx *IOContext) WriteFull(oid string, data []byte) error {
 // The object is appended with the provided data. If the object exists,
 // it is atomically appended to. It returns an error, if any.
 func (ioctx *IOContext) Append(oid string, data []byte) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
-	ret := C.rados_append(ioctx.ioctx, c_oid,
+	ret := C.rados_append(ioctx.ioctx, cOid,
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
 	return getError(ret)
@@ -174,8 +174,8 @@ func (ioctx *IOContext) Append(oid string, data []byte) error {
 // Read reads up to len(data) bytes from the object with key oid starting at byte
 // offset offset. It returns the number of bytes read and an error, if any.
 func (ioctx *IOContext) Read(oid string, data []byte, offset uint64) (int, error) {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
 	var buf *C.char
 	if len(data) > 0 {
@@ -184,7 +184,7 @@ func (ioctx *IOContext) Read(oid string, data []byte, offset uint64) (int, error
 
 	ret := C.rados_read(
 		ioctx.ioctx,
-		c_oid,
+		cOid,
 		buf,
 		(C.size_t)(len(data)),
 		(C.uint64_t)(offset))
@@ -197,10 +197,10 @@ func (ioctx *IOContext) Read(oid string, data []byte, offset uint64) (int, error
 
 // Delete deletes the object with key oid. It returns an error, if any.
 func (ioctx *IOContext) Delete(oid string) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
-	return getError(C.rados_remove(ioctx.ioctx, c_oid))
+	return getError(C.rados_remove(ioctx.ioctx, cOid))
 }
 
 // Truncate resizes the object with key oid to size size. If the operation
@@ -208,10 +208,10 @@ func (ioctx *IOContext) Delete(oid string) error {
 // operation shrinks the object, the excess data is removed. It returns an
 // error, if any.
 func (ioctx *IOContext) Truncate(oid string, size uint64) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
-	return getError(C.rados_trunc(ioctx.ioctx, c_oid, (C.uint64_t)(size)))
+	return getError(C.rados_trunc(ioctx.ioctx, cOid, (C.uint64_t)(size)))
 }
 
 // Destroy informs librados that the I/O context is no longer in use.
@@ -228,24 +228,24 @@ func (ioctx *IOContext) Destroy() {
 //  int rados_ioctx_pool_stat(rados_ioctx_t io,
 //                            struct rados_pool_stat_t *stats);
 func (ioctx *IOContext) GetPoolStats() (stat PoolStat, err error) {
-	c_stat := C.struct_rados_pool_stat_t{}
-	ret := C.rados_ioctx_pool_stat(ioctx.ioctx, &c_stat)
+	cStat := C.struct_rados_pool_stat_t{}
+	ret := C.rados_ioctx_pool_stat(ioctx.ioctx, &cStat)
 	if ret < 0 {
 		return PoolStat{}, getError(ret)
 	}
 	return PoolStat{
-		Num_bytes:                      uint64(c_stat.num_bytes),
-		Num_kb:                         uint64(c_stat.num_kb),
-		Num_objects:                    uint64(c_stat.num_objects),
-		Num_object_clones:              uint64(c_stat.num_object_clones),
-		Num_object_copies:              uint64(c_stat.num_object_copies),
-		Num_objects_missing_on_primary: uint64(c_stat.num_objects_missing_on_primary),
-		Num_objects_unfound:            uint64(c_stat.num_objects_unfound),
-		Num_objects_degraded:           uint64(c_stat.num_objects_degraded),
-		Num_rd:                         uint64(c_stat.num_rd),
-		Num_rd_kb:                      uint64(c_stat.num_rd_kb),
-		Num_wr:                         uint64(c_stat.num_wr),
-		Num_wr_kb:                      uint64(c_stat.num_wr_kb),
+		Num_bytes:                      uint64(cStat.num_bytes),
+		Num_kb:                         uint64(cStat.num_kb),
+		Num_objects:                    uint64(cStat.num_objects),
+		Num_object_clones:              uint64(cStat.num_object_clones),
+		Num_object_copies:              uint64(cStat.num_object_copies),
+		Num_objects_missing_on_primary: uint64(cStat.num_objects_missing_on_primary),
+		Num_objects_unfound:            uint64(cStat.num_objects_unfound),
+		Num_objects_degraded:           uint64(cStat.num_objects_degraded),
+		Num_rd:                         uint64(cStat.num_rd),
+		Num_rd_kb:                      uint64(cStat.num_rd_kb),
+		Num_wr:                         uint64(cStat.num_wr),
+		Num_wr_kb:                      uint64(cStat.num_wr_kb),
 	}, nil
 }
 
@@ -289,51 +289,51 @@ func (ioctx *IOContext) ListObjects(listFn ObjectListFunc) error {
 	defer func() { C.rados_nobjects_list_close(ctx) }()
 
 	for {
-		var c_entry *C.char
-		ret := C.rados_nobjects_list_next(ctx, &c_entry, nil, nil)
+		var cEntry *C.char
+		ret := C.rados_nobjects_list_next(ctx, &cEntry, nil, nil)
 		if ret == -C.ENOENT {
 			return nil
 		} else if ret < 0 {
 			return getError(ret)
 		}
-		listFn(C.GoString(c_entry))
+		listFn(C.GoString(cEntry))
 	}
 }
 
 // Stat returns the size of the object and its last modification time
 func (ioctx *IOContext) Stat(object string) (stat ObjectStat, err error) {
-	var c_psize C.uint64_t
-	var c_pmtime C.time_t
-	c_object := C.CString(object)
-	defer C.free(unsafe.Pointer(c_object))
+	var cPsize C.uint64_t
+	var cPmtime C.time_t
+	cObject := C.CString(object)
+	defer C.free(unsafe.Pointer(cObject))
 
 	ret := C.rados_stat(
 		ioctx.ioctx,
-		c_object,
-		&c_psize,
-		&c_pmtime)
+		cObject,
+		&cPsize,
+		&cPmtime)
 
 	if ret < 0 {
 		return ObjectStat{}, getError(ret)
 	}
 	return ObjectStat{
-		Size:    uint64(c_psize),
-		ModTime: time.Unix(int64(c_pmtime), 0),
+		Size:    uint64(cPsize),
+		ModTime: time.Unix(int64(cPmtime), 0),
 	}, nil
 }
 
 // GetXattr gets an xattr with key `name`, it returns the length of
 // the key read or an error if not successful
 func (ioctx *IOContext) GetXattr(object string, name string, data []byte) (int, error) {
-	c_object := C.CString(object)
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_object))
-	defer C.free(unsafe.Pointer(c_name))
+	cObject := C.CString(object)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cObject))
+	defer C.free(unsafe.Pointer(cName))
 
 	ret := C.rados_getxattr(
 		ioctx.ioctx,
-		c_object,
-		c_name,
+		cObject,
+		cName,
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
 
@@ -345,15 +345,15 @@ func (ioctx *IOContext) GetXattr(object string, name string, data []byte) (int, 
 
 // SetXattr sets an xattr for an object with key `name` with value as `data`
 func (ioctx *IOContext) SetXattr(object string, name string, data []byte) error {
-	c_object := C.CString(object)
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_object))
-	defer C.free(unsafe.Pointer(c_name))
+	cObject := C.CString(object)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cObject))
+	defer C.free(unsafe.Pointer(cName))
 
 	ret := C.rados_setxattr(
 		ioctx.ioctx,
-		c_object,
-		c_name,
+		cObject,
+		cName,
 		(*C.char)(unsafe.Pointer(&data[0])),
 		(C.size_t)(len(data)))
 
@@ -363,82 +363,82 @@ func (ioctx *IOContext) SetXattr(object string, name string, data []byte) error 
 // ListXattrs lists all the xattrs for an object. The xattrs are returned as a
 // mapping of string keys and byte-slice values.
 func (ioctx *IOContext) ListXattrs(oid string) (map[string][]byte, error) {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
 	var it C.rados_xattrs_iter_t
 
-	ret := C.rados_getxattrs(ioctx.ioctx, c_oid, &it)
+	ret := C.rados_getxattrs(ioctx.ioctx, cOid, &it)
 	if ret < 0 {
 		return nil, getError(ret)
 	}
 	defer func() { C.rados_getxattrs_end(it) }()
 	m := make(map[string][]byte)
 	for {
-		var c_name, c_val *C.char
-		var c_len C.size_t
-		defer C.free(unsafe.Pointer(c_name))
-		defer C.free(unsafe.Pointer(c_val))
+		var cName, cVal *C.char
+		var cLen C.size_t
+		defer C.free(unsafe.Pointer(cName))
+		defer C.free(unsafe.Pointer(cVal))
 
-		ret := C.rados_getxattrs_next(it, &c_name, &c_val, &c_len)
+		ret := C.rados_getxattrs_next(it, &cName, &cVal, &cLen)
 		if ret < 0 {
 			return nil, getError(ret)
 		}
 		// rados api returns a null name,val & 0-length upon
 		// end of iteration
-		if c_name == nil {
+		if cName == nil {
 			return m, nil // stop iteration
 		}
-		m[C.GoString(c_name)] = C.GoBytes(unsafe.Pointer(c_val), (C.int)(c_len))
+		m[C.GoString(cName)] = C.GoBytes(unsafe.Pointer(cVal), (C.int)(cLen))
 	}
 }
 
 // RmXattr removes an xattr with key `name` from object `oid`
 func (ioctx *IOContext) RmXattr(oid string, name string) error {
-	c_oid := C.CString(oid)
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_oid))
-	defer C.free(unsafe.Pointer(c_name))
+	cOid := C.CString(oid)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cOid))
+	defer C.free(unsafe.Pointer(cName))
 
 	ret := C.rados_rmxattr(
 		ioctx.ioctx,
-		c_oid,
-		c_name)
+		cOid,
+		cName)
 
 	return getError(ret)
 }
 
 // LockExclusive takes an exclusive lock on an object.
 func (ioctx *IOContext) LockExclusive(oid, name, cookie, desc string, duration time.Duration, flags *byte) (int, error) {
-	c_oid := C.CString(oid)
-	c_name := C.CString(name)
-	c_cookie := C.CString(cookie)
-	c_desc := C.CString(desc)
+	cOid := C.CString(oid)
+	cName := C.CString(name)
+	cCookie := C.CString(cookie)
+	cDesc := C.CString(desc)
 
-	var c_duration C.struct_timeval
+	var cDuration C.struct_timeval
 	if duration != 0 {
 		tv := syscall.NsecToTimeval(duration.Nanoseconds())
-		c_duration = C.struct_timeval{tv_sec: C.ceph_time_t(tv.Sec), tv_usec: C.ceph_suseconds_t(tv.Usec)}
+		cDuration = C.struct_timeval{tv_sec: C.ceph_time_t(tv.Sec), tv_usec: C.ceph_suseconds_t(tv.Usec)}
 	}
 
-	var c_flags C.uint8_t
+	var cFlags C.uint8_t
 	if flags != nil {
-		c_flags = C.uint8_t(*flags)
+		cFlags = C.uint8_t(*flags)
 	}
 
-	defer C.free(unsafe.Pointer(c_oid))
-	defer C.free(unsafe.Pointer(c_name))
-	defer C.free(unsafe.Pointer(c_cookie))
-	defer C.free(unsafe.Pointer(c_desc))
+	defer C.free(unsafe.Pointer(cOid))
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cCookie))
+	defer C.free(unsafe.Pointer(cDesc))
 
 	ret := C.rados_lock_exclusive(
 		ioctx.ioctx,
-		c_oid,
-		c_name,
-		c_cookie,
-		c_desc,
-		&c_duration,
-		c_flags)
+		cOid,
+		cName,
+		cCookie,
+		cDesc,
+		&cDuration,
+		cFlags)
 
 	// 0 on success, negative error code on failure
 	// -EBUSY if the lock is already held by another (client, cookie) pair
@@ -458,38 +458,38 @@ func (ioctx *IOContext) LockExclusive(oid, name, cookie, desc string, duration t
 
 // LockShared takes a shared lock on an object.
 func (ioctx *IOContext) LockShared(oid, name, cookie, tag, desc string, duration time.Duration, flags *byte) (int, error) {
-	c_oid := C.CString(oid)
-	c_name := C.CString(name)
-	c_cookie := C.CString(cookie)
-	c_tag := C.CString(tag)
-	c_desc := C.CString(desc)
+	cOid := C.CString(oid)
+	cName := C.CString(name)
+	cCookie := C.CString(cookie)
+	cTag := C.CString(tag)
+	cDesc := C.CString(desc)
 
-	var c_duration C.struct_timeval
+	var cDuration C.struct_timeval
 	if duration != 0 {
 		tv := syscall.NsecToTimeval(duration.Nanoseconds())
-		c_duration = C.struct_timeval{tv_sec: C.ceph_time_t(tv.Sec), tv_usec: C.ceph_suseconds_t(tv.Usec)}
+		cDuration = C.struct_timeval{tv_sec: C.ceph_time_t(tv.Sec), tv_usec: C.ceph_suseconds_t(tv.Usec)}
 	}
 
-	var c_flags C.uint8_t
+	var cFlags C.uint8_t
 	if flags != nil {
-		c_flags = C.uint8_t(*flags)
+		cFlags = C.uint8_t(*flags)
 	}
 
-	defer C.free(unsafe.Pointer(c_oid))
-	defer C.free(unsafe.Pointer(c_name))
-	defer C.free(unsafe.Pointer(c_cookie))
-	defer C.free(unsafe.Pointer(c_tag))
-	defer C.free(unsafe.Pointer(c_desc))
+	defer C.free(unsafe.Pointer(cOid))
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cCookie))
+	defer C.free(unsafe.Pointer(cTag))
+	defer C.free(unsafe.Pointer(cDesc))
 
 	ret := C.rados_lock_shared(
 		ioctx.ioctx,
-		c_oid,
-		c_name,
-		c_cookie,
-		c_tag,
-		c_desc,
-		&c_duration,
-		c_flags)
+		cOid,
+		cName,
+		cCookie,
+		cTag,
+		cDesc,
+		&cDuration,
+		cFlags)
 
 	// 0 on success, negative error code on failure
 	// -EBUSY if the lock is already held by another (client, cookie) pair
@@ -509,22 +509,22 @@ func (ioctx *IOContext) LockShared(oid, name, cookie, tag, desc string, duration
 
 // Unlock releases a shared or exclusive lock on an object.
 func (ioctx *IOContext) Unlock(oid, name, cookie string) (int, error) {
-	c_oid := C.CString(oid)
-	c_name := C.CString(name)
-	c_cookie := C.CString(cookie)
+	cOid := C.CString(oid)
+	cName := C.CString(name)
+	cCookie := C.CString(cookie)
 
-	defer C.free(unsafe.Pointer(c_oid))
-	defer C.free(unsafe.Pointer(c_name))
-	defer C.free(unsafe.Pointer(c_cookie))
+	defer C.free(unsafe.Pointer(cOid))
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cCookie))
 
 	// 0 on success, negative error code on failure
 	// -ENOENT if the lock is not held by the specified (client, cookie) pair
 
 	ret := C.rados_unlock(
 		ioctx.ioctx,
-		c_oid,
-		c_name,
-		c_cookie)
+		cOid,
+		cName,
+		cCookie)
 
 	switch ret {
 	case 0:
@@ -542,40 +542,40 @@ func (ioctx *IOContext) Unlock(oid, name, cookie string) (int, error) {
 // out parameter.  If any of the provided buffers are too short, -ERANGE is
 // returned after these sizes are filled in.
 func (ioctx *IOContext) ListLockers(oid, name string) (*LockInfo, error) {
-	c_oid := C.CString(oid)
-	c_name := C.CString(name)
+	cOid := C.CString(oid)
+	cName := C.CString(name)
 
-	c_tag := (*C.char)(C.malloc(C.size_t(1024)))
-	c_clients := (*C.char)(C.malloc(C.size_t(1024)))
-	c_cookies := (*C.char)(C.malloc(C.size_t(1024)))
-	c_addrs := (*C.char)(C.malloc(C.size_t(1024)))
+	cTag := (*C.char)(C.malloc(C.size_t(1024)))
+	cClients := (*C.char)(C.malloc(C.size_t(1024)))
+	cCookies := (*C.char)(C.malloc(C.size_t(1024)))
+	cAddrs := (*C.char)(C.malloc(C.size_t(1024)))
 
-	var c_exclusive C.int
-	c_tag_len := C.size_t(1024)
-	c_clients_len := C.size_t(1024)
-	c_cookies_len := C.size_t(1024)
-	c_addrs_len := C.size_t(1024)
+	var cExclusive C.int
+	cTag_len := C.size_t(1024)
+	cClients_len := C.size_t(1024)
+	cCookies_len := C.size_t(1024)
+	cAddrs_len := C.size_t(1024)
 
-	defer C.free(unsafe.Pointer(c_oid))
-	defer C.free(unsafe.Pointer(c_name))
-	defer C.free(unsafe.Pointer(c_tag))
-	defer C.free(unsafe.Pointer(c_clients))
-	defer C.free(unsafe.Pointer(c_cookies))
-	defer C.free(unsafe.Pointer(c_addrs))
+	defer C.free(unsafe.Pointer(cOid))
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cTag))
+	defer C.free(unsafe.Pointer(cClients))
+	defer C.free(unsafe.Pointer(cCookies))
+	defer C.free(unsafe.Pointer(cAddrs))
 
 	ret := C.rados_list_lockers(
 		ioctx.ioctx,
-		c_oid,
-		c_name,
-		&c_exclusive,
-		c_tag,
-		&c_tag_len,
-		c_clients,
-		&c_clients_len,
-		c_cookies,
-		&c_cookies_len,
-		c_addrs,
-		&c_addrs_len)
+		cOid,
+		cName,
+		&cExclusive,
+		cTag,
+		&cTag_len,
+		cClients,
+		&cClients_len,
+		cCookies,
+		&cCookies_len,
+		cAddrs,
+		&cAddrs_len)
 
 	splitCString := func(items *C.char, itemsLen C.size_t) []string {
 		currLen := 0
@@ -591,20 +591,20 @@ func (ioctx *IOContext) ListLockers(oid, name string) (*LockInfo, error) {
 	if ret < 0 {
 		return nil, RadosError(ret)
 	}
-	return &LockInfo{int(ret), c_exclusive == 1, C.GoString(c_tag), splitCString(c_clients, c_clients_len), splitCString(c_cookies, c_cookies_len), splitCString(c_addrs, c_addrs_len)}, nil
+	return &LockInfo{int(ret), cExclusive == 1, C.GoString(cTag), splitCString(cClients, cClients_len), splitCString(cCookies, cCookies_len), splitCString(cAddrs, cAddrs_len)}, nil
 }
 
 // BreakLock releases a shared or exclusive lock on an object, which was taken by the specified client.
 func (ioctx *IOContext) BreakLock(oid, name, client, cookie string) (int, error) {
-	c_oid := C.CString(oid)
-	c_name := C.CString(name)
-	c_client := C.CString(client)
-	c_cookie := C.CString(cookie)
+	cOid := C.CString(oid)
+	cName := C.CString(name)
+	cClient := C.CString(client)
+	cCookie := C.CString(cookie)
 
-	defer C.free(unsafe.Pointer(c_oid))
-	defer C.free(unsafe.Pointer(c_name))
-	defer C.free(unsafe.Pointer(c_client))
-	defer C.free(unsafe.Pointer(c_cookie))
+	defer C.free(unsafe.Pointer(cOid))
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cClient))
+	defer C.free(unsafe.Pointer(cCookie))
 
 	// 0 on success, negative error code on failure
 	// -ENOENT if the lock is not held by the specified (client, cookie) pair
@@ -612,10 +612,10 @@ func (ioctx *IOContext) BreakLock(oid, name, client, cookie string) (int, error)
 
 	ret := C.rados_break_lock(
 		ioctx.ioctx,
-		c_oid,
-		c_name,
-		c_client,
-		c_cookie)
+		cOid,
+		cName,
+		cClient,
+		cCookie)
 
 	switch ret {
 	case 0:

--- a/rados/object_iter.go
+++ b/rados/object_iter.go
@@ -50,14 +50,14 @@ func (iter *Iter) Seek(token IterToken) {
 //	return iter.Err()
 //
 func (iter *Iter) Next() bool {
-	var c_entry *C.char
-	var c_namespace *C.char
-	if cerr := C.rados_nobjects_list_next(iter.ctx, &c_entry, nil, &c_namespace); cerr < 0 {
+	var cEntry *C.char
+	var cNamespace *C.char
+	if cerr := C.rados_nobjects_list_next(iter.ctx, &cEntry, nil, &cNamespace); cerr < 0 {
 		iter.err = getError(cerr)
 		return false
 	}
-	iter.entry = C.GoString(c_entry)
-	iter.namespace = C.GoString(c_namespace)
+	iter.entry = C.GoString(cEntry)
+	iter.namespace = C.GoString(cNamespace)
 	return true
 }
 

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -12,42 +12,42 @@ import (
 
 // SetOmap appends the map `pairs` to the omap `oid`
 func (ioctx *IOContext) SetOmap(oid string, pairs map[string][]byte) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
 	var s C.size_t
 	var c *C.char
 	ptrSize := unsafe.Sizeof(c)
 
-	c_keys := C.malloc(C.size_t(len(pairs)) * C.size_t(ptrSize))
-	c_values := C.malloc(C.size_t(len(pairs)) * C.size_t(ptrSize))
-	c_lengths := C.malloc(C.size_t(len(pairs)) * C.size_t(unsafe.Sizeof(s)))
+	cKeys := C.malloc(C.size_t(len(pairs)) * C.size_t(ptrSize))
+	cValues := C.malloc(C.size_t(len(pairs)) * C.size_t(ptrSize))
+	cLengths := C.malloc(C.size_t(len(pairs)) * C.size_t(unsafe.Sizeof(s)))
 
-	defer C.free(unsafe.Pointer(c_keys))
-	defer C.free(unsafe.Pointer(c_values))
-	defer C.free(unsafe.Pointer(c_lengths))
+	defer C.free(unsafe.Pointer(cKeys))
+	defer C.free(unsafe.Pointer(cValues))
+	defer C.free(unsafe.Pointer(cLengths))
 
 	i := 0
 	for key, value := range pairs {
 		// key
-		c_key_ptr := (**C.char)(unsafe.Pointer(uintptr(c_keys) + uintptr(i)*ptrSize))
-		*c_key_ptr = C.CString(key)
-		defer C.free(unsafe.Pointer(*c_key_ptr))
+		cKeyPtr := (**C.char)(unsafe.Pointer(uintptr(cKeys) + uintptr(i)*ptrSize))
+		*cKeyPtr = C.CString(key)
+		defer C.free(unsafe.Pointer(*cKeyPtr))
 
 		// value and its length
-		c_value_ptr := (**C.char)(unsafe.Pointer(uintptr(c_values) + uintptr(i)*ptrSize))
+		cValuePtr := (**C.char)(unsafe.Pointer(uintptr(cValues) + uintptr(i)*ptrSize))
 
-		var c_length C.size_t
+		var cLength C.size_t
 		if len(value) > 0 {
-			*c_value_ptr = (*C.char)(unsafe.Pointer(&value[0]))
-			c_length = C.size_t(len(value))
+			*cValuePtr = (*C.char)(unsafe.Pointer(&value[0]))
+			cLength = C.size_t(len(value))
 		} else {
-			*c_value_ptr = nil
-			c_length = C.size_t(0)
+			*cValuePtr = nil
+			cLength = C.size_t(0)
 		}
 
-		c_length_ptr := (*C.size_t)(unsafe.Pointer(uintptr(c_lengths) + uintptr(i)*ptrSize))
-		*c_length_ptr = c_length
+		cLengthPtr := (*C.size_t)(unsafe.Pointer(uintptr(cLengths) + uintptr(i)*ptrSize))
+		*cLengthPtr = cLength
 
 		i++
 	}
@@ -55,12 +55,12 @@ func (ioctx *IOContext) SetOmap(oid string, pairs map[string][]byte) error {
 	op := C.rados_create_write_op()
 	C.rados_write_op_omap_set(
 		op,
-		(**C.char)(c_keys),
-		(**C.char)(c_values),
-		(*C.size_t)(c_lengths),
+		(**C.char)(cKeys),
+		(**C.char)(cValues),
+		(*C.size_t)(cLengths),
 		C.size_t(len(pairs)))
 
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
+	ret := C.rados_write_op_operate(op, ioctx.ioctx, cOid, nil, 0)
 	C.rados_release_write_op(op)
 
 	return getError(ret)
@@ -78,56 +78,56 @@ type OmapListFunc func(key string, value []byte)
 // `maxReturn`: iterate no more than `maxReturn` key/value pairs
 // `listFn`: the function called at each iteration
 func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPrefix string, maxReturn int64, listFn OmapListFunc) error {
-	c_oid := C.CString(oid)
-	c_start_after := C.CString(startAfter)
-	c_filter_prefix := C.CString(filterPrefix)
-	c_max_return := C.uint64_t(maxReturn)
+	cOid := C.CString(oid)
+	cStartAfter := C.CString(startAfter)
+	cFilterPrefix := C.CString(filterPrefix)
+	cMaxReturn := C.uint64_t(maxReturn)
 
-	defer C.free(unsafe.Pointer(c_oid))
-	defer C.free(unsafe.Pointer(c_start_after))
-	defer C.free(unsafe.Pointer(c_filter_prefix))
+	defer C.free(unsafe.Pointer(cOid))
+	defer C.free(unsafe.Pointer(cStartAfter))
+	defer C.free(unsafe.Pointer(cFilterPrefix))
 
 	op := C.rados_create_read_op()
 
-	var c_iter C.rados_omap_iter_t
-	var c_prval C.int
+	var cIter C.rados_omap_iter_t
+	var cPrval C.int
 	C.rados_read_op_omap_get_vals2(
 		op,
-		c_start_after,
-		c_filter_prefix,
-		c_max_return,
-		&c_iter,
+		cStartAfter,
+		cFilterPrefix,
+		cMaxReturn,
+		&cIter,
 		nil,
-		&c_prval,
+		&cPrval,
 	)
 
-	ret := C.rados_read_op_operate(op, ioctx.ioctx, c_oid, 0)
+	ret := C.rados_read_op_operate(op, ioctx.ioctx, cOid, 0)
 
 	if int(ret) != 0 {
 		return getError(ret)
-	} else if int(c_prval) != 0 {
-		return getError(c_prval)
+	} else if int(cPrval) != 0 {
+		return getError(cPrval)
 	}
 
 	for {
-		var c_key *C.char
-		var c_val *C.char
-		var c_len C.size_t
+		var cKey *C.char
+		var cVal *C.char
+		var cLen C.size_t
 
-		ret = C.rados_omap_get_next(c_iter, &c_key, &c_val, &c_len)
+		ret = C.rados_omap_get_next(cIter, &cKey, &cVal, &cLen)
 
 		if int(ret) != 0 {
 			return getError(ret)
 		}
 
-		if c_key == nil {
+		if cKey == nil {
 			break
 		}
 
-		listFn(C.GoString(c_key), C.GoBytes(unsafe.Pointer(c_val), C.int(c_len)))
+		listFn(C.GoString(cKey), C.GoBytes(unsafe.Pointer(cVal), C.int(cLen)))
 	}
 
-	C.rados_omap_get_end(c_iter)
+	C.rados_omap_get_end(cIter)
 	C.rados_release_read_op(op)
 
 	return nil
@@ -184,30 +184,30 @@ func (ioctx *IOContext) GetAllOmapValues(oid string, startAfter string, filterPr
 
 // RmOmapKeys removes the specified `keys` from the omap `oid`
 func (ioctx *IOContext) RmOmapKeys(oid string, keys []string) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
 	var c *C.char
 	ptrSize := unsafe.Sizeof(c)
 
-	c_keys := C.malloc(C.size_t(len(keys)) * C.size_t(ptrSize))
-	defer C.free(unsafe.Pointer(c_keys))
+	cKeys := C.malloc(C.size_t(len(keys)) * C.size_t(ptrSize))
+	defer C.free(unsafe.Pointer(cKeys))
 
 	i := 0
 	for _, key := range keys {
-		c_key_ptr := (**C.char)(unsafe.Pointer(uintptr(c_keys) + uintptr(i)*ptrSize))
-		*c_key_ptr = C.CString(key)
-		defer C.free(unsafe.Pointer(*c_key_ptr))
+		cKeyPtr := (**C.char)(unsafe.Pointer(uintptr(cKeys) + uintptr(i)*ptrSize))
+		*cKeyPtr = C.CString(key)
+		defer C.free(unsafe.Pointer(*cKeyPtr))
 		i++
 	}
 
 	op := C.rados_create_write_op()
 	C.rados_write_op_omap_rm_keys(
 		op,
-		(**C.char)(c_keys),
+		(**C.char)(cKeys),
 		C.size_t(len(keys)))
 
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
+	ret := C.rados_write_op_operate(op, ioctx.ioctx, cOid, nil, 0)
 	C.rados_release_write_op(op)
 
 	return getError(ret)
@@ -215,13 +215,13 @@ func (ioctx *IOContext) RmOmapKeys(oid string, keys []string) error {
 
 // CleanOmap clears the omap `oid`
 func (ioctx *IOContext) CleanOmap(oid string) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
 
 	op := C.rados_create_write_op()
 	C.rados_write_op_omap_clear(op)
 
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
+	ret := C.rados_write_op_operate(op, ioctx.ioctx, cOid, nil, 0)
 	C.rados_release_write_op(op)
 
 	return getError(ret)

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -28,9 +28,9 @@ const (
 // Version returns the major, minor, and patch components of the version of
 // the RADOS library linked against.
 func Version() (int, int, int) {
-	var c_major, c_minor, c_patch C.int
-	C.rados_version(&c_major, &c_minor, &c_patch)
-	return int(c_major), int(c_minor), int(c_patch)
+	var cMajor, cMinor, cPatch C.int
+	C.rados_version(&cMajor, &cMinor, &cPatch)
+	return int(cMajor), int(cMinor), int(cPatch)
 }
 
 func makeConn() *Conn {
@@ -58,22 +58,22 @@ func NewConn() (*Conn, error) {
 // NewConnWithUser creates a new connection object with a custom username.
 // It returns the connection and an error, if any.
 func NewConnWithUser(user string) (*Conn, error) {
-	c_user := C.CString(user)
-	defer C.free(unsafe.Pointer(c_user))
-	return newConn(c_user)
+	cUser := C.CString(user)
+	defer C.free(unsafe.Pointer(cUser))
+	return newConn(cUser)
 }
 
 // NewConnWithClusterAndUser creates a new connection object for a specific cluster and username.
 // It returns the connection and an error, if any.
 func NewConnWithClusterAndUser(clusterName string, userName string) (*Conn, error) {
-	c_cluster_name := C.CString(clusterName)
-	defer C.free(unsafe.Pointer(c_cluster_name))
+	cClusterName := C.CString(clusterName)
+	defer C.free(unsafe.Pointer(cClusterName))
 
-	c_name := C.CString(userName)
-	defer C.free(unsafe.Pointer(c_name))
+	cName := C.CString(userName)
+	defer C.free(unsafe.Pointer(cName))
 
 	conn := makeConn()
-	ret := C.rados_create2(&conn.cluster, c_cluster_name, c_name, 0)
+	ret := C.rados_create2(&conn.cluster, cClusterName, cName, 0)
 	if ret != 0 {
 		return nil, getError(ret)
 	}

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -138,21 +138,21 @@ func (suite *RadosTestSuite) TestGetSetConfigOption() {
 	assert.Error(suite.T(), err)
 
 	// verify SetConfigOption changes a values
-	prev_val, err := suite.conn.GetConfigOption("log_file")
+	prevVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
 	err = suite.conn.SetConfigOption("log_file", "/dev/null")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	curr_val, err := suite.conn.GetConfigOption("log_file")
+	currVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	assert.NotEqual(suite.T(), prev_val, "/dev/null")
-	assert.Equal(suite.T(), curr_val, "/dev/null")
+	assert.NotEqual(suite.T(), prevVal, "/dev/null")
+	assert.Equal(suite.T(), currVal, "/dev/null")
 }
 
 func (suite *RadosTestSuite) TestParseDefaultConfigEnv() {
-	prev_val, err := suite.conn.GetConfigOption("log_file")
+	prevVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
 	err = os.Setenv("CEPH_ARGS", "--log-file /dev/null")
@@ -161,34 +161,34 @@ func (suite *RadosTestSuite) TestParseDefaultConfigEnv() {
 	err = suite.conn.ParseDefaultConfigEnv()
 	assert.NoError(suite.T(), err)
 
-	curr_val, err := suite.conn.GetConfigOption("log_file")
+	currVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	assert.NotEqual(suite.T(), prev_val, "/dev/null")
-	assert.Equal(suite.T(), curr_val, "/dev/null")
+	assert.NotEqual(suite.T(), prevVal, "/dev/null")
+	assert.Equal(suite.T(), currVal, "/dev/null")
 }
 
 func (suite *RadosTestSuite) TestParseCmdLineArgs() {
-	prev_val, err := suite.conn.GetConfigOption("log_file")
+	prevVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
 	args := []string{"--log_file", "/dev/null"}
 	err = suite.conn.ParseCmdLineArgs(args)
 	assert.NoError(suite.T(), err)
 
-	curr_val, err := suite.conn.GetConfigOption("log_file")
+	currVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	assert.NotEqual(suite.T(), prev_val, "/dev/null")
-	assert.Equal(suite.T(), curr_val, "/dev/null")
+	assert.NotEqual(suite.T(), prevVal, "/dev/null")
+	assert.Equal(suite.T(), currVal, "/dev/null")
 }
 
 func (suite *RadosTestSuite) TestReadConfigFile() {
 	// check current log_file value
-	prev_str, err := suite.conn.GetConfigOption("log_max_new")
+	prevStr, err := suite.conn.GetConfigOption("log_max_new")
 	assert.NoError(suite.T(), err)
 
-	prev_val, err := strconv.Atoi(prev_str)
+	prevVal, err := strconv.Atoi(prevStr)
 	assert.NoError(suite.T(), err)
 
 	// create conf file that changes log_file conf option
@@ -199,8 +199,8 @@ func (suite *RadosTestSuite) TestReadConfigFile() {
 		assert.NoError(suite.T(), os.Remove(file.Name()))
 	}()
 
-	next_val := prev_val + 1
-	conf := fmt.Sprintf("[global]\nlog_max_new = %d\n", next_val)
+	nextVal := prevVal + 1
+	conf := fmt.Sprintf("[global]\nlog_max_new = %d\n", nextVal)
 	_, err = io.WriteString(file, conf)
 	assert.NoError(suite.T(), err)
 
@@ -209,22 +209,22 @@ func (suite *RadosTestSuite) TestReadConfigFile() {
 	assert.NoError(suite.T(), err)
 
 	// check current log_file value
-	curr_str, err := suite.conn.GetConfigOption("log_max_new")
+	currStr, err := suite.conn.GetConfigOption("log_max_new")
 	assert.NoError(suite.T(), err)
 
-	curr_val, err := strconv.Atoi(curr_str)
+	currVal, err := strconv.Atoi(currStr)
 	assert.NoError(suite.T(), err)
 
-	assert.NotEqual(suite.T(), prev_str, curr_str)
-	assert.Equal(suite.T(), curr_val, prev_val+1)
+	assert.NotEqual(suite.T(), prevStr, currStr)
+	assert.Equal(suite.T(), currVal, prevVal+1)
 }
 
 func (suite *RadosTestSuite) TestGetClusterStats() {
 	suite.SetupConnection()
 
 	// grab current stats
-	prev_stat, err := suite.conn.GetClusterStats()
-	fmt.Printf("prev_stat: %+v\n", prev_stat)
+	prevStat, err := suite.conn.GetClusterStats()
+	fmt.Printf("prevStat: %+v\n", prevStat)
 	assert.NoError(suite.T(), err)
 
 	// make some changes to the cluster
@@ -241,12 +241,12 @@ func (suite *RadosTestSuite) TestGetClusterStats() {
 		assert.NoError(suite.T(), err)
 
 		// wait for something to change
-		if stat == prev_stat {
-			fmt.Printf("curr_stat: %+v (trying again...)\n", stat)
+		if stat == prevStat {
+			fmt.Printf("currStat: %+v (trying again...)\n", stat)
 			time.Sleep(time.Second)
 		} else {
 			// success
-			fmt.Printf("curr_stat: %+v (change detected)\n", stat)
+			fmt.Printf("currStat: %+v (change detected)\n", stat)
 			return
 		}
 	}
@@ -265,19 +265,19 @@ func (suite *RadosTestSuite) TestMakeDeletePool() {
 	suite.SetupConnection()
 
 	// check that new pool name is unique
-	new_name := uuid.Must(uuid.NewV4()).String()
-	_, err := suite.conn.GetPoolByName(new_name)
+	newName := uuid.Must(uuid.NewV4()).String()
+	_, err := suite.conn.GetPoolByName(newName)
 	if err == nil {
 		suite.T().Error("Random pool name exists!")
 		return
 	}
 
 	// create pool
-	err = suite.conn.MakePool(new_name)
+	err = suite.conn.MakePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that the new pool name exists
-	pool, err := suite.conn.GetPoolByName(new_name)
+	pool, err := suite.conn.GetPoolByName(newName)
 	assert.NoError(suite.T(), err)
 
 	if pool == 0 {
@@ -285,11 +285,11 @@ func (suite *RadosTestSuite) TestMakeDeletePool() {
 	}
 
 	// delete the pool
-	err = suite.conn.DeletePool(new_name)
+	err = suite.conn.DeletePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that it is gone
-	pool, _ = suite.conn.GetPoolByName(new_name)
+	pool, _ = suite.conn.GetPoolByName(newName)
 	if pool != 0 {
 		suite.T().Error("Deleted pool still exists")
 	}
@@ -303,38 +303,38 @@ func (suite *RadosTestSuite) TestGetPoolByName() {
 	assert.NoError(suite.T(), err)
 
 	// check that new pool name is unique
-	new_name := uuid.Must(uuid.NewV4()).String()
+	newName := uuid.Must(uuid.NewV4()).String()
 	require.NotContains(
-		suite.T(), pools, new_name, "Random pool name exists!")
+		suite.T(), pools, newName, "Random pool name exists!")
 
-	pool, _ := suite.conn.GetPoolByName(new_name)
+	pool, _ := suite.conn.GetPoolByName(newName)
 	assert.Equal(suite.T(), int64(0), pool, "Pool does not exist, but was found!")
 
 	// create pool
-	err = suite.conn.MakePool(new_name)
+	err = suite.conn.MakePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that the new pool name exists
 	pools, err = suite.conn.ListPools()
 	assert.NoError(suite.T(), err)
 	assert.Contains(
-		suite.T(), pools, new_name, "Cannot find newly created pool")
+		suite.T(), pools, newName, "Cannot find newly created pool")
 
-	pool, err = suite.conn.GetPoolByName(new_name)
+	pool, err = suite.conn.GetPoolByName(newName)
 	assert.NoError(suite.T(), err)
 	assert.NotEqual(suite.T(), int64(0), pool, "Pool not found!")
 
 	// delete the pool
-	err = suite.conn.DeletePool(new_name)
+	err = suite.conn.DeletePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that it is gone
 	pools, err = suite.conn.ListPools()
 	assert.NoError(suite.T(), err)
 	assert.NotContains(
-		suite.T(), pools, new_name, "Deleted pool still exists")
+		suite.T(), pools, newName, "Deleted pool still exists")
 
-	pool, err = suite.conn.GetPoolByName(new_name)
+	pool, err = suite.conn.GetPoolByName(newName)
 	assert.Error(suite.T(), err)
 	assert.Equal(
 		suite.T(), int64(0), pool, "Pool should have been deleted, but was found!")
@@ -344,19 +344,19 @@ func (suite *RadosTestSuite) TestGetPoolByID() {
 	suite.SetupConnection()
 
 	// check that new pool name is unique
-	new_name := uuid.Must(uuid.NewV4()).String()
-	pool, err := suite.conn.GetPoolByName(new_name)
+	newName := uuid.Must(uuid.NewV4()).String()
+	pool, err := suite.conn.GetPoolByName(newName)
 	if pool != 0 || err == nil {
 		suite.T().Error("Random pool name exists!")
 		return
 	}
 
 	// create pool
-	err = suite.conn.MakePool(new_name)
+	err = suite.conn.MakePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that the new pool name exists
-	id, err := suite.conn.GetPoolByName(new_name)
+	id, err := suite.conn.GetPoolByName(newName)
 	assert.NoError(suite.T(), err)
 
 	if id == 0 {
@@ -372,7 +372,7 @@ func (suite *RadosTestSuite) TestGetPoolByID() {
 	}
 
 	// delete the pool
-	err = suite.conn.DeletePool(new_name)
+	err = suite.conn.DeletePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that it is gone
@@ -425,7 +425,7 @@ func (suite *RadosTestSuite) TestGetLargePoolList() {
 		err = suite.conn.MakePool(name)
 		require.NoError(suite.T(), err)
 	}
-	pools, err = suite.conn.ListPools()
+	pools, _ = suite.conn.ListPools()
 	for _, name := range names {
 		assert.Contains(suite.T(), pools, name)
 	}
@@ -469,25 +469,27 @@ func (suite *RadosTestSuite) TestCreate() {
 func (suite *RadosTestSuite) TestReadWrite() {
 	suite.SetupConnection()
 
-	bytes_in := []byte("input data")
-	err := suite.ioctx.Write("obj", bytes_in, 0)
+	bytesIn := []byte("input data")
+	err := suite.ioctx.Write("obj", bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
-	bytes_out := make([]byte, len(bytes_in))
-	n_out, err := suite.ioctx.Read("obj", bytes_out, 0)
-
-	assert.Equal(suite.T(), n_out, len(bytes_in))
-	assert.Equal(suite.T(), bytes_in, bytes_out)
-
-	bytes_in = []byte("input another data")
-	err = suite.ioctx.WriteFull("obj", bytes_in)
+	bytesOut := make([]byte, len(bytesIn))
+	nOut, err := suite.ioctx.Read("obj", bytesOut, 0)
 	assert.NoError(suite.T(), err)
 
-	bytes_out = make([]byte, len(bytes_in))
-	n_out, err = suite.ioctx.Read("obj", bytes_out, 0)
+	assert.Equal(suite.T(), nOut, len(bytesIn))
+	assert.Equal(suite.T(), bytesIn, bytesOut)
 
-	assert.Equal(suite.T(), n_out, len(bytes_in))
-	assert.Equal(suite.T(), bytes_in, bytes_out)
+	bytesIn = []byte("input another data")
+	err = suite.ioctx.WriteFull("obj", bytesIn)
+	assert.NoError(suite.T(), err)
+
+	bytesOut = make([]byte, len(bytesIn))
+	nOut, err = suite.ioctx.Read("obj", bytesOut, 0)
+	assert.NoError(suite.T(), err)
+
+	assert.Equal(suite.T(), nOut, len(bytesIn))
+	assert.Equal(suite.T(), bytesIn, bytesOut)
 }
 
 func (suite *RadosTestSuite) TestAppend() {
@@ -549,14 +551,15 @@ func (suite *RadosTestSuite) TestObjectStat() {
 	stat, err := suite.ioctx.Stat(oid)
 	assert.Equal(suite.T(), uint64(len(bytes)), stat.Size)
 	assert.NotNil(suite.T(), stat.ModTime)
+	assert.NoError(suite.T(), err)
 }
 
 func (suite *RadosTestSuite) TestGetPoolStats() {
 	suite.SetupConnection()
 
 	// grab current stats
-	prev_stat, err := suite.ioctx.GetPoolStats()
-	fmt.Printf("prev_stat: %+v\n", prev_stat)
+	prevStat, err := suite.ioctx.GetPoolStats()
+	fmt.Printf("prevStat: %+v\n", prevStat)
 	assert.NoError(suite.T(), err)
 
 	// make some changes to the cluster
@@ -573,12 +576,12 @@ func (suite *RadosTestSuite) TestGetPoolStats() {
 		assert.NoError(suite.T(), err)
 
 		// wait for something to change
-		if stat == prev_stat {
-			fmt.Printf("curr_stat: %+v (trying again...)\n", stat)
+		if stat == prevStat {
+			fmt.Printf("currStat: %+v (trying again...)\n", stat)
 			time.Sleep(time.Second)
 		} else {
 			// success
-			fmt.Printf("curr_stat: %+v (change detected)\n", stat)
+			fmt.Printf("currStat: %+v (change detected)\n", stat)
 			return
 		}
 	}
@@ -631,14 +634,14 @@ func (suite *RadosTestSuite) TestMonCommandWithInputBuffer() {
 	})
 	assert.NoError(suite.T(), err)
 
-	client_key := fmt.Sprintf(clientKeyFormat, entity)
+	clientKey := fmt.Sprintf(clientKeyFormat, entity)
 
-	inbuf := []byte(client_key)
+	inbuf := []byte(clientKey)
 
 	buf, info, err := suite.conn.MonCommandWithInputBuffer(command, inbuf)
 	assert.NoError(suite.T(), err)
-	expected_info := fmt.Sprintf("added key for %s", entity)
-	assert.Equal(suite.T(), expected_info, info)
+	expectedInfo := fmt.Sprintf("added key for %s", entity)
+	assert.Equal(suite.T(), expectedInfo, info)
 	assert.Equal(suite.T(), "", string(buf[:]))
 
 	// get the key and verify that it's what we previously set
@@ -728,8 +731,8 @@ func (suite *RadosTestSuite) TestObjectIterator() {
 	// create an object in a different namespace to verify that
 	// iteration within a namespace does not return it
 	suite.ioctx.SetNamespace("ns1")
-	bytes_in := []byte("input data")
-	err = suite.ioctx.Write(suite.GenObjectName(), bytes_in, 0)
+	bytesIn := []byte("input data")
+	err = suite.ioctx.Write(suite.GenObjectName(), bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	// create some objects in default namespace
@@ -737,8 +740,8 @@ func (suite *RadosTestSuite) TestObjectIterator() {
 	createdList := []string{}
 	for i := 0; i < 10; i++ {
 		oid := suite.GenObjectName()
-		bytes_in := []byte("input data")
-		err = suite.ioctx.Write(oid, bytes_in, 0)
+		bytesIn := []byte("input data")
+		err = suite.ioctx.Write(oid, bytesIn, 0)
 		assert.NoError(suite.T(), err)
 		createdList = append(createdList, oid)
 	}
@@ -788,8 +791,8 @@ func (suite *RadosTestSuite) TestObjectIteratorAcrossNamespaces() {
 	suite.ioctx.SetNamespace("nsX")
 	for i := 0; i < 10; i++ {
 		oid := suite.GenObjectName()
-		bytes_in := []byte("input data")
-		err = suite.ioctx.Write(oid, bytes_in, 0)
+		bytesIn := []byte("input data")
+		err = suite.ioctx.Write(oid, bytesIn, 0)
 		assert.NoError(suite.T(), err)
 		createdList = append(createdList, oid)
 	}
@@ -799,8 +802,8 @@ func (suite *RadosTestSuite) TestObjectIteratorAcrossNamespaces() {
 	suite.ioctx.SetNamespace("nsY")
 	for i := 0; i < 10; i++ {
 		oid := suite.GenObjectName()
-		bytes_in := []byte("input data")
-		err = suite.ioctx.Write(oid, bytes_in, 0)
+		bytesIn := []byte("input data")
+		err = suite.ioctx.Write(oid, bytesIn, 0)
 		assert.NoError(suite.T(), err)
 		createdList = append(createdList, oid)
 	}
@@ -1032,13 +1035,14 @@ func (suite *RadosTestSuite) TestSetNamespace() {
 
 	// create oid
 	oid := suite.GenObjectName()
-	bytes_in := []byte("input data")
-	err := suite.ioctx.Write(oid, bytes_in, 0)
+	bytesIn := []byte("input data")
+	err := suite.ioctx.Write(oid, bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	stat, err := suite.ioctx.Stat(oid)
-	assert.Equal(suite.T(), uint64(len(bytes_in)), stat.Size)
+	assert.Equal(suite.T(), uint64(len(bytesIn)), stat.Size)
 	assert.NotNil(suite.T(), stat.ModTime)
+	assert.NoError(suite.T(), err)
 
 	// oid isn't seen in space1 ns
 	suite.ioctx.SetNamespace("space1")
@@ -1047,8 +1051,8 @@ func (suite *RadosTestSuite) TestSetNamespace() {
 
 	// create oid2 in space1 ns
 	oid2 := suite.GenObjectName()
-	bytes_in = []byte("input data")
-	err = suite.ioctx.Write(oid2, bytes_in, 0)
+	bytesIn = []byte("input data")
+	err = suite.ioctx.Write(oid2, bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	suite.ioctx.SetNamespace("")
@@ -1056,8 +1060,9 @@ func (suite *RadosTestSuite) TestSetNamespace() {
 	assert.Equal(suite.T(), err, ErrNotFound)
 
 	stat, err = suite.ioctx.Stat(oid)
-	assert.Equal(suite.T(), uint64(len(bytes_in)), stat.Size)
+	assert.Equal(suite.T(), uint64(len(bytesIn)), stat.Size)
 	assert.NotNil(suite.T(), stat.ModTime)
+	assert.NoError(suite.T(), err)
 }
 
 func (suite *RadosTestSuite) TestListAcrossNamespaces() {
@@ -1068,18 +1073,19 @@ func (suite *RadosTestSuite) TestListAcrossNamespaces() {
 	err := suite.ioctx.ListObjects(func(oid string) {
 		origObjects++
 	})
+	assert.NoError(suite.T(), err)
 
 	// create oid
 	oid := suite.GenObjectName()
-	bytes_in := []byte("input data")
-	err = suite.ioctx.Write(oid, bytes_in, 0)
+	bytesIn := []byte("input data")
+	err = suite.ioctx.Write(oid, bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	// create oid2 in space1 ns
 	suite.ioctx.SetNamespace("space1")
 	oid2 := suite.GenObjectName()
-	bytes_in = []byte("input data")
-	err = suite.ioctx.Write(oid2, bytes_in, 0)
+	bytesIn = []byte("input data")
+	err = suite.ioctx.Write(oid2, bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	// count objects in space1 ns

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -65,9 +65,10 @@ var (
 	// missing.
 	ErrNotFound = errors.New("RBD image not found")
 
-	// revive:disable:exported for compatibility with old versions
+	// RbdErrorImageNotOpen revive:disable:exported for compatibility with old versions
 	RbdErrorImageNotOpen = ErrImageNotOpen
-	RbdErrorNotFound     = ErrNotFound
+	// RbdErrorNotFound revive:disable:exported for compatibility with old versions
+	RbdErrorNotFound = ErrNotFound
 	// revive:enable:exported
 )
 

--- a/rbd/options.go
+++ b/rbd/options.go
@@ -117,10 +117,10 @@ func (rio *ImageOptions) Destroy() {
 //  int rbd_image_options_set_string(rbd_image_options_t opts, int optname,
 //          const char* optval);
 func (rio *ImageOptions) SetString(option ImageOption, value string) error {
-	c_value := C.CString(value)
-	defer C.free(unsafe.Pointer(c_value))
+	cValue := C.CString(value)
+	defer C.free(unsafe.Pointer(cValue))
 
-	ret := C.rbd_image_options_set_string(rio.options, C.int(option), c_value)
+	ret := C.rbd_image_options_set_string(rio.options, C.int(option), cValue)
 	if ret != 0 {
 		return fmt.Errorf("%v, could not set option %v to \"%v\"",
 			getError(ret), option, value)
@@ -153,9 +153,9 @@ func (rio *ImageOptions) GetString(option ImageOption) (string, error) {
 //  int rbd_image_options_set_uint64(rbd_image_options_t opts, int optname,
 //          const uint64_t optval);
 func (rio *ImageOptions) SetUint64(option ImageOption, value uint64) error {
-	c_value := C.uint64_t(value)
+	cValue := C.uint64_t(value)
 
-	ret := C.rbd_image_options_set_uint64(rio.options, C.int(option), c_value)
+	ret := C.rbd_image_options_set_uint64(rio.options, C.int(option), cValue)
 	if ret != 0 {
 		return fmt.Errorf("%v, could not set option %v to \"%v\"",
 			getError(ret), option, value)
@@ -170,14 +170,14 @@ func (rio *ImageOptions) SetUint64(option ImageOption, value uint64) error {
 //  int rbd_image_options_get_uint64(rbd_image_options_t opts, int optname,
 //          uint64_t* optval);
 func (rio *ImageOptions) GetUint64(option ImageOption) (uint64, error) {
-	var c_value C.uint64_t
+	var cValue C.uint64_t
 
-	ret := C.rbd_image_options_get_uint64(rio.options, C.int(option), &c_value)
+	ret := C.rbd_image_options_get_uint64(rio.options, C.int(option), &cValue)
 	if ret != 0 {
 		return 0, fmt.Errorf("%v, could not get option %v", getError(ret), option)
 	}
 
-	return uint64(c_value), nil
+	return uint64(cValue), nil
 }
 
 // IsSet returns a true if the RbdImageOption is set, false otherwise.

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -258,8 +258,8 @@ func TestDeprecatedImageOpen(t *testing.T) {
 	err = image.Open(true)
 	assert.NoError(t, err)
 
-	bytes_in := []byte("input data")
-	_, err = image.Write(bytes_in)
+	bytesIn := []byte("input data")
+	_, err = image.Write(bytesIn)
 	// writing should fail in read-only mode
 	assert.Error(t, err)
 
@@ -421,28 +421,28 @@ func TestImageSeek(t *testing.T) {
 	_, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)
 
-	bytes_in := []byte("input data")
-	n_in, err := img.Write(bytes_in)
+	bytesIn := []byte("input data")
+	nIn, err := img.Write(bytesIn)
 	assert.NoError(t, err)
-	assert.Equal(t, n_in, len(bytes_in))
+	assert.Equal(t, nIn, len(bytesIn))
 
 	pos, err := img.Seek(0, SeekCur)
 	assert.NoError(t, err)
-	assert.Equal(t, pos, int64(n_in))
+	assert.Equal(t, pos, int64(nIn))
 
 	pos, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)
 	assert.Equal(t, pos, int64(0))
 
-	bytes_out := make([]byte, len(bytes_in))
-	n_out, err := img.Read(bytes_out)
+	bytesOut := make([]byte, len(bytesIn))
+	nOut, err := img.Read(bytesOut)
 	assert.NoError(t, err)
-	assert.Equal(t, n_out, len(bytes_out))
-	assert.Equal(t, bytes_in, bytes_out)
+	assert.Equal(t, nOut, len(bytesOut))
+	assert.Equal(t, bytesIn, bytesOut)
 
 	pos, err = img.Seek(0, SeekCur)
 	assert.NoError(t, err)
-	assert.Equal(t, pos, int64(n_out))
+	assert.Equal(t, pos, int64(nOut))
 
 	pos, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)
@@ -550,52 +550,55 @@ func TestIOReaderWriter(t *testing.T) {
 	assert.Equal(t, &stats, &stats2)
 
 	_, err = img.Seek(0, SeekSet)
-	bytes_in := []byte("input data")
-	_, err = img.Write(bytes_in)
+	assert.NoError(t, err)
+
+	bytesIn := []byte("input data")
+	_, err = img.Write(bytesIn)
 	assert.NoError(t, err)
 
 	_, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)
 
 	// reading 0 bytes should succeed
-	nil_bytes := make([]byte, 0)
-	n_out, err := img.Read(nil_bytes)
-	assert.Equal(t, n_out, 0)
+	nilBytes := make([]byte, 0)
+	nOut, err := img.Read(nilBytes)
+	assert.Equal(t, nOut, 0)
 	assert.NoError(t, err)
 
-	bytes_out := make([]byte, len(bytes_in))
-	n_out, err = img.Read(bytes_out)
+	bytesOut := make([]byte, len(bytesIn))
+	nOut, err = img.Read(bytesOut)
 
-	assert.Equal(t, n_out, len(bytes_in))
-	assert.Equal(t, bytes_in, bytes_out)
+	assert.NoError(t, err)
+	assert.Equal(t, nOut, len(bytesIn))
+	assert.Equal(t, bytesIn, bytesOut)
 
 	// write some data at the end of the image
-	offset := int64(stats.Size) - int64(len(bytes_in))
+	offset := int64(stats.Size) - int64(len(bytesIn))
 
 	_, err = img.Seek(offset, SeekSet)
 	assert.NoError(t, err)
 
-	n_out, err = img.Write(bytes_in)
-	assert.Equal(t, len(bytes_in), n_out)
+	nOut, err = img.Write(bytesIn)
+	assert.Equal(t, len(bytesIn), nOut)
 	assert.NoError(t, err)
 
 	_, err = img.Seek(offset, SeekSet)
 	assert.NoError(t, err)
 
-	bytes_out = make([]byte, len(bytes_in))
-	n_out, err = img.Read(bytes_out)
-	assert.Equal(t, n_out, len(bytes_in))
-	assert.Equal(t, bytes_in, bytes_out)
+	bytesOut = make([]byte, len(bytesIn))
+	nOut, err = img.Read(bytesOut)
+	assert.Equal(t, nOut, len(bytesIn))
+	assert.Equal(t, bytesIn, bytesOut)
 	assert.NoError(t, err)
 
 	// reading after EOF (needs to be large enough to hit EOF)
 	_, err = img.Seek(offset, SeekSet)
 	assert.NoError(t, err)
 
-	bytes_in = make([]byte, len(bytes_out)+256)
-	n_out, err = img.Read(bytes_in)
-	assert.Equal(t, n_out, len(bytes_out))
-	assert.Equal(t, bytes_in[0:len(bytes_out)], bytes_out)
+	bytesIn = make([]byte, len(bytesOut)+256)
+	nOut, err = img.Read(bytesIn)
+	assert.Equal(t, nOut, len(bytesOut))
+	assert.Equal(t, bytesIn[0:len(bytesOut)], bytesOut)
 	assert.Equal(t, io.EOF, err)
 
 	err = img.Close()
@@ -631,39 +634,39 @@ func TestReadAt(t *testing.T) {
 	assert.NoError(t, err)
 
 	// write 0 bytes should succeed
-	data_out := make([]byte, 0)
-	n_out, err := img.WriteAt(data_out, 256)
-	assert.Equal(t, 0, n_out)
+	dataOut := make([]byte, 0)
+	nOut, err := img.WriteAt(dataOut, 256)
+	assert.Equal(t, 0, nOut)
 	assert.NoError(t, err)
 
 	// reading 0 bytes should be successful
-	data_in := make([]byte, 0)
-	n_in, err := img.ReadAt(data_in, 256)
-	assert.Equal(t, 0, n_in)
+	dataIn := make([]byte, 0)
+	nIn, err := img.ReadAt(dataIn, 256)
+	assert.Equal(t, 0, nIn)
 	assert.NoError(t, err)
 
 	// write some data at the end of the image
-	data_out = []byte("Hi rbd! Nice to talk through go-ceph :)")
+	dataOut = []byte("Hi rbd! Nice to talk through go-ceph :)")
 
 	stats, err := img.Stat()
 	require.NoError(t, err)
-	offset := int64(stats.Size) - int64(len(data_out))
+	offset := int64(stats.Size) - int64(len(dataOut))
 
-	n_out, err = img.WriteAt(data_out, offset)
-	assert.Equal(t, len(data_out), n_out)
+	nOut, err = img.WriteAt(dataOut, offset)
+	assert.Equal(t, len(dataOut), nOut)
 	assert.NoError(t, err)
 
-	data_in = make([]byte, len(data_out))
-	n_in, err = img.ReadAt(data_in, offset)
-	assert.Equal(t, n_in, len(data_in))
-	assert.Equal(t, data_in, data_out)
+	dataIn = make([]byte, len(dataOut))
+	nIn, err = img.ReadAt(dataIn, offset)
+	assert.Equal(t, nIn, len(dataIn))
+	assert.Equal(t, dataIn, dataOut)
 	assert.NoError(t, err)
 
 	// reading after EOF (needs to be large enough to hit EOF)
-	data_in = make([]byte, len(data_out)+256)
-	n_in, err = img.ReadAt(data_in, offset)
-	assert.Equal(t, n_in, len(data_out))
-	assert.Equal(t, data_in[0:len(data_out)], data_out)
+	dataIn = make([]byte, len(dataOut)+256)
+	nIn, err = img.ReadAt(dataIn, offset)
+	assert.Equal(t, nIn, len(dataOut))
+	assert.Equal(t, dataIn[0:len(dataOut)], dataOut)
 	assert.Equal(t, io.EOF, err)
 
 	err = img.Close()
@@ -673,7 +676,7 @@ func TestReadAt(t *testing.T) {
 	img, err = OpenImageReadOnly(ioctx, name, NoSnapshot)
 	assert.NoError(t, err)
 
-	_, err = img.WriteAt(data_out, 256)
+	_, err = img.WriteAt(dataOut, 256)
 	assert.Error(t, err)
 
 	err = img.Close()
@@ -1254,8 +1257,8 @@ func TestOpenImage(t *testing.T) {
 	oImage, err = OpenImageReadOnly(ioctx, name, NoSnapshot)
 	assert.NoError(t, err)
 
-	bytes_in := []byte("input data")
-	_, err = oImage.Write(bytes_in)
+	bytesIn := []byte("input data")
+	_, err = oImage.Write(bytesIn)
 	// writing should fail in read-only mode
 	assert.Error(t, err)
 

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -25,10 +25,10 @@ func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
 		return nil, err
 	}
 
-	c_snapname := C.CString(snapname)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapname := C.CString(snapname)
+	defer C.free(unsafe.Pointer(cSnapname))
 
-	ret := C.rbd_snap_create(image.image, c_snapname)
+	ret := C.rbd_snap_create(image.image, cSnapname)
 	if ret < 0 {
 		return nil, RBDError(ret)
 	}
@@ -70,10 +70,10 @@ func (snapshot *Snapshot) Remove() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapname))
 
-	return getError(C.rbd_snap_remove(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_remove(snapshot.image.image, cSnapname))
 }
 
 // Rollback the image to the snapshot.
@@ -85,10 +85,10 @@ func (snapshot *Snapshot) Rollback() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapname))
 
-	return getError(C.rbd_snap_rollback(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_rollback(snapshot.image.image, cSnapname))
 }
 
 // Protect a snapshot from unwanted deletion.
@@ -100,10 +100,10 @@ func (snapshot *Snapshot) Protect() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapname))
 
-	return getError(C.rbd_snap_protect(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_protect(snapshot.image.image, cSnapname))
 }
 
 // Unprotect stops protecting the snapshot.
@@ -115,10 +115,10 @@ func (snapshot *Snapshot) Unprotect() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapname))
 
-	return getError(C.rbd_snap_unprotect(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_unprotect(snapshot.image.image, cSnapname))
 }
 
 // IsProtected returns true if the snapshot is currently protected.
@@ -131,18 +131,18 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 		return false, err
 	}
 
-	var c_is_protected C.int
+	var cIsProtected C.int
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapname))
 
-	ret := C.rbd_snap_is_protected(snapshot.image.image, c_snapname,
-		&c_is_protected)
+	ret := C.rbd_snap_is_protected(snapshot.image.image, cSnapname,
+		&cIsProtected)
 	if ret < 0 {
 		return false, RBDError(ret)
 	}
 
-	return c_is_protected != 0, nil
+	return cIsProtected != 0, nil
 }
 
 // Set updates the rbd image (not the Snapshot) such that the snapshot
@@ -155,8 +155,8 @@ func (snapshot *Snapshot) Set() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapname := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapname))
 
-	return getError(C.rbd_snap_set(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_set(snapshot.image.image, cSnapname))
 }


### PR DESCRIPTION
Go report card for ceph/go-ceph had 13 issues in 62 files before this change.
What is improved:
1. golint
2. ineffassign
3. misspell
What is not changed:
- Variables starting with capital-case as those are exported and changing those might break users of go-ceph.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
