### PR TITLE
rados: add support for remaining missing "command" funcs

### DIFF
--- a/rados/command.go
+++ b/rados/command.go
@@ -17,15 +17,11 @@ func radosBufferFree(p unsafe.Pointer) {
 
 // MonCommand sends a command to one of the monitors
 func (c *Conn) MonCommand(args []byte) ([]byte, string, error) {
-	return c.monCommand(args, nil)
+	return c.MonCommandWithInputBuffer(args, nil)
 }
 
 // MonCommandWithInputBuffer sends a command to one of the monitors, with an input buffer
 func (c *Conn) MonCommandWithInputBuffer(args, inputBuffer []byte) ([]byte, string, error) {
-	return c.monCommand(args, inputBuffer)
-}
-
-func (c *Conn) monCommand(args, inputBuffer []byte) ([]byte, string, error) {
 	ci := cutil.NewCommandInput([][]byte{args}, inputBuffer)
 	defer ci.Free()
 	co := cutil.NewCommandOutput().SetFreeFunc(radosBufferFree)
@@ -54,7 +50,7 @@ func (c *Conn) monCommand(args, inputBuffer []byte) ([]byte, string, error) {
 //                       char **outbuf, size_t *outbuflen,
 //                       char **outs, size_t *outslen);
 func (c *Conn) PGCommand(pgid []byte, args [][]byte) ([]byte, string, error) {
-	return c.pgCommand(pgid, args, nil)
+	return c.PGCommandWithInputBuffer(pgid, args, nil)
 }
 
 // PGCommandWithInputBuffer sends a command to one of the PGs, with an input buffer
@@ -66,10 +62,6 @@ func (c *Conn) PGCommand(pgid []byte, args [][]byte) ([]byte, string, error) {
 //                       char **outbuf, size_t *outbuflen,
 //                       char **outs, size_t *outslen);
 func (c *Conn) PGCommandWithInputBuffer(pgid []byte, args [][]byte, inputBuffer []byte) ([]byte, string, error) {
-	return c.pgCommand(pgid, args, inputBuffer)
-}
-
-func (c *Conn) pgCommand(pgid []byte, args [][]byte, inputBuffer []byte) ([]byte, string, error) {
 	name := C.CString(string(pgid))
 	defer C.free(unsafe.Pointer(name))
 	ci := cutil.NewCommandInput(args, inputBuffer)
@@ -94,21 +86,18 @@ func (c *Conn) pgCommand(pgid []byte, args [][]byte, inputBuffer []byte) ([]byte
 
 // MgrCommand sends a command to a ceph-mgr.
 func (c *Conn) MgrCommand(args [][]byte) ([]byte, string, error) {
-	return c.mgrCommand(args, nil)
+	return c.MgrCommandWithInputBuffer(args, nil)
 }
 
 // MgrCommandWithInputBuffer sends a command, with an input buffer, to a ceph-mgr.
-func (c *Conn) MgrCommandWithInputBuffer(args [][]byte, inputBuffer []byte) ([]byte, string, error) {
-	return c.mgrCommand(args, inputBuffer)
-}
-
+//
 // Implements:
 //  int rados_mgr_command(rados_t cluster, const char **cmd,
 //                         size_t cmdlen, const char *inbuf,
 //                         size_t inbuflen, char **outbuf,
 //                         size_t *outbuflen, char **outs,
 //                          size_t *outslen);
-func (c *Conn) mgrCommand(args [][]byte, inputBuffer []byte) ([]byte, string, error) {
+func (c *Conn) MgrCommandWithInputBuffer(args [][]byte, inputBuffer []byte) ([]byte, string, error) {
 	ci := cutil.NewCommandInput(args, inputBuffer)
 	defer ci.Free()
 	co := cutil.NewCommandOutput().SetFreeFunc(radosBufferFree)

--- a/rados/command_test.go
+++ b/rados/command_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	osdNumber = 0
+)
+
 func (suite *RadosTestSuite) TestMonCommand() {
 	suite.SetupConnection()
 
@@ -125,6 +129,48 @@ func (suite *RadosTestSuite) TestMgrCommandMalformedCommand() {
 
 	command := []byte("JUNK!")
 	buf, info, err := suite.conn.MgrCommand([][]byte{command})
+	assert.Error(suite.T(), err)
+	assert.NotEqual(suite.T(), info, "")
+	assert.Len(suite.T(), buf, 0)
+}
+
+func (suite *RadosTestSuite) TestOsdCommandDescriptions() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "get_command_descriptions", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.OsdCommand(osdNumber, [][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestOsdCommand() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "version", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.OsdCommand(osdNumber, [][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestOsdCommandMalformedCommand() {
+	suite.SetupConnection()
+
+	command := []byte("JUNK!")
+	buf, info, err := suite.conn.OsdCommand(osdNumber, [][]byte{command})
 	assert.Error(suite.T(), err)
 	assert.NotEqual(suite.T(), info, "")
 	assert.Len(suite.T(), buf, 0)

--- a/rados/command_test.go
+++ b/rados/command_test.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	osdNumber = 0
+	monName   = "a"
 )
 
 func (suite *RadosTestSuite) TestMonCommand() {
@@ -171,6 +172,48 @@ func (suite *RadosTestSuite) TestOsdCommandMalformedCommand() {
 
 	command := []byte("JUNK!")
 	buf, info, err := suite.conn.OsdCommand(osdNumber, [][]byte{command})
+	assert.Error(suite.T(), err)
+	assert.NotEqual(suite.T(), info, "")
+	assert.Len(suite.T(), buf, 0)
+}
+
+func (suite *RadosTestSuite) TestMonCommandTargetDescriptions() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "get_command_descriptions", "format": "json"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.MonCommandTarget(monName, [][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestMonCommandTarget() {
+	suite.SetupConnection()
+
+	command, err := json.Marshal(
+		map[string]string{"prefix": "mon_status"})
+	assert.NoError(suite.T(), err)
+
+	buf, info, err := suite.conn.MonCommandTarget(monName, [][]byte{command})
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), info, "")
+
+	var message map[string]interface{}
+	err = json.Unmarshal(buf, &message)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestMonCommandTargetMalformedCommand() {
+	suite.SetupConnection()
+
+	command := []byte("JUNK!")
+	buf, info, err := suite.conn.MonCommandTarget(monName, [][]byte{command})
 	assert.Error(suite.T(), err)
 	assert.NotEqual(suite.T(), info, "")
 	assert.Len(suite.T(), buf, 0)


### PR DESCRIPTION
This series of changes do a little clean up before wrapping rados_osd_command & rados_mon_command_target and tests.

Fixes: #272 
Fixes: #270 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
