### PR TITLE
Add RbdImageOption constants for Ceph versions including Octopus

### DIFF
--- a/rbd/options.go
+++ b/rbd/options.go
@@ -69,9 +69,6 @@ const (
 	RbdImageOptionFeaturesClear = ImageOptionFeaturesClear
 	// RbdImageOptionDataPool deprecated alias for ImageOptionDataPool
 	RbdImageOptionDataPool = ImageOptionDataPool
-
-	// introduced with Ceph Mimic
-	//RbdImageOptionFlatten = C.RBD_IMAGE_OPTION_FLATTEN
 )
 
 // ImageOptions represents a group of configurable image options.

--- a/rbd/options_mimic.go
+++ b/rbd/options_mimic.go
@@ -1,0 +1,12 @@
+// +build !luminous
+
+package rbd
+
+// #include <rbd/librbd.h>
+import "C"
+
+const (
+	// ImageOptionFlatten is the representation of RBD_IMAGE_OPTION_FLATTEN
+	// from librbd
+	ImageOptionFlatten = C.RBD_IMAGE_OPTION_FLATTEN
+)

--- a/rbd/options_nautilus.go
+++ b/rbd/options_nautilus.go
@@ -1,0 +1,12 @@
+// +build !luminous,!mimic
+
+package rbd
+
+// #include <rbd/librbd.h>
+import "C"
+
+const (
+	// ImageOptionCloneFormat is the representation of
+	// RBD_IMAGE_OPTION_CLONE_FORMAT from librbd
+	ImageOptionCloneFormat = C.RBD_IMAGE_OPTION_CLONE_FORMAT
+)

--- a/rbd/options_octopus.go
+++ b/rbd/options_octopus.go
@@ -1,0 +1,12 @@
+// +build !luminous,!mimic,!nautilus
+
+package rbd
+
+// #include <rbd/librbd.h>
+import "C"
+
+const (
+	// ImageOptionMirrorImageMode is the representation of
+	// RBD_IMAGE_OPTION_MIRROR_IMAGE_MODE from librbd
+	ImageOptionMirrorImageMode = C.RBD_IMAGE_OPTION_MIRROR_IMAGE_MODE
+)


### PR DESCRIPTION
Recent Ceph versions add more RbdImageOption constants, these were missing in go-ceph.

Closes: #295

## Checklist
- [ ] ~Added tests for features and functional changes~
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
