### PR TITLE
Add an "implements" tool to contrib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.out
 *.test
 *.json
+implements

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ VOLUME_FLAGS :=
 CEPH_VERSION := nautilus
 RESULTS_DIR :=
 CHECK_GOFMT_FLAGS := -e -s -l
+IMPLEMENTS_OPTS :=
 
 SELINUX := $(shell getenforce 2>/dev/null)
 ifeq ($(SELINUX),Enforcing)
@@ -74,6 +75,9 @@ test-bins: test-binaries
 implements:
 	go build -o implements ./contrib/implements
 
+check-implements: implements
+	./implements $(IMPLEMENTS_OPTS) ./cephfs ./rados ./rbd
+
 # force_go_build is phony and builds nothing, can be used for forcing
 # go toolchain commands to always run
-.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build
+.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ test-bins: test-binaries
 %.test: % force_go_build
 	go test -c ./$<
 
+implements:
+	go build -o implements ./contrib/implements
+
 # force_go_build is phony and builds nothing, can be used for forcing
 # go toolchain commands to always run
 .PHONY: build fmt test test-docker check test-binaries test-bins force_go_build

--- a/contrib/implements/README.md
+++ b/contrib/implements/README.md
@@ -4,4 +4,46 @@
 implements is a small-ish tool created to compare the Ceph C APIs with
 go-ceph implmeents.
 
+## Build
 
+In the go-ceph repository run `make implmeents` to create a standalone
+binary for the `implements` cli tool.
+
+## Run
+
+```
+./implements [--verbose] [--json] [--list] [pkg...]
+```
+
+The --verbose option causes verbose details about the source scan to be
+printed.
+
+The tool can produce either plain-text output, or JSON with the --json option.
+
+The --list option produces a list of all covered and missing functions from
+the Ceph library. The listing also provides information about each function's
+status.
+
+`DIR` should be a directory containing go-ceph sources. If running the command from the root of the go-ceph git checkout, `.` is sufficient.
+
+`pkg` is one or more package names such as: "cephfs", "rados", or "rbd".
+The packages may be indicated by directory, such as "./cephfs".
+The tool will output a section pertaining to each named package.
+
+
+Examples:
+
+```
+# Quickly summarize all packages
+./implements cephfs rados rbd
+
+# List missing and present functions in rbd
+./implements --list ./rbd
+
+# Print debugging info while processing rados
+./implements --verbose rados
+
+# Full analysis of everything in JSON
+./implements --json --list ./cephfs ./rados ./rbd
+
+```

--- a/contrib/implements/README.md
+++ b/contrib/implements/README.md
@@ -1,0 +1,7 @@
+
+# The 'implements' tool
+
+implements is a small-ish tool created to compare the Ceph C APIs with
+go-ceph implmeents.
+
+

--- a/contrib/implements/internal/implements/cast.go
+++ b/contrib/implements/internal/implements/cast.go
@@ -1,0 +1,150 @@
+package implements
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+var (
+	// CastXmlBin is the name/location of the castxml binary.
+	CastXmlBin = "castxml"
+
+	// Add a stub C function that goes nowhere and does nothing. Just
+	// to give castxml something to chew on. It may not be strictly
+	// needed but it worked for me.
+	// TODO Cleanup - The macro part is probably totally unnecessary but I wanted
+	// to see how much "extra stuff" castxml picked up.
+
+	gndn = `
+
+#define GNDN
+GNDN int foo(int x) {
+    return x;
+}
+`
+
+	// Individual "package" stubs. Add the needed headers to pick up the
+	// ceph lib<whatever> content plus the code stub for castxml.
+
+	cephfs_c_stub = `
+#define FILE_OFFSET_BITS 64
+#include <stdlib.h>
+#define __USE_FILE_OFFSET64
+#include <cephfs/libcephfs.h>
+` + gndn
+	rados_c_stub = `
+#include <rados/librados.h>
+` + gndn
+	rbd_c_stub = `
+#include <rbd/librbd.h>
+#include <rbd/features.h>
+` + gndn
+
+	stubs = map[string]string{
+		"cephfs": cephfs_c_stub,
+		"rados":  rados_c_stub,
+		"rbd":    rbd_c_stub,
+	}
+	funcPrefix = map[string]string{
+		"cephfs": "ceph_",
+		"rados":  "rados_",
+		"rbd":    "rbd_",
+	}
+)
+
+type allCFunctions struct {
+	Functions CFunctions `xml:"Function"`
+}
+
+func parseCFunctions(xmlData []byte) ([]CFunction, error) {
+	cf := allCFunctions{}
+	if err := xml.Unmarshal(xmlData, &cf); err != nil {
+		return nil, err
+	}
+	return cf.Functions.ensure()
+}
+
+func parseCFunctionsFromFile(fname string) ([]CFunction, error) {
+	cf := allCFunctions{}
+
+	f, err := os.Open(fname)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	xdec := xml.NewDecoder(f)
+	err = xdec.Decode(&cf)
+	if err != nil {
+		return nil, err
+	}
+	return cf.Functions.ensure()
+}
+
+func parseCFunctionsFromCmd(args []string) (CFunctions, error) {
+	cf := allCFunctions{}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	logger.Printf("will call: %v", cmd)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	xdec := xml.NewDecoder(stdout)
+	parseErr := xdec.Decode(&cf)
+
+	err = cmd.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	return cf.Functions.ensure()
+}
+
+func stubCFunctions(libname string) (CFunctions, error) {
+	cstub := stubs[libname]
+	if cstub == "" {
+		return nil, fmt.Errorf("no C stub available for '%s'", libname)
+	}
+
+	tfile, err := ioutil.TempFile("", "*-"+libname+".c")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tfile.Name())
+
+	_, err = tfile.Write([]byte(cstub))
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := []string{
+		CastXmlBin,
+		"--castxml-output=1",
+		"-o", "-",
+		tfile.Name(),
+	}
+	return parseCFunctionsFromCmd(cmd)
+}
+
+// CephCFunctions will extract C functions from the supplied package name
+// and update the results within the code inspector.
+func CephCFunctions(pkg string, ii *Inspector) error {
+	logger.Printf("getting C AST for %s", pkg)
+	f, err := stubCFunctions(pkg)
+	if err != nil {
+		return err
+	}
+	return ii.SetExpected(funcPrefix[pkg], f)
+}

--- a/contrib/implements/internal/implements/cfunctions.go
+++ b/contrib/implements/internal/implements/cfunctions.go
@@ -1,0 +1,32 @@
+package implements
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CFunction represents a function in C code.
+type CFunction struct {
+	Name string `xml:"name,attr"`
+	Attr string `xml:"attributes,attr"`
+}
+
+// isDeprecated will return true if the C function is marked deprecated
+// via attributes.
+func (cf CFunction) isDeprecated() bool {
+	return strings.Contains(cf.Attr, "deprecated")
+}
+
+// CFunctions is a sortable slice of CFunction.
+type CFunctions []CFunction
+
+func (cfs CFunctions) Len() int           { return len(cfs) }
+func (cfs CFunctions) Swap(i, j int)      { cfs[i], cfs[j] = cfs[j], cfs[i] }
+func (cfs CFunctions) Less(i, j int) bool { return cfs[i].Name < cfs[j].Name }
+
+func (cfs CFunctions) ensure() (CFunctions, error) {
+	if len(cfs) < 1 {
+		return nil, fmt.Errorf("found %d c functions", len(cfs))
+	}
+	return cfs, nil
+}

--- a/contrib/implements/internal/implements/gosrc.go
+++ b/contrib/implements/internal/implements/gosrc.go
@@ -1,0 +1,124 @@
+package implements
+
+import (
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"path"
+	"regexp"
+	"strings"
+)
+
+type visitor struct {
+	inFunction *ast.FuncDecl
+
+	callMap map[string]string
+	docMap  map[string]string
+}
+
+func newVisitor() *visitor {
+	return &visitor{
+		callMap: map[string]string{},
+		docMap:  map[string]string{},
+	}
+}
+
+func (v *visitor) checkDocImplements(fdec *ast.FuncDecl) {
+	dtext := fdec.Doc.Text()
+	lines := strings.Split(dtext, "\n")
+	for i := range lines {
+		if lines[i] == "Implements:" {
+			cfunc := cfuncFromComment(lines[i+1])
+			if cfunc == "" {
+				return
+			}
+			v.docMap[cfunc] = fdec.Name.Name
+			logger.Printf("updated %s in doc map\n", cfunc)
+		}
+	}
+}
+
+func (v *visitor) checkCalled(s *ast.SelectorExpr) {
+	ident, ok := s.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+	if "C" == ident.String() {
+		v.callMap[s.Sel.String()] = v.inFunction.Name.Name
+		logger.Printf("updated %s in call map\n", s.Sel.String())
+	}
+}
+
+func (v *visitor) Visit(node ast.Node) ast.Visitor {
+	switch {
+	case node == nil:
+		return nil
+	case v.inFunction == nil:
+	case node.Pos() > v.inFunction.End():
+		logger.Printf("left function %v\n", v.inFunction.Name.Name)
+		v.inFunction = nil
+	}
+
+	switch n := node.(type) {
+	case *ast.File:
+		v.inFunction = nil
+		return v
+	case *ast.FuncDecl:
+		logger.Printf("checking function: %v\n", n.Name.Name)
+		v.checkDocImplements(n)
+		v.inFunction = n
+		return v
+	case *ast.CallExpr:
+		if v.inFunction == nil {
+			return nil
+		}
+		if s, ok := n.Fun.(*ast.SelectorExpr); ok {
+			v.checkCalled(s)
+		}
+	}
+	if v.inFunction != nil {
+		return v
+	}
+	return nil
+}
+
+func cfuncFromComment(ctext string) string {
+	m := regexp.MustCompile(` ([a-zA-Z0-9_]+)\(`).FindAllSubmatch([]byte(ctext), 1)
+	if len(m) < 1 {
+		return ""
+	}
+	return string(m[0][1])
+}
+
+// CephGoFunctions will look for C functions called by the code code and
+// update the found functions for the package within the inspector.
+func CephGoFunctions(source, packageName string, ii *Inspector) error {
+	p, err := build.Import("./"+packageName, source, 0)
+	if err != nil {
+		return err
+	}
+
+	toCheck := []string{}
+	toCheck = append(toCheck, p.GoFiles...)
+	toCheck = append(toCheck, p.CgoFiles...)
+	for _, fname := range toCheck {
+		logger.Printf("Reading go file: %v\n", fname)
+		src, err := ioutil.ReadFile(path.Join(p.Dir, fname))
+		if err != nil {
+			return err
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(
+			fset,
+			fname,
+			src,
+			parser.ParseComments|parser.AllErrors)
+		if err != nil {
+			return err
+		}
+		ast.Walk(ii.visitor, f)
+	}
+	return nil
+}

--- a/contrib/implements/internal/implements/inspector.go
+++ b/contrib/implements/internal/implements/inspector.go
@@ -1,0 +1,64 @@
+package implements
+
+import (
+	"strings"
+)
+
+type foundFlags int
+
+const (
+	isCalled     = foundFlags(1)
+	isDocumented = foundFlags(2)
+	isDeprecated = foundFlags(4)
+)
+
+// Inspector types collect the high-level results from C and Go
+// code scans.
+type Inspector struct {
+	visitor *visitor
+
+	expected          CFunctions
+	found             map[string]foundFlags
+	deprecatedMissing int
+}
+
+// SetExpected sets the expected C functions, asuming the supplied prefix.
+func (ii *Inspector) SetExpected(prefix string, expected CFunctions) error {
+	ii.expected = make([]CFunction, 0, len(expected))
+	for _, cfunc := range expected {
+		if strings.HasPrefix(cfunc.Name, prefix) {
+			logger.Printf("C function \"%s\" has matching prefix", cfunc.Name)
+			ii.expected = append(ii.expected, cfunc)
+		}
+	}
+	_, err := ii.expected.ensure()
+	return err
+}
+
+func (ii *Inspector) update() {
+	ii.found = map[string]foundFlags{}
+	ii.deprecatedMissing = 0
+	for i := range ii.expected {
+		n := ii.expected[i].Name
+		if _, found := ii.visitor.callMap[n]; found {
+			ii.found[n] |= isCalled
+		}
+		if _, found := ii.visitor.docMap[n]; found {
+			ii.found[n] |= isDocumented
+		}
+		if ii.expected[i].isDeprecated() {
+			if _, found := ii.found[n]; found {
+				ii.found[n] |= isDeprecated
+			} else {
+				ii.deprecatedMissing++
+			}
+		}
+	}
+}
+
+// NewInspector returns a newly created code inspector object.
+func NewInspector() *Inspector {
+	return &Inspector{
+		visitor: newVisitor(),
+	}
+}

--- a/contrib/implements/internal/implements/json_report.go
+++ b/contrib/implements/internal/implements/json_report.go
@@ -47,7 +47,7 @@ type jrPackage struct {
 		Missing    int `json:"missing"`
 		Deprecated int `json:"deprecated"`
 	} `json:"summary"`
-	Covered []jrFunction `json:"covered,omitempty"`
+	Found   []jrFunction `json:"found,omitempty"`
 	Missing []jrFunction `json:"missing,omitempty"`
 }
 
@@ -90,7 +90,7 @@ func collectFuncs(jp *jrPackage, ii *Inspector) {
 			if n := ii.visitor.docMap[cf.Name]; n != "" {
 				refm[n] = true
 			}
-			jp.Covered = append(jp.Covered,
+			jp.Found = append(jp.Found,
 				jrFunction{cf.Name, jrFlags(flags), mkeys(refm)})
 		}
 	}

--- a/contrib/implements/internal/implements/json_report.go
+++ b/contrib/implements/internal/implements/json_report.go
@@ -1,0 +1,123 @@
+package implements
+
+import (
+	"encoding/json"
+	"io"
+	"sort"
+)
+
+// JSONReport is a type that implements the Report interface and generates
+// structured JSON.
+type JSONReport struct {
+	o    ReportOptions
+	dest io.Writer
+
+	data jrOut
+}
+
+type jrFlags foundFlags
+
+func (f jrFlags) MarshalJSON() ([]byte, error) {
+	o := []string{}
+	flags := foundFlags(f)
+
+	if flags&isCalled == isCalled {
+		o = append(o, "called")
+	}
+	if flags&isDocumented == isDocumented {
+		o = append(o, "documented")
+	}
+	if flags&isDeprecated == isDeprecated {
+		o = append(o, "deprecated")
+	}
+	return json.Marshal(o)
+}
+
+type jrFunction struct {
+	CName string   `json:"c_name"`
+	Flags jrFlags  `json:"flags,omitempty"`
+	Refs  []string `json:"referenced_by,omitempty"`
+}
+
+type jrPackage struct {
+	Name    string `json:"name"`
+	Summary struct {
+		Total      int `json:"total"`
+		Found      int `json:"found"`
+		Missing    int `json:"missing"`
+		Deprecated int `json:"deprecated"`
+	} `json:"summary"`
+	Covered []jrFunction `json:"covered,omitempty"`
+	Missing []jrFunction `json:"missing,omitempty"`
+}
+
+type jrOut map[string]jrPackage
+
+// NewJSONReport creates a new json report. The JSON will be written to
+// the supplied dest when Done is called.
+func NewJSONReport(o ReportOptions, dest io.Writer) *JSONReport {
+	return &JSONReport{o, dest, jrOut{}}
+}
+
+// Report will update the JSON report with the current code inspector's state.
+func (r *JSONReport) Report(name string, ii *Inspector) error {
+	ii.update()
+
+	jp := jrPackage{}
+	total := len(ii.expected)
+	found := len(ii.found)
+	jp.Summary.Total = total
+	jp.Summary.Found = found
+	jp.Summary.Missing = total - found - ii.deprecatedMissing
+	jp.Summary.Deprecated = ii.deprecatedMissing
+	jp.Name = name
+
+	if r.o.List {
+		collectFuncs(&jp, ii)
+	}
+	r.data[name] = jp
+	return nil
+}
+
+func collectFuncs(jp *jrPackage, ii *Inspector) {
+	sort.Sort(ii.expected)
+	for _, cf := range ii.expected {
+		if flags, ok := ii.found[cf.Name]; ok {
+			refm := map[string]bool{}
+			if n := ii.visitor.callMap[cf.Name]; n != "" {
+				refm[n] = true
+			}
+			if n := ii.visitor.docMap[cf.Name]; n != "" {
+				refm[n] = true
+			}
+			jp.Covered = append(jp.Covered,
+				jrFunction{cf.Name, jrFlags(flags), mkeys(refm)})
+		}
+	}
+	for _, cf := range ii.expected {
+		if _, ok := ii.found[cf.Name]; ok {
+			continue
+		}
+		var flags jrFlags
+		if cf.isDeprecated() {
+			flags |= jrFlags(isDeprecated)
+		}
+		jp.Missing = append(jp.Missing,
+			jrFunction{cf.Name, flags, []string{}})
+	}
+}
+
+func mkeys(m map[string]bool) []string {
+	o := make([]string, 0, len(m))
+	for k := range m {
+		o = append(o, k)
+	}
+	return o
+}
+
+// Done completes the JSON report and writes the JSON to the output.
+func (r *JSONReport) Done() error {
+	enc := json.NewEncoder(r.dest)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r.data)
+}

--- a/contrib/implements/internal/implements/log.go
+++ b/contrib/implements/internal/implements/log.go
@@ -1,0 +1,20 @@
+package implements
+
+// DebugLogger is a simple interface to allow debug logging w/in the
+// implements package.
+type DebugLogger interface {
+	Printf(format string, v ...interface{})
+}
+
+// NoOpLogger is a dummy logger that generates no output.
+type NoOpLogger struct{}
+
+// Printf implements the DebugLogger interface.
+func (NoOpLogger) Printf(_ string, _ ...interface{}) {}
+
+var logger DebugLogger = NoOpLogger{}
+
+// SetLogger will set the given debug logger for the whole implements package.
+func SetLogger(l DebugLogger) {
+	logger = l
+}

--- a/contrib/implements/internal/implements/report.go
+++ b/contrib/implements/internal/implements/report.go
@@ -78,7 +78,7 @@ func (r *TextReport) Report(name string, ii *Inspector) error {
 					tags = " (" + strings.TrimSpace(tags) + ")"
 				}
 			}
-			fmt.Printf("  Covered: %s%s\n", cf.Name, tags)
+			fmt.Printf("  Found: %s%s\n", cf.Name, tags)
 		}
 	}
 	for _, cf := range ii.expected {

--- a/contrib/implements/internal/implements/report.go
+++ b/contrib/implements/internal/implements/report.go
@@ -1,0 +1,98 @@
+package implements
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ReportOptions is a common set of options for reports.
+type ReportOptions struct {
+	List     bool
+	Annotate bool
+}
+
+// Reporter is a common interface to report on the "implements"
+// analysis.
+type Reporter interface {
+	// Report reports on the given (sub)package with the given inspector's
+	// contents.
+	Report(string, *Inspector) error
+	// Done flushes any buffered state between calls to Report.
+	Done() error
+}
+
+// TextReport implements a streaming plain-text output report.
+type TextReport struct {
+	o ReportOptions
+}
+
+// NewTextReport creates a new TextReport.
+func NewTextReport(o ReportOptions) *TextReport {
+	return &TextReport{o}
+}
+
+// Report on the given code inspector.
+func (r *TextReport) Report(name string, ii *Inspector) error {
+	o := r.o
+	packageLabel := strings.ToUpper(name)
+
+	ii.update()
+
+	found := len(ii.found)
+	total := len(ii.expected)
+	fmt.Printf(
+		"%s functions covered: %d/%d : %v%%\n",
+		packageLabel,
+		found,
+		total,
+		(100*found)/total)
+	missing := total - found - ii.deprecatedMissing
+	fmt.Printf(
+		"%s functions missing: %d/%d : %v%%\n",
+		packageLabel,
+		missing,
+		total,
+		(100*missing)/total)
+	fmt.Printf(
+		"  (note missing count does not include deprecated functions in ceph)\n")
+
+	if !o.List {
+		return nil
+	}
+	sort.Sort(ii.expected)
+	for _, cf := range ii.expected {
+		if flags, ok := ii.found[cf.Name]; ok {
+			tags := ""
+			if o.Annotate {
+				if flags&isCalled == isCalled {
+					tags += " called"
+				}
+				if flags&isDocumented == isDocumented {
+					tags += " documented"
+				}
+				if flags&isDeprecated == isDeprecated {
+					tags += " deprecated"
+				}
+				if tags != "" {
+					tags = " (" + strings.TrimSpace(tags) + ")"
+				}
+			}
+			fmt.Printf("  Covered: %s%s\n", cf.Name, tags)
+		}
+	}
+	for _, cf := range ii.expected {
+		if _, ok := ii.found[cf.Name]; ok {
+			continue
+		}
+		d := ""
+		if o.Annotate && cf.isDeprecated() {
+			d = " (deprecated)"
+		}
+		fmt.Printf("  Missing: %s%s\n", cf.Name, d)
+	}
+	return nil
+}
+
+// Done updating report with inspectors.
+func (*TextReport) Done() error { return nil }

--- a/contrib/implements/main.go
+++ b/contrib/implements/main.go
@@ -13,7 +13,7 @@ package main
 //   ./implements ./cephfs ./rados ./rbd
 //
 //   # generate a comprehensive report on rbd in json
-//   ./implements --list --annotate --json rbd
+//   ./implements --list --json rbd
 
 import (
 	"flag"
@@ -27,7 +27,6 @@ import (
 var (
 	verbose    bool
 	list       bool
-	annotate   bool
 	reportJSON bool
 
 	// verbose logger
@@ -41,7 +40,6 @@ func abort(msg string) {
 func init() {
 	flag.BoolVar(&verbose, "verbose", false, "be more verbose (for debugging)")
 	flag.BoolVar(&list, "list", false, "list functions")
-	flag.BoolVar(&annotate, "annotate", false, "annotate functions")
 	flag.BoolVar(&reportJSON, "json", false, "use JSON output format")
 }
 
@@ -56,9 +54,11 @@ func main() {
 	}
 
 	var r implements.Reporter
+	// always annotate for now, leave the option of disabling it someday if it
+	// gets costly
 	o := implements.ReportOptions{
 		List:     list,
-		Annotate: annotate,
+		Annotate: true,
 	}
 	switch {
 	case reportJSON:

--- a/contrib/implements/main.go
+++ b/contrib/implements/main.go
@@ -1,0 +1,95 @@
+package main
+
+// The "implements" tool uses code analysis and the conventions of the go-ceph
+// project to produce a report comparing what go-ceph implements and what
+// exists in the C ceph APIs. Only (lib)cephfs, (lib)rados, and (lib)rbd are
+// and the equilvaent go-ceph packages are supported.
+//
+// Examples:
+//   # generate a full report on cephfs with a function listing
+//   ./implements --list ./cephfs
+//
+//   # generate a brief summary on all packages
+//   ./implements ./cephfs ./rados ./rbd
+//
+//   # generate a comprehensive report on rbd in json
+//   ./implements --list --annotate --json rbd
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path"
+
+	"github.com/ceph/go-ceph/contrib/implements/internal/implements"
+)
+
+var (
+	verbose    bool
+	list       bool
+	annotate   bool
+	reportJSON bool
+
+	// verbose logger
+	logger = log.New(os.Stderr, "(implements/verbose) ", log.LstdFlags)
+)
+
+func abort(msg string) {
+	log.Fatalf("error: %v\n", msg)
+}
+
+func init() {
+	flag.BoolVar(&verbose, "verbose", false, "be more verbose (for debugging)")
+	flag.BoolVar(&list, "list", false, "list functions")
+	flag.BoolVar(&annotate, "annotate", false, "annotate functions")
+	flag.BoolVar(&reportJSON, "json", false, "use JSON output format")
+}
+
+func main() {
+	flag.Parse()
+	args := flag.Args()
+	if len(args) < 1 {
+		abort("missing package(s) to analyze")
+	}
+	if verbose {
+		implements.SetLogger(logger)
+	}
+
+	var r implements.Reporter
+	o := implements.ReportOptions{
+		List:     list,
+		Annotate: annotate,
+	}
+	switch {
+	case reportJSON:
+		r = implements.NewJSONReport(o, os.Stdout)
+	default:
+		r = implements.NewTextReport(o)
+	}
+
+	for _, pkgref := range args[0:] {
+		source, pkg := path.Split(pkgref)
+		switch pkg {
+		case "cephfs", "rados", "rbd":
+			if verbose {
+				logger.Printf("Processing package: %s\n", pkg)
+			}
+		default:
+			abort("unknown package name: " + pkg)
+		}
+		if source == "" {
+			source = "."
+		}
+		ii := implements.NewInspector()
+		if err := implements.CephCFunctions(pkg, ii); err != nil {
+			abort(err.Error())
+		}
+		if err := implements.CephGoFunctions(source, pkg, ii); err != nil {
+			abort(err.Error())
+		}
+		if err := r.Report(pkg, ii); err != nil {
+			abort(err.Error())
+		}
+	}
+	r.Done()
+}


### PR DESCRIPTION
Add a new Go-based tool to the contrib dir that helps determine what is covered, what is missing, and other basic stats.
This should be a superset of the features of `apicompare.py` in the contrib dir. I converted it to Go to make the languages for the library and the tool consistent and perhaps easier for others to contribute to. In addition we can now make use of the native Go AST packages.

If this is accepted I will probably file a follow up PR to remove the python based apicompare.py.

Future directions:
* I want to run the tool in the CI runs with the tests and capture the output
* I hope to make use of the json output to do additional analysis per-pr, like maybe reporting on
* Adding code to verify that the "Implements:" comment standard is formatted properly in the CI.
* Adding the ability to make comments that indicate a Ceph API function will _not_ be covered by this project. For example if our library fully covers the features of a call w/ another call and said call will never be needed.


## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
