### PR TITLE
rbd: additional error checking in OpenImage, CreateImage and RemoveImage

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1028,6 +1028,13 @@ func TrashRestore(ioctx *rados.IOContext, id, name string) error {
 //  int rbd_open(rados_ioctx_t io, const char *name,
 //               rbd_image_t *image, const char *snap_name);
 func OpenImage(ioctx *rados.IOContext, name, snapName string) (*Image, error) {
+	if ioctx == nil {
+		return nil, ErrNoIOContext
+	}
+	if name == "" {
+		return nil, ErrNoName
+	}
+
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
@@ -1064,6 +1071,13 @@ func OpenImage(ioctx *rados.IOContext, name, snapName string) (*Image, error) {
 //  int rbd_open_read_only(rados_ioctx_t io, const char *name,
 //                         rbd_image_t *image, const char *snap_name);
 func OpenImageReadOnly(ioctx *rados.IOContext, name, snapName string) (*Image, error) {
+	if ioctx == nil {
+		return nil, ErrNoIOContext
+	}
+	if name == "" {
+		return nil, ErrNoName
+	}
+
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
@@ -1101,6 +1115,13 @@ func OpenImageReadOnly(ioctx *rados.IOContext, name, snapName string) (*Image, e
 //  int rbd_open_by_id(rados_ioctx_t io, const char *id,
 //                     rbd_image_t *image, const char *snap_name);
 func OpenImageById(ioctx *rados.IOContext, id, snapName string) (*Image, error) {
+	if ioctx == nil {
+		return nil, ErrNoIOContext
+	}
+	if id == "" {
+		return nil, ErrNoName
+	}
+
 	cid := C.CString(id)
 	defer C.free(unsafe.Pointer(cid))
 
@@ -1138,6 +1159,13 @@ func OpenImageById(ioctx *rados.IOContext, id, snapName string) (*Image, error) 
 //  int rbd_open_by_id_read_only(rados_ioctx_t io, const char *id,
 //                               rbd_image_t *image, const char *snap_name);
 func OpenImageByIdReadOnly(ioctx *rados.IOContext, id, snapName string) (*Image, error) {
+	if ioctx == nil {
+		return nil, ErrNoIOContext
+	}
+	if id == "" {
+		return nil, ErrNoName
+	}
+
 	cid := C.CString(id)
 	defer C.free(unsafe.Pointer(cid))
 

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1198,7 +1198,12 @@ func OpenImageByIdReadOnly(ioctx *rados.IOContext, id, snapName string) (*Image,
 //  int rbd_create4(rados_ioctx_t io, const char *name, uint64_t size,
 //                 rbd_image_options_t opts);
 func CreateImage(ioctx *rados.IOContext, name string, size uint64, rio *ImageOptions) error {
-
+	if ioctx == nil {
+		return ErrNoIOContext
+	}
+	if name == "" {
+		return ErrNoName
+	}
 	if rio == nil {
 		return RBDError(C.EINVAL)
 	}

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1216,6 +1216,13 @@ func CreateImage(ioctx *rados.IOContext, name string, size uint64, rio *ImageOpt
 // Implements:
 //  int rbd_remove(rados_ioctx_t io, const char *name);
 func RemoveImage(ioctx *rados.IOContext, name string) error {
+	if ioctx == nil {
+		return ErrNoIOContext
+	}
+	if name == "" {
+		return ErrNoName
+	}
+
 	c_name := C.CString(name)
 	defer C.free(unsafe.Pointer(c_name))
 	return getError(C.rbd_remove(cephIoctx(ioctx), c_name))

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -152,10 +152,13 @@ func TestCreateImageWithOptions(t *testing.T) {
 
 	// nil options, causes a panic if not handled correctly
 	name := GetUUID()
+	options := NewRbdImageOptions()
+	err = CreateImage(nil, name, testImageSize, options)
+	assert.Error(t, err)
+	err = CreateImage(ioctx, "", testImageSize, options)
+	assert.Error(t, err)
 	err = CreateImage(ioctx, name, testImageSize, nil)
 	assert.Error(t, err)
-
-	options := NewRbdImageOptions()
 
 	// empty/default options
 	name = GetUUID()

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -1300,6 +1300,12 @@ func TestRemoveImage(t *testing.T) {
 	ioctx, err := conn.OpenIOContext(poolname)
 	require.NoError(t, err)
 
+	// pass invalid parameters
+	err = RemoveImage(nil, "some-name")
+	require.Error(t, err)
+	err = RemoveImage(ioctx, "")
+	require.Error(t, err)
+
 	// trying to remove a non-existent image is an error
 	err = RemoveImage(ioctx, "bananarama")
 	require.Error(t, err)

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -1242,6 +1242,13 @@ func TestOpenImage(t *testing.T) {
 
 	name := GetUUID()
 
+	// pass invalid arguments
+	_, err = OpenImage(nil, "some-image", NoSnapshot)
+	require.Error(t, err)
+	_, err = OpenImage(ioctx, "", NoSnapshot)
+	require.Error(t, err)
+
+	// image does not exist yet
 	_, err = OpenImage(ioctx, name, NoSnapshot)
 	assert.Error(t, err)
 
@@ -1255,6 +1262,12 @@ func TestOpenImage(t *testing.T) {
 	assert.NoError(t, err)
 
 	// open read-only
+	// pass invalid parameters
+	_, err = OpenImageReadOnly(nil, "some-image", NoSnapshot)
+	require.Error(t, err)
+	_, err = OpenImageReadOnly(ioctx, "", NoSnapshot)
+	require.Error(t, err)
+
 	oImage, err = OpenImageReadOnly(ioctx, name, NoSnapshot)
 	assert.NoError(t, err)
 
@@ -1495,6 +1508,16 @@ func TestOpenImageById(t *testing.T) {
 	err = workingImage.Close()
 	assert.NoError(t, err)
 
+	t.Run("InvalidArguments", func(t *testing.T) {
+		_, err = OpenImageById(nil, "some-id", NoSnapshot)
+		require.Error(t, err)
+		_, err = OpenImageById(ioctx, "", NoSnapshot)
+		require.Error(t, err)
+		_, err = OpenImageByIdReadOnly(nil, "some-id", NoSnapshot)
+		require.Error(t, err)
+		_, err = OpenImageByIdReadOnly(ioctx, "", NoSnapshot)
+		require.Error(t, err)
+	})
 	t.Run("ReadWriteBadId", func(t *testing.T) {
 		t.Skip("segfaults due to https://tracker.ceph.com/issues/43178")
 		// phony id


### PR DESCRIPTION
When passing `nil` arguments or empty strings for names some librbd functions may segfault. We do not like this, so we catch the errors early and return something to the called.

## Checklist
- [x] Added tests for features and functional changes
- [ ] ~Public functions and types are documented~
- [x] Standard formatting is applied to Go code

Reported-by: @madhu-1