### PR TITLE
rados: add new WriteOp and ReadOp types & supporting framework

### DIFF
--- a/internal/timespec/timespec.go
+++ b/internal/timespec/timespec.go
@@ -28,3 +28,12 @@ func CStructToTimespec(cts CTimespecPtr) Timespec {
 		Nsec: int64(t.tv_nsec),
 	}
 }
+
+// CopyToCStruct copies the time values from a Timespec to a previously
+// allocated C `struct timespec`. Due to restrictions on Cgo the C pointer
+// must be passed via the CTimespecPtr wrapper.
+func CopyToCStruct(ts Timespec, cts CTimespecPtr) {
+	t := (*C.struct_timespec)(cts)
+	t.tv_sec = C.time_t(ts.Sec)
+	t.tv_nsec = C.long(ts.Nsec)
+}

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -52,6 +52,9 @@ var (
 	// ErrInvalidIOContext may be returned if an api call requires an IOContext
 	// but IOContext is not ready for use.
 	ErrInvalidIOContext = errors.New("IOContext is not ready for use")
+	// ErrOperationIncomplete is returned from write op or read op elements for
+	// which the operation has not been performed yet.
+	ErrOperationIncomplete = errors.New("Operation has not been performed yet")
 )
 
 // Public radosErrors:

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -128,15 +128,10 @@ func (ioctx *IOContext) SetNamespace(namespace string) {
 //  void rados_write_op_create(rados_write_op_t write_op, int exclusive,
 //                             const char* category)
 func (ioctx *IOContext) Create(oid string, exclusive CreateOption) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
-
-	op := C.rados_create_write_op()
-	C.rados_write_op_create(op, C.int(exclusive), nil)
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
-	C.rados_release_write_op(op)
-
-	return getError(ret)
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(exclusive)
+	return op.operateCompat(ioctx, oid)
 }
 
 // Write writes len(data) bytes to the object with key oid starting at byte

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -284,14 +284,8 @@ func (ioctx *IOContext) RmOmapKeys(oid string, keys []string) error {
 
 // CleanOmap clears the omap `oid`
 func (ioctx *IOContext) CleanOmap(oid string) error {
-	c_oid := C.CString(oid)
-	defer C.free(unsafe.Pointer(c_oid))
-
-	op := C.rados_create_write_op()
-	C.rados_write_op_omap_clear(op)
-
-	ret := C.rados_write_op_operate(op, ioctx.ioctx, c_oid, nil, 0)
-	C.rados_release_write_op(op)
-
-	return getError(ret)
+	op := CreateWriteOp()
+	defer op.Release()
+	op.CleanOmap()
+	return op.operateCompat(ioctx, oid)
 }

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 )
 
+// omapSetElement is a write op element used to track state, especially
+// C memory, across the setup and use of a WriteOp.
 type omapSetElement struct {
 	// inputs:
 	pairs map[string][]byte
@@ -195,6 +197,8 @@ func (oge *OmapGetElement) More() bool {
 	return oge.more != 0
 }
 
+// omapRmKeysElement is a write element used to track state, especially
+// C memory, across the setup and use of a WriteOp.
 type omapRmKeysElement struct {
 	// inputs:
 	keys []string

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -14,6 +14,9 @@ import (
 // omapSetElement is a write op element used to track state, especially
 // C memory, across the setup and use of a WriteOp.
 type omapSetElement struct {
+	withoutReset
+	withoutUpdate
+
 	// inputs:
 	pairs map[string][]byte
 
@@ -90,13 +93,6 @@ func (oe *omapSetElement) free() {
 		C.free(p)
 	}
 	oe.refs = nil
-}
-
-func (*omapSetElement) reset() {
-}
-
-func (*omapSetElement) update() error {
-	return nil
 }
 
 // OmapKeyValue items are returned by the OmapGetElement's Next call.
@@ -200,6 +196,9 @@ func (oge *OmapGetElement) More() bool {
 // omapRmKeysElement is a write element used to track state, especially
 // C memory, across the setup and use of a WriteOp.
 type omapRmKeysElement struct {
+	withoutReset
+	withoutUpdate
+
 	// inputs:
 	keys []string
 
@@ -243,13 +242,6 @@ func (oe *omapRmKeysElement) free() {
 		C.free(p)
 	}
 	oe.refs = nil
-}
-
-func (*omapRmKeysElement) reset() {
-}
-
-func (*omapRmKeysElement) update() error {
-	return nil
 }
 
 // SetOmap appends the map `pairs` to the omap `oid`

--- a/rados/operation.go
+++ b/rados/operation.go
@@ -132,3 +132,24 @@ func (o *operation) freeElements() {
 		freeElement(o.elements[i])
 	}
 }
+
+// withoutReset can be embedded in a struct to help indicate
+// the type implements the opElement interface but has a no-op
+// update function.
+type withoutReset struct{}
+
+func (*withoutReset) reset() {}
+
+// withoutUpdate can be embedded in a struct to help indicate
+// the type implements the opElement interface but has a no-op
+// update function.
+type withoutUpdate struct{}
+
+func (*withoutUpdate) update() error { return nil }
+
+// withoutFree can be embedded in a struct to help indicate
+// the type implements the opElement interface but has a no-op
+// free function.
+type withoutFree struct{}
+
+func (*withoutFree) free() {}

--- a/rados/operation.go
+++ b/rados/operation.go
@@ -1,0 +1,134 @@
+package rados
+
+import "C"
+
+import (
+	"fmt"
+)
+
+// The file operation.go exists to support both read op and write op types that
+// have some pretty common behaviors between them. In C/C++ its assumed that
+// the buffer types and other pointers will not be freed between passing them
+// to the action setup calls (things like rados_write_op_write or
+// rados_read_op_omap_get_vals2) and the call to Operate(...).  Since there's
+// nothing stopping one from sleeping for hours between these calls, or passing
+// the op to other functions and calling Operate there, we want a mechanism
+// that's (fairly) simple to understand and won't run afoul of Go's garbage
+// collection.  That's one reason the operation type tracks the elements (the
+// parts that track complex inputs and outputs) so that as long as the op
+// exists it will have a reference to the element, which will have references
+// to the C language types.
+
+// OperationError is an error type that may be returned an Operate call and
+// captures both the error from operating any any data conversion errors that
+// may have occurred.
+type OperationError struct {
+	flavor        string
+	OpError       error
+	ElementErrors []error
+}
+
+func (e OperationError) Error() string {
+	s := fmt.Sprintf("%s operation error:", e.flavor)
+	count := 0
+	if e.OpError != nil {
+		s = fmt.Sprintf("%s (op) %s", s, e.OpError.Error())
+		count++
+	}
+	var sep string
+	for i, ee := range e.ElementErrors {
+		sep = ""
+		if count > 0 {
+			sep = ","
+		}
+		s = fmt.Sprintf("%s%s (%d) %s", s, sep, i+1, ee.Error())
+		count++
+	}
+	return s
+}
+
+// Unwrap will return the first error returned from an operation or nil
+// if no error is in set.
+func (e OperationError) Unwrap() error {
+	if e.OpError != nil {
+		return e.OpError
+	}
+	for _, ee := range e.ElementErrors {
+		return ee
+	}
+	return nil
+}
+
+// opElement provides an interface for types that are tied to the management of
+// data being input or output from write ops and read ops. The elements are
+// meant to simplify the internals of the ops themselves and be exportable when
+// appropriate. If an element is not being exported it should not be returned
+// from an ops action function. If the element is exported it should be
+// returned from an ops action function.
+//
+// Not all types implementing opElement are expected to need all the functions
+// in the interface. However, for the sake of simplicity on the op side, we use
+// the same interface for all cases and expect those implementing opElement
+// just add empty funcs. Since this in a non-public interface this should not
+// be much of a burden, hopefully.
+type opElement interface {
+	// reset will be called before the op's Operate function.  It can be used
+	// to reset state between uses of Operate, as it can be called multiple
+	// times.
+	reset()
+	// update will be called after the op's Operate function. It can be used
+	// to convert values from C and cache them and/or communicate a failure
+	// of the action associated with the element.
+	update() error
+	// free will be called to free any resources, especially C memory, that
+	// the element is managing.
+	free()
+}
+
+// freeElement calls the free method of the opElement if it is valid.
+func freeElement(oe opElement) {
+	if oe != nil {
+		oe.free()
+	}
+}
+
+// operation represents some of the shared underlying mechanisms for
+// both read and write op types.
+type operation struct {
+	elements []opElement
+}
+
+// reset all of the elements this operation contains.
+func (o *operation) reset() {
+	for i := range o.elements {
+		o.elements[i].reset()
+	}
+}
+
+// finish the operation (the Operate call) by updating all the elements and
+// collecting any errors from them or the librados operate call.
+func (o *operation) finish(flavor string, ret C.int) error {
+	elementErrors := make([]error, 0)
+	for i := range o.elements {
+		err := o.elements[i].update()
+		if err != nil {
+			elementErrors = append(elementErrors, err)
+		}
+	}
+	if ret == 0 && len(elementErrors) == 0 {
+		return nil
+	}
+	return OperationError{
+		flavor:        flavor,
+		OpError:       getError(ret),
+		ElementErrors: elementErrors,
+	}
+}
+
+// freeElements will call the free method of all the elements this operation
+// contains.
+func (o *operation) freeElements() {
+	for i := range o.elements {
+		freeElement(o.elements[i])
+	}
+}

--- a/rados/read_op.go
+++ b/rados/read_op.go
@@ -55,3 +55,22 @@ func (r *ReadOp) operateCompat(ioctx *IOContext, oid string) error {
 		return err
 	}
 }
+
+// GetOmapValues is used to iterate over a set, or sub-set, of omap keys
+// as part of a read operation. An OmapGetElement is returned from this
+// function. The OmapGetElement may be used to iterate over the key-value
+// pairs after the Operate call has been performed.
+func (r *ReadOp) GetOmapValues(startAfter, filterPrefix string, maxReturn uint64) *OmapGetElement {
+	oge := newOmapGetElement(startAfter, filterPrefix, maxReturn)
+	r.elements = append(r.elements, oge)
+	C.rados_read_op_omap_get_vals2(
+		r.op,
+		oge.cStartAfter,
+		oge.cFilterPrefix,
+		C.uint64_t(oge.maxReturn),
+		&oge.iter,
+		&oge.more,
+		&oge.rval,
+	)
+	return oge
+}

--- a/rados/read_op.go
+++ b/rados/read_op.go
@@ -56,6 +56,14 @@ func (r *ReadOp) operateCompat(ioctx *IOContext, oid string) error {
 	}
 }
 
+// AssertExists assures the object targeted by the read op exists.
+//
+// Implements:
+//  void rados_read_op_assert_exists(rados_read_op_t read_op);
+func (r *ReadOp) AssertExists() {
+	C.rados_read_op_assert_exists(r.op)
+}
+
 // GetOmapValues is used to iterate over a set, or sub-set, of omap keys
 // as part of a read operation. An OmapGetElement is returned from this
 // function. The OmapGetElement may be used to iterate over the key-value

--- a/rados/read_op.go
+++ b/rados/read_op.go
@@ -1,0 +1,57 @@
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <errno.h>
+// #include <stdlib.h>
+// #include <rados/librados.h>
+//
+import "C"
+
+import (
+	"unsafe"
+)
+
+// ReadOp manages a set of discrete object read actions that will be performed
+// together atomically.
+type ReadOp struct {
+	operation
+	op C.rados_read_op_t
+}
+
+// CreateReadOp returns a newly constructed read operation.
+func CreateReadOp() *ReadOp {
+	return &ReadOp{
+		op: C.rados_create_read_op(),
+	}
+}
+
+// Release the resources associated with this read operation.
+func (r *ReadOp) Release() {
+	C.rados_release_read_op(r.op)
+	r.freeElements()
+}
+
+// Operate will perform the operation(s).
+func (r *ReadOp) Operate(ioctx *IOContext, oid string, flags OperationFlags) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
+
+	r.reset()
+	ret := C.rados_read_op_operate(r.op, ioctx.ioctx, cOid, C.int(flags))
+	return r.finish("read", ret)
+}
+
+func (r *ReadOp) operateCompat(ioctx *IOContext, oid string) error {
+	switch err := r.Operate(ioctx, oid, OperationNoFlag).(type) {
+	case nil:
+		return nil
+	case OperationError:
+		return err.Unwrap()
+	default:
+		return err
+	}
+}

--- a/rados/read_op_test.go
+++ b/rados/read_op_test.go
@@ -1,0 +1,133 @@
+package rados
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestReadOpAssertExists() {
+	suite.SetupConnection()
+	oid := "TestReadOpAssertExists"
+
+	wrop := CreateWriteOp()
+	defer wrop.Release()
+	wrop.Create(CreateIdempotent)
+	err := wrop.Operate(suite.ioctx, oid, OperationNoFlag)
+	assert.NoError(suite.T(), err)
+
+	op := CreateReadOp()
+	defer op.Release()
+	op.AssertExists()
+	err = op.Operate(suite.ioctx, oid, OperationNoFlag)
+	assert.NoError(suite.T(), err)
+
+	op2 := CreateReadOp()
+	defer op2.Release()
+	op2.AssertExists()
+	err = op2.Operate(suite.ioctx, oid+"junk", OperationNoFlag)
+	assert.Error(suite.T(), err)
+}
+
+func omeMap(ome *OmapGetElement) map[string][]byte {
+	r := make(map[string][]byte)
+	for {
+		kv, err := ome.Next()
+		if err != nil {
+			panic(err)
+		}
+		if kv == nil {
+			break
+		}
+		r[kv.Key] = kv.Value
+	}
+	return r
+}
+
+func (suite *RadosTestSuite) TestReadOpGetOmapValues() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+	oid := "TestReadOpGetOmapValues"
+
+	wrop := CreateWriteOp()
+	defer wrop.Release()
+	wrop.Create(CreateIdempotent)
+	wrop.SetOmap(map[string][]byte{
+		"tos.captain":       []byte("Kirk"),
+		"tos.first-officer": []byte("Spock"),
+		"tos.doctor":        []byte("McCoy"),
+		"tng.captain":       []byte("Picard"),
+		"tng.first-officer": []byte("Riker"),
+		"tng.doctor":        []byte("Crusher"),
+		"random.value":      []byte("foobar"),
+		"no.value":          []byte(""),
+	})
+	err := wrop.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	suite.T().Run("simple", func(t *testing.T) {
+		ta := assert.New(t)
+		op := CreateReadOp()
+		defer op.Release()
+		op.AssertExists()
+		ome := op.GetOmapValues("", "", 16)
+		err = op.Operate(suite.ioctx, oid, OperationNoFlag)
+		ta.NoError(err)
+
+		omap := omeMap(ome)
+		ta.Len(omap, 8)
+		ta.Contains(omap, "tos.captain")
+		ta.Contains(omap, "tng.captain")
+		ta.False(ome.More())
+	})
+
+	suite.T().Run("twoIterations", func(t *testing.T) {
+		// test two iterations over different subsets of omap keys
+		ta := assert.New(t)
+		op := CreateReadOp()
+		defer op.Release()
+		op.AssertExists()
+		ome1 := op.GetOmapValues("", "tos", 16)
+		ome2 := op.GetOmapValues("", "tng", 16)
+		err = op.Operate(suite.ioctx, oid, OperationNoFlag)
+		ta.NoError(err)
+
+		omap1 := omeMap(ome1)
+		ta.Len(omap1, 3)
+		ta.Contains(omap1, "tos.captain")
+		ta.Contains(omap1, "tos.first-officer")
+		ta.Contains(omap1, "tos.doctor")
+		omap2 := omeMap(ome2)
+		ta.Len(omap2, 3)
+		ta.Contains(omap2, "tng.captain")
+		ta.Contains(omap2, "tng.first-officer")
+		ta.Contains(omap2, "tng.doctor")
+	})
+
+	suite.T().Run("checkForMore", func(t *testing.T) {
+		// test two iterations over different subsets of omap keys
+		ta := assert.New(t)
+		op := CreateReadOp()
+		defer op.Release()
+		op.AssertExists()
+		ome := op.GetOmapValues("", "", 6)
+		err = op.Operate(suite.ioctx, oid, OperationNoFlag)
+		ta.NoError(err)
+
+		omap1 := omeMap(ome)
+		ta.Len(omap1, 6)
+		ta.True(ome.More())
+	})
+
+	suite.T().Run("iterateTooEarly", func(t *testing.T) {
+		// test two iterations over different subsets of omap keys
+		ta := assert.New(t)
+		op := CreateReadOp()
+		defer op.Release()
+		op.AssertExists()
+		ome := op.GetOmapValues("", "", 6)
+		_, err := ome.Next()
+		ta.Error(err)
+		ta.Equal(ErrOperationIncomplete, err)
+	})
+}

--- a/rados/write_element.go
+++ b/rados/write_element.go
@@ -8,6 +8,10 @@ import (
 )
 
 type writeElement struct {
+	withoutReset
+	withoutUpdate
+	withoutFree
+
 	// inputs:
 	b []byte
 
@@ -27,7 +31,3 @@ func newWriteElement(b []byte, writeLen, offset uint64) *writeElement {
 		cOffset:   C.uint64_t(offset),
 	}
 }
-
-func (*writeElement) reset()        {}
-func (*writeElement) update() error { return nil }
-func (*writeElement) free()         {}

--- a/rados/write_element.go
+++ b/rados/write_element.go
@@ -1,0 +1,33 @@
+package rados
+
+// #include <stdint.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+type writeElement struct {
+	// inputs:
+	b []byte
+
+	// arguments:
+	cBuffer   *C.char
+	cDataLen  C.size_t
+	cWriteLen C.size_t
+	cOffset   C.uint64_t
+}
+
+func newWriteElement(b []byte, writeLen, offset uint64) *writeElement {
+	return &writeElement{
+		b:         b,
+		cBuffer:   (*C.char)(unsafe.Pointer(&b[0])),
+		cDataLen:  C.size_t(len(b)),
+		cWriteLen: C.size_t(writeLen),
+		cOffset:   C.uint64_t(offset),
+	}
+}
+
+func (*writeElement) reset()        {}
+func (*writeElement) update() error { return nil }
+func (*writeElement) free()         {}

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -80,3 +80,8 @@ func (w *WriteOp) RmOmapKeys(keys []string) {
 		oe.cKeys,
 		oe.cNum)
 }
+
+// CleanOmap clears the omap `oid`
+func (w *WriteOp) CleanOmap() {
+	C.rados_write_op_omap_clear(w.op)
+}

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -85,3 +85,11 @@ func (w *WriteOp) RmOmapKeys(keys []string) {
 func (w *WriteOp) CleanOmap() {
 	C.rados_write_op_omap_clear(w.op)
 }
+
+// AssertExists assures the object targeted by the write op exists.
+//
+// Implements:
+//  void rados_write_op_assert_exists(rados_write_op_t write_op);
+func (w *WriteOp) AssertExists() {
+	C.rados_write_op_assert_exists(w.op)
+}

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -70,3 +70,13 @@ func (w *WriteOp) SetOmap(pairs map[string][]byte) {
 		oe.cLengths,
 		oe.cNum)
 }
+
+// RmOmapKeys removes the specified `keys` from the omap `oid`
+func (w *WriteOp) RmOmapKeys(keys []string) {
+	oe := newOmapRmKeysElement(keys)
+	w.elements = append(w.elements, oe)
+	C.rados_write_op_omap_rm_keys(
+		w.op,
+		oe.cKeys,
+		oe.cNum)
+}

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -11,6 +11,35 @@ import (
 	"unsafe"
 )
 
+// OperationFlags control the behavior of read an write operations.
+type OperationFlags int
+
+const (
+	// OperationNoFlag indicates no special behavior is requested.
+	OperationNoFlag = OperationFlags(C.LIBRADOS_OPERATION_NOFLAG)
+	// OperationBalanceReads TODO
+	OperationBalanceReads = OperationFlags(C.LIBRADOS_OPERATION_BALANCE_READS)
+	// OperationLocalizeReads TODO
+	OperationLocalizeReads = OperationFlags(C.LIBRADOS_OPERATION_LOCALIZE_READS)
+	// OperationOrderReadsWrites TODO
+	OperationOrderReadsWrites = OperationFlags(C.LIBRADOS_OPERATION_ORDER_READS_WRITES)
+	// OperationIgnoreCache TODO
+	OperationIgnoreCache = OperationFlags(C.LIBRADOS_OPERATION_IGNORE_CACHE)
+	// OperationSkipRWLocks TODO
+	OperationSkipRWLocks = OperationFlags(C.LIBRADOS_OPERATION_SKIPRWLOCKS)
+	// OperationIgnoreOverlay TODO
+	OperationIgnoreOverlay = OperationFlags(C.LIBRADOS_OPERATION_IGNORE_OVERLAY)
+	// OperationFullTry send request to a full cluster or pool, ops such as delete
+	// can succeed while other ops will return out-of-space errors.
+	OperationFullTry = OperationFlags(C.LIBRADOS_OPERATION_FULL_TRY)
+	// OperationFullForce TODO
+	OperationFullForce = OperationFlags(C.LIBRADOS_OPERATION_FULL_FORCE)
+	// OperationIgnoreRedirect TODO
+	OperationIgnoreRedirect = OperationFlags(C.LIBRADOS_OPERATION_IGNORE_REDIRECT)
+	// OperationOrderSnap TODO -- FIXME post-luminous
+	//OperationOrderSnap = OperationFlags(C.LIBRADOS_OPERATION_ORDERSNAP)
+)
+
 // WriteOp manages a set of discrete actions that will be performed together
 // atomically.
 type WriteOp struct {

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -93,3 +93,56 @@ func (w *WriteOp) CleanOmap() {
 func (w *WriteOp) AssertExists() {
 	C.rados_write_op_assert_exists(w.op)
 }
+
+// Write a given byte slice at the supplied offset.
+//
+// Implements:
+//  void rados_write_op_write(rados_write_op_t write_op,
+//                                       const char *buffer,
+//                                       size_t len,
+//                                       uint64_t offset);
+func (w *WriteOp) Write(b []byte, offset uint64) {
+	oe := newWriteElement(b, 0, offset)
+	w.elements = append(w.elements, oe)
+	C.rados_write_op_write(
+		w.op,
+		oe.cBuffer,
+		oe.cDataLen,
+		oe.cOffset)
+}
+
+// WriteFull writes a given byte slice as the whole object,
+// atomically replacing it.
+//
+// Implements:
+//  void rados_write_op_write_full(rados_write_op_t write_op,
+//                                 const char *buffer,
+//                                 size_t len);
+func (w *WriteOp) WriteFull(b []byte) {
+	oe := newWriteElement(b, 0, 0)
+	w.elements = append(w.elements, oe)
+	C.rados_write_op_write_full(
+		w.op,
+		oe.cBuffer,
+		oe.cDataLen)
+}
+
+// WriteSame write a given byte slice to the object multiple times, until
+// writeLen is satisfied.
+//
+// Implements:
+//  void rados_write_op_writesame(rados_write_op_t write_op,
+//                                const char *buffer,
+//                                size_t data_len,
+//                                size_t write_len,
+//                                uint64_t offset);
+func (w *WriteOp) WriteSame(b []byte, writeLen, offset uint64) {
+	oe := newWriteElement(b, writeLen, offset)
+	w.elements = append(w.elements, oe)
+	C.rados_write_op_writesame(
+		w.op,
+		oe.cBuffer,
+		oe.cDataLen,
+		oe.cWriteLen,
+		oe.cOffset)
+}

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -1,0 +1,60 @@
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <errno.h>
+// #include <stdlib.h>
+// #include <rados/librados.h>
+//
+import "C"
+
+import (
+	"unsafe"
+)
+
+// WriteOp manages a set of discrete actions that will be performed together
+// atomically.
+type WriteOp struct {
+	operation
+	op C.rados_write_op_t
+}
+
+// CreateWriteOp returns a newly constructed write operation.
+func CreateWriteOp() *WriteOp {
+	return &WriteOp{
+		op: C.rados_create_write_op(),
+	}
+}
+
+// Release the resources associated with this write operation.
+func (w *WriteOp) Release() {
+	C.rados_release_write_op(w.op)
+	w.freeElements()
+}
+
+// Operate will perform the operation(s).
+func (w *WriteOp) Operate(ioctx *IOContext, oid string) error {
+	cOid := C.CString(oid)
+	defer C.free(unsafe.Pointer(cOid))
+
+	w.reset()
+	ret := C.rados_write_op_operate(w.op, ioctx.ioctx, cOid, nil, 0)
+	return w.finish("write", ret)
+}
+
+func (w *WriteOp) operateCompat(ioctx *IOContext, oid string) error {
+	switch err := w.Operate(ioctx, oid).(type) {
+	case nil:
+		return nil
+	case OperationError:
+		return err.Unwrap()
+	default:
+		return err
+	}
+}
+
+// Create a rados object.
+func (w *WriteOp) Create(exclusive CreateOption) {
+	// category, the 3rd param, is deprecated and has no effect so we do not
+	// implement it in go-ceph
+	C.rados_write_op_create(w.op, C.int(exclusive), nil)
+}

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -58,3 +58,15 @@ func (w *WriteOp) Create(exclusive CreateOption) {
 	// implement it in go-ceph
 	C.rados_write_op_create(w.op, C.int(exclusive), nil)
 }
+
+// SetOmap appends the map `pairs` to the omap `oid`
+func (w *WriteOp) SetOmap(pairs map[string][]byte) {
+	oe := newOmapSetElement(pairs)
+	w.elements = append(w.elements, oe)
+	C.rados_write_op_omap_set(
+		w.op,
+		oe.cKeys,
+		oe.cValues,
+		oe.cLengths,
+		oe.cNum)
+}

--- a/rados/write_op_test.go
+++ b/rados/write_op_test.go
@@ -1,0 +1,232 @@
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+// timeStamp generates a dummy Timespec value.
+func timeStamp() Timespec {
+	// Future TODO (maybe?) - vary the value?
+	return Timespec{342334800, 0}
+}
+
+func (suite *RadosTestSuite) TestWriteOpCreate() {
+	suite.SetupConnection()
+
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	err := op.Operate(suite.ioctx, "TestWriteOpCreate", OperationNoFlag)
+	assert.NoError(suite.T(), err)
+
+	op2 := CreateWriteOp()
+	defer op2.Release()
+	op.Create(CreateExclusive)
+	err = op.Operate(suite.ioctx, "TestWriteOpCreate", OperationNoFlag)
+	assert.Error(suite.T(), err)
+}
+
+func (suite *RadosTestSuite) TestWriteOpCreateWithTimestamp() {
+	suite.SetupConnection()
+
+	oid := "TestWriteOpCreateWithTimestamp"
+	gts := timeStamp()
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	err := op.OperateWithMtime(suite.ioctx, oid, gts, OperationNoFlag)
+	assert.NoError(suite.T(), err)
+
+	s, err := suite.ioctx.Stat(oid)
+	assert.NoError(suite.T(), err)
+	statTime := s.ModTime.Unix()
+	assert.Equal(suite.T(), gts.Sec, statTime)
+}
+
+func (suite *RadosTestSuite) TestWriteOpSetOmap() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestWriteOpSetOmap"
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	op.SetOmap(map[string][]byte{
+		"alice":   []byte("car"),
+		"boss":    []byte("office"),
+		"catbert": []byte("dungeon"),
+	})
+	err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	// the 2nd set of omap values should not be applied because
+	// the Create will fail to exclusively make the object
+	op2 := CreateWriteOp()
+	defer op2.Release()
+	op.Create(CreateExclusive)
+	op.SetOmap(map[string][]byte{
+		"alice":   []byte("home"),
+		"boss":    []byte("golf course"),
+		"catbert": []byte("dungeon"),
+	})
+	err = op.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.Error(err)
+
+	fetched, err := suite.ioctx.GetOmapValues(oid, "", "", 10)
+	ta.NoError(err)
+	ta.Equal("car", string(fetched["alice"]))
+	ta.Equal("office", string(fetched["boss"]))
+}
+
+func (suite *RadosTestSuite) TestWriteOpRmOmapKeys() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestWriteOpRmOmapKeys"
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	op.SetOmap(map[string][]byte{
+		"alice":   []byte("car"),
+		"boss":    []byte("office"),
+		"catbert": []byte("dungeon"),
+	})
+	err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	op2 := CreateWriteOp()
+	defer op2.Release()
+	op2.Create(CreateIdempotent)
+	op2.SetOmap(map[string][]byte{
+		"dogbert": []byte("lab"),
+	})
+	op2.RmOmapKeys([]string{"catbert"})
+	err = op2.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	fetched, err := suite.ioctx.GetOmapValues(oid, "", "", 10)
+	ta.NoError(err)
+	ta.Len(fetched, 3)
+	ta.Equal("car", string(fetched["alice"]))
+	ta.Equal("office", string(fetched["boss"]))
+	ta.Equal("lab", string(fetched["dogbert"]))
+	ta.NotContains(fetched, "catbert")
+}
+
+func (suite *RadosTestSuite) TestWriteOpCleanOmap() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestWriteOpCleanOmap"
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	op.SetOmap(map[string][]byte{
+		"alice":   []byte("car"),
+		"boss":    []byte("office"),
+		"catbert": []byte("dungeon"),
+	})
+	err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	// this test simulates wanting to start a fresh new set of
+	// omap keys, atomically clearing and setting a new key & value.
+	op2 := CreateWriteOp()
+	defer op2.Release()
+	op2.Create(CreateIdempotent)
+	op2.CleanOmap()
+	op2.SetOmap(map[string][]byte{
+		"dogbert": []byte("lab"),
+	})
+	op2.RmOmapKeys([]string{"catbert"})
+	err = op2.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	fetched, err := suite.ioctx.GetOmapValues(oid, "", "", 10)
+	ta.NoError(err)
+	ta.Len(fetched, 1)
+	ta.Equal("lab", string(fetched["dogbert"]))
+}
+
+func (suite *RadosTestSuite) TestWriteOpAssertExists() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestWriteOpRmOmapKeys"
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	op2 := CreateWriteOp()
+	defer op2.Release()
+	op2.AssertExists()
+	op2.CleanOmap()
+	err = op2.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	op3 := CreateWriteOp()
+	defer op3.Release()
+	op3.AssertExists()
+	op3.CleanOmap()
+	err = op3.Operate(suite.ioctx, oid+"dne", OperationNoFlag)
+	ta.Error(err)
+}
+
+func (suite *RadosTestSuite) TestWriteOpWrite() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestWriteOpWrite"
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	op.Write([]byte("go-go-gadget"), 0)
+	op.Write([]byte("ceph project!"), 6)
+	err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	d := make([]byte, 32)
+	l, err := suite.ioctx.Read(oid, d, 0)
+	ta.NoError(err)
+	ta.Equal("go-go-ceph project!", string(d[:l]))
+}
+
+func (suite *RadosTestSuite) TestWriteOpWriteFull() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestWriteOpWriteFull"
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	op.WriteFull([]byte("one, two"))
+	op.WriteFull([]byte("buckle my shoe"))
+	err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	d := make([]byte, 32)
+	l, err := suite.ioctx.Read(oid, d, 0)
+	ta.NoError(err)
+	ta.Equal("buckle my shoe", string(d[:l]))
+}
+
+func (suite *RadosTestSuite) TestWriteOpWriteSame() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestWriteOpWriteSame"
+	op := CreateWriteOp()
+	defer op.Release()
+	op.Create(CreateIdempotent)
+	op.WriteSame([]byte("repetition "), 44, 0)
+	op.Write([]byte("is fun"), 44)
+	err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	d := make([]byte, 64)
+	l, err := suite.ioctx.Read(oid, d, 0)
+	ta.NoError(err)
+	ta.Equal("repetition repetition repetition repetition is fun", string(d[:l]))
+}


### PR DESCRIPTION
When we added IOContext.Create(...) in pr #160 we had a brief discussion about exposing the full extent of the rados_write_op_* (and implicitly, rados_read_op_*) APIs in librados.  As a background task I've been working on that on and off since. I'm now finally happy enough with an approach to that API that I want to share with you all for feedback.


Because these are basically "batch" operations that collect many actions into a single op, our API both needs to reflect that and not allow the Go garbage collector to free C memory that might be needed at the time the rados_(read|write)_op_operate calls are made. In C there's basically the op and the "actions" which are the functions (set omaps, write data, etc). This series introduces an extra concept called an element, which is our "noun" corresponding to the input/output of the action. If the element is not exported it is only used for managing memory within the op. If the element is exported, then it will also be used by the caller to fetch results for action, after the op is performed. Please see comments in the code for more details.

The functions I implemented for this PR are quite incomplete and may even seem somewhat random. I wanted to get a good enough selection to make sure the interface for the elements and the approach was complete but not too heavyweight. Any functions already in the code have been converted to the new style internally, and a few additional functions have been added for validation. Once, we are happy with the general approach adding functions to the ReadOp and WriteOp types can be done case-by-case in follow up PRs.

There are few things still left undone. In particular, very few of the constants in librados for the flags argument to the operate calls have documentation comments. Rather than spend a lot of time looking them up and further delaying this PR, I left "TODO" on many of them.

I was also very very temped to add a Map() call to the OmapGetElement as I'm quite convinced the common use case would be to get your omap key-value pairs and shove them into a map. However, I resisted the temptation this time. But I may try to it in in a later PR. :-)

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
