### PR TITLE
Minor makefile workflow improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CI_IMAGE_NAME = go-ceph-ci
 CONTAINER_CMD ?=
 CONTAINER_OPTS := --security-opt $(shell grep -q selinux /sys/kernel/security/lsm && echo "label=disable" || echo "apparmor:unconfined")
 CONTAINER_CONFIG_DIR := testing/containers/ceph
-VOLUME_FLAGS := 
+VOLUME_FLAGS :=
 CEPH_VERSION := nautilus
 RESULTS_DIR :=
 CHECK_GOFMT_FLAGS := -e -s -l

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test:
 
 .PHONY: test-docker test-container
 test-docker: test-container
-test-container: check-ceph-version $(BUILDFILE) $(RESULTS_DIR)
+test-container: $(BUILDFILE) $(RESULTS_DIR)
 	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(RESULTS_VOLUME) $(CI_IMAGE_TAG)
 
 ifdef RESULTS_DIR
@@ -53,12 +53,6 @@ $(BUILDFILE): $(CONTAINER_CONFIG_DIR)/Dockerfile entrypoint.sh
 	$(CONTAINER_CMD) build --build-arg CEPH_VERSION=$(CEPH_VERSION) -t $(CI_IMAGE_TAG) -f $(CONTAINER_CONFIG_DIR)/Dockerfile .
 	@$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CI_IMAGE_TAG) > $(BUILDFILE)
 	echo $(CEPH_VERSION) >> $(BUILDFILE)
-
-# check-ceph-version checks for the last used Ceph version in the container
-# image and forces a rebuild of the image in case the Ceph version changed
-.PHONY: check-ceph-version
-check-ceph-version:
-	@grep -wq '$(CEPH_VERSION)' $(BUILDFILE) 2>/dev/null || $(RM) $(BUILDFILE)
 
 check: check-revive check-format
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CI_IMAGE_NAME = go-ceph-ci
-CONTAINER_CMD := docker
+CONTAINER_CMD ?=
 CONTAINER_OPTS := --security-opt $(shell grep -q selinux /sys/kernel/security/lsm && echo "label=disable" || echo "apparmor:unconfined")
 CONTAINER_CONFIG_DIR := testing/containers/ceph
 VOLUME_FLAGS := 
@@ -7,6 +7,13 @@ CEPH_VERSION := nautilus
 RESULTS_DIR :=
 CHECK_GOFMT_FLAGS := -e -s -l
 IMPLEMENTS_OPTS :=
+
+ifeq ($(CONTAINER_CMD),)
+	CONTAINER_CMD:=$(shell docker version >/dev/null 2>&1 && echo docker)
+endif
+ifeq ($(CONTAINER_CMD),)
+	CONTAINER_CMD:=$(shell podman version >/dev/null 2>&1 && echo podman)
+endif
 
 # the full name of the marker file including the ceph version
 BUILDFILE=.build.$(CEPH_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build:
 fmt:
 	go fmt ./...
 test:
-	go test -v ./...
+	go test -v -tags $(CEPH_VERSION) ./...
 
 .PHONY: test-docker test-container
 test-docker: test-container
@@ -83,7 +83,7 @@ test-binaries: \
 test-bins: test-binaries
 
 %.test: % force_go_build
-	go test -c ./$<
+	go test -c -tags $(CEPH_VERSION) ./$<
 
 implements:
 	go build -o implements ./contrib/implements


### PR DESCRIPTION
When working locally I was finding it annoying to have to remove the "build marker" just to switch between images based on nautilus, octopus, etc. when testing features that vary by ceph version.
This did not impact the ci because it creates a separate (vm) instance for each run.
Now, the build markers are per- ceph version.

I also made it so the makefile would auto-detect if you have docker vs. podman, similar to, but not the same as the way ceph-csi was doing it.

I removed some trailing whitespace that just looked ugly in my editor. :-)

We now pass `-tags $(CEPH_VERSON)` on the make rules that invoke go test, as we missed that before but because I have nautilus locally I hadn't noticed it until the first octopus only files were added recently.