### PR TITLE
Add support for rbd_get_{create,access,modify}_timestamp() functions

### DIFF
--- a/cephfs/statx.go
+++ b/cephfs/statx.go
@@ -7,6 +7,13 @@ package cephfs
 */
 import "C"
 
+import (
+	ts "github.com/ceph/go-ceph/internal/timespec"
+)
+
+// Timespec is a public type for the internal C 'struct timespec'
+type Timespec ts.Timespec
+
 // StatxMask values contain bit-flags indicating what data should be
 // populated by a statx-type call.
 type StatxMask uint32
@@ -109,10 +116,10 @@ func cStructToCephStatx(s C.struct_ceph_statx) *CephStatx {
 		Blocks:  uint64(s.stx_blocks),
 		Dev:     uint64(s.stx_dev),
 		Rdev:    uint64(s.stx_rdev),
-		Atime:   cStructToTimespec(s.stx_atime),
-		Ctime:   cStructToTimespec(s.stx_ctime),
-		Mtime:   cStructToTimespec(s.stx_mtime),
-		Btime:   cStructToTimespec(s.stx_btime),
+		Atime:   Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&s.stx_atime))),
+		Ctime:   Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&s.stx_ctime))),
+		Mtime:   Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&s.stx_mtime))),
+		Btime:   Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&s.stx_btime))),
 		Version: uint64(s.stx_version),
 	}
 }

--- a/internal/timespec/timespec.go
+++ b/internal/timespec/timespec.go
@@ -1,4 +1,4 @@
-package cephfs
+package timespec
 
 /*
 #include <time.h>
@@ -6,6 +6,8 @@ package cephfs
 import "C"
 
 import (
+	"unsafe"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -14,7 +16,13 @@ import (
 // apis that could be lossy with the use of Go time types.
 type Timespec unix.Timespec
 
-func cStructToTimespec(t C.struct_timespec) Timespec {
+// CTimespecPtr is an unsafe pointer wrapping C's `struct timespec`.
+type CTimespecPtr unsafe.Pointer
+
+// CStructToTimespec creates a new Timespec for the C 'struct timespec'.
+func CStructToTimespec(cts CTimespecPtr) Timespec {
+	t := (*C.struct_timespec)(cts)
+
 	return Timespec{
 		Sec:  int64(t.tv_sec),
 		Nsec: int64(t.tv_nsec),

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/ceph/go-ceph/internal/retry"
+	ts "github.com/ceph/go-ceph/internal/timespec"
 	"github.com/ceph/go-ceph/rados"
 )
 
@@ -44,6 +45,9 @@ const (
 	// NoSnapshot indicates that no snapshot name is in use (see OpenImage)
 	NoSnapshot = ""
 )
+
+// Timespec is a public type for the internal C 'struct timespec'
+type Timespec ts.Timespec
 
 // ImageInfo represents the status information for an image.
 type ImageInfo struct {

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -83,3 +83,21 @@ func (image *Image) GetAccessTimestamp() (Timespec, error) {
 
 	return Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&cts))), nil
 }
+
+// GetModifyTimestamp returns the time the rbd image was last modified.
+//
+// Implements:
+//  int rbd_get_modify_timestamp(rbd_image_t image, struct timespec *timestamp);
+func (image *Image) GetModifyTimestamp() (Timespec, error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return Timespec{}, err
+	}
+
+	var cts C.struct_timespec
+
+	if ret := C.rbd_get_modify_timestamp(image.image, &cts); ret < 0 {
+		return Timespec{}, getError(ret)
+	}
+
+	return Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&cts))), nil
+}

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -1,6 +1,7 @@
 // +build !luminous,!mimic
 //
-// Ceph Nautilus is the first release that includes rbd_list2().
+// Ceph Nautilus is the first release that includes rbd_list2() and
+// rbd_get_create_timestamp().
 
 package rbd
 
@@ -14,6 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/ceph/go-ceph/internal/retry"
+	ts "github.com/ceph/go-ceph/internal/timespec"
 	"github.com/ceph/go-ceph/rados"
 )
 
@@ -44,4 +46,22 @@ func GetImageNames(ioctx *rados.IOContext) ([]string, error) {
 		names[i] = C.GoString(image.name)
 	}
 	return names, nil
+}
+
+// GetCreateTimestamp returns the time the rbd image was created.
+//
+// Implements:
+//  int rbd_get_create_timestamp(rbd_image_t image, struct timespec *timestamp);
+func (image *Image) GetCreateTimestamp() (Timespec, error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return Timespec{}, err
+	}
+
+	var cts C.struct_timespec
+
+	if ret := C.rbd_get_create_timestamp(image.image, &cts); ret < 0 {
+		return Timespec{}, getError(ret)
+	}
+
+	return Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&cts))), nil
 }

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -65,3 +65,21 @@ func (image *Image) GetCreateTimestamp() (Timespec, error) {
 
 	return Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&cts))), nil
 }
+
+// GetAccessTimestamp returns the time the rbd image was last accessed.
+//
+// Implements:
+//  int rbd_get_access_timestamp(rbd_image_t image, struct timespec *timestamp);
+func (image *Image) GetAccessTimestamp() (Timespec, error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return Timespec{}, err
+	}
+
+	var cts C.struct_timespec
+
+	if ret := C.rbd_get_access_timestamp(image.image, &cts); ret < 0 {
+		return Timespec{}, getError(ret)
+	}
+
+	return Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&cts))), nil
+}

--- a/rbd/rbd_nautilus_test.go
+++ b/rbd/rbd_nautilus_test.go
@@ -1,0 +1,67 @@
+// +build !luminous,!mimic
+
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImagePropertiesNautilus(t *testing.T) {
+	conn := radosConnect(t)
+	defer conn.Shutdown()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, conn.DeletePool(poolname)) }()
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+	defer ioctx.Destroy()
+
+	name := GetUUID()
+	err = quickCreate(ioctx, name, testImageSize, testImageOrder)
+	require.NoError(t, err)
+
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, img.Remove()) }()
+	defer func() { assert.NoError(t, img.Close()) }()
+
+	_, err = img.GetCreateTimestamp()
+	assert.NoError(t, err)
+}
+
+func TestClosedImageNautilus(t *testing.T) {
+	conn := radosConnect(t)
+	defer conn.Shutdown()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, conn.DeletePool(poolname)) }()
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+	defer ioctx.Destroy()
+
+	name := GetUUID()
+	err = quickCreate(ioctx, name, testImageSize, testImageOrder)
+	assert.NoError(t, err)
+
+	image, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, image.Remove()) }()
+
+	// close the image
+	err = image.Close()
+	assert.NoError(t, err)
+
+	// functions should now fail with an RBDError
+
+	_, err = image.GetCreateTimestamp()
+	assert.Error(t, err)
+}

--- a/rbd/rbd_nautilus_test.go
+++ b/rbd/rbd_nautilus_test.go
@@ -33,6 +33,9 @@ func TestImagePropertiesNautilus(t *testing.T) {
 
 	_, err = img.GetCreateTimestamp()
 	assert.NoError(t, err)
+
+	_, err = img.GetAccessTimestamp()
+	assert.NoError(t, err)
 }
 
 func TestClosedImageNautilus(t *testing.T) {
@@ -63,5 +66,8 @@ func TestClosedImageNautilus(t *testing.T) {
 	// functions should now fail with an RBDError
 
 	_, err = image.GetCreateTimestamp()
+	assert.Error(t, err)
+
+	_, err = image.GetAccessTimestamp()
 	assert.Error(t, err)
 }

--- a/rbd/rbd_nautilus_test.go
+++ b/rbd/rbd_nautilus_test.go
@@ -36,6 +36,9 @@ func TestImagePropertiesNautilus(t *testing.T) {
 
 	_, err = img.GetAccessTimestamp()
 	assert.NoError(t, err)
+
+	_, err = img.GetModifyTimestamp()
+	assert.NoError(t, err)
 }
 
 func TestClosedImageNautilus(t *testing.T) {
@@ -69,5 +72,8 @@ func TestClosedImageNautilus(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = image.GetAccessTimestamp()
+	assert.Error(t, err)
+
+	_, err = image.GetModifyTimestamp()
 	assert.Error(t, err)
 }


### PR DESCRIPTION
Ceph-CSI needs functions to fetch the timestamps from RBD images, these functions have not been implemented in go-ceph/rbd yet.

CephFS already returns a `Timespec` type, which is `golang.org/x/sys/unix.Timespec` compatible. Re-using that in thr rbd package with `cephfs.Timespec` is a little ugly, so the 'proxy type' has been moved under `internal/timespec` package. This might be a little controversial, but I could not think of a different way without duplicating the code too much. This approach does not require the consumers of go-ceph/cephfs to make any changes.

Closes: #309

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
