### PR TITLE
gitignore: ignore .test and .json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .build-docker
 *.swp
 *.out
+*.test
+*.json


### PR DESCRIPTION
The .test files are generated by some makefile rules and should
never be checked in.
There's also no reason to track json files which may be generated
by running tools.

