### PR TITLE
rbd: Add UpdateWatch, Unwatch, and rbd metadata change watch callback support

### DIFF
--- a/rbd/callback_shims_mimic.go
+++ b/rbd/callback_shims_mimic.go
@@ -1,0 +1,15 @@
+// +build !luminous
+
+package rbd
+
+/*
+
+#include <rbd/librbd.h>
+
+extern void imageWatchCallback(int index);
+
+void callWatchCallback(int index) {
+	imageWatchCallback(index);
+}
+*/
+import "C"


### PR DESCRIPTION
These patches add support for setting watches on rbd images via a new UpdateWatch function implementing rbd_update_watch as well as Unwatch implementing rbd_update_unwatch, to remove the watch. Tests are included, along with an extensive test case using watch callbacks to feed a go channel. This test exercises multiples watches at once as well as interaction between C and Go code.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
