### PR TITLE
testing: update container packages before installing new ones

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -4,6 +4,8 @@ FROM ceph/daemon-base:latest-${CEPH_VERSION:-nautilus}
 ENV CEPH_VERSION=${CEPH_VERSION:-nautilus}
 
 RUN true && \
+    yum clean all && \
+    ( if [ "${CEPH_VERSION}" = "octopus" ]; then dnf install -y --repo BaseOS 'dnf-command(config-manager)' && dnf config-manager --set-disabled epel && dnf update -y; fi ) && \
     yum install -y git wget curl libcephfs-devel librados-devel librbd-devel /usr/bin/cc /usr/bin/c++ make && \
     (yum install -y /usr/bin/castxml || true) && \
     true


### PR DESCRIPTION
On octopus taking in the -devel packages causes *some* of the packages
to be updated but not all. This apparently makes ceph-fuse fail to
start correctly by blocking forever. This works around that issue.

fixes: #323 



