### PR TITLE
rbd: additional error checking in *PoolMetadata() functions

### DIFF
--- a/rbd/pool_nautilus.go
+++ b/rbd/pool_nautilus.go
@@ -23,6 +23,10 @@ import (
 // Implements:
 //  int rbd_pool_metadata_get(rados_ioctx_t io_ctx, const char *key, char *value, size_t *val_len);
 func GetPoolMetadata(ioctx *rados.IOContext, key string) (string, error) {
+	if ioctx == nil {
+		return "", ErrNoIOContext
+	}
+
 	cKey := C.CString(key)
 	defer C.free(unsafe.Pointer(cKey))
 
@@ -52,6 +56,10 @@ func GetPoolMetadata(ioctx *rados.IOContext, key string) (string, error) {
 // Implements:
 //  int rbd_pool_metadata_set(rados_ioctx_t io_ctx, const char *key, const char *value);
 func SetPoolMetadata(ioctx *rados.IOContext, key, value string) error {
+	if ioctx == nil {
+		return ErrNoIOContext
+	}
+
 	cKey := C.CString(key)
 	defer C.free(unsafe.Pointer(cKey))
 	cValue := C.CString(value)
@@ -66,6 +74,10 @@ func SetPoolMetadata(ioctx *rados.IOContext, key, value string) error {
 // Implements:
 //  int rbd_pool_metadata_remove(rados_ioctx_t io_ctx, const char *key)
 func RemovePoolMetadata(ioctx *rados.IOContext, key string) error {
+	if ioctx == nil {
+		return ErrNoIOContext
+	}
+
 	cKey := C.CString(key)
 	defer C.free(unsafe.Pointer(cKey))
 

--- a/rbd/pool_nautilus_test.go
+++ b/rbd/pool_nautilus_test.go
@@ -30,6 +30,24 @@ func TestPoolMetadata(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("NullKey", func(t *testing.T) {
+		_, err := GetPoolMetadata(ioctx, "")
+		assert.Error(t, err)
+		err = SetPoolMetadata(ioctx, "", "")
+		assert.NoError(t, err)
+		err = RemovePoolMetadata(ioctx, "")
+		assert.NoError(t, err)
+	})
+
+	t.Run("NullIOContext", func(t *testing.T) {
+		_, err := GetPoolMetadata(nil, "someKey")
+		assert.Error(t, err)
+		err = SetPoolMetadata(nil, "someKey", "someValue")
+		assert.Error(t, err)
+		err = RemovePoolMetadata(nil, "someKey")
+		assert.Error(t, err)
+	})
+
 	t.Run("SetGetValues", func(t *testing.T) {
 		var (
 			key1 = "key1"


### PR DESCRIPTION
added a check to validate ioctx in all the three *PoolMetadata() functions namely
GetPoolMetadata, SetPoolMetadata and RemovePoolMetadata

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
