### PR TITLE
Improve and begin integrating 'implements'-tool reporting automation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,13 @@ jobs:
     - name: Run test container
       run: make test-container "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
     - name: Archive coverage results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: "go-ceph-coverage-${{ matrix.ceph_version }}"
         path: "_results/coverage/go-ceph.html"
+    - name: Archive implements results
+      if: "matrix.ceph_version == 'octopus'"
+      uses: actions/upload-artifact@v2
+      with:
+        name: "go-ceph-implements-${{ matrix.ceph_version }}"
+        path: "_results/implements.*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -149,6 +149,7 @@ pre_all_tests() {
     # Prepare Go code
     go get -t -v ${BUILD_TAGS} ./...
     diff -u <(echo -n) <(gofmt -d -s .)
+    make implements
 
     # Reset whole-module coverage file
     echo "mode: count" > "cover.out"
@@ -158,6 +159,15 @@ post_all_tests() {
     if [[ ${COVERAGE} = yes ]]; then
         mkdir -p "${RESULTS_DIR}/coverage"
         show go tool cover -html=cover.out -o "${RESULTS_DIR}/coverage/go-ceph.html"
+    fi
+    if [[ ${COVERAGE} = yes ]] && command -v castxml ; then
+        mkdir -p "${RESULTS_DIR}/coverage"
+        show ./implements --list \
+            --report-json "${RESULTS_DIR}/implements.json" \
+            --report-text "${RESULTS_DIR}/implements.txt" \
+            cephfs rados rbd
+        # output the brief summary info onto stdout
+        grep '^[A-Z]' "${RESULTS_DIR}/implements.txt"
     fi
 }
 

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -5,6 +5,7 @@ ENV CEPH_VERSION=${CEPH_VERSION:-nautilus}
 
 RUN true && \
     yum install -y git wget curl libcephfs-devel librados-devel librbd-devel /usr/bin/cc /usr/bin/c++ make && \
+    (yum install -y /usr/bin/castxml || true) && \
     true
 
 ENV GOTAR=go1.12.17.linux-amd64.tar.gz


### PR DESCRIPTION
This series enhances the implements tool to produce multiple kinds of output in one run of the tool rather than having to run it multiple times.
Then the container and entrypoint script are updated to run the tool after the code coverage report is generated. Unfortunately, getting castxml on the centos7 based containers seems like an inordinate amount of work so I skipped that for now. Only the centos8 (octopus) based container will run the tool.
In the spirit of something-is-better-than-nothing the octopus builds are a good enough starting point.
When all the conditions should be met the json and test output of the implements report files are to be captured by the github workflow.