### PR TITLE
Export cephfs List and Names functions

### DIFF
--- a/cephfs/directory.go
+++ b/cephfs/directory.go
@@ -191,11 +191,6 @@ func (dir *Directory) RewindDir() {
 	C.ceph_rewinddir(dir.mount.mount, dir.dir)
 }
 
-// dirEntries provides a convenient wrapper around slices of DirEntry items.
-// For example, use the Names() call to easily get only the names from a
-// DirEntry slice.
-type dirEntries []*DirEntry
-
 // List returns all the contents of a directory as a dirEntries slice.
 //
 // List is implemented using ReadDir. If any of the calls to ReadDir returns
@@ -204,11 +199,11 @@ type dirEntries []*DirEntry
 // the entries return value even when an error is returned.
 // List rewinds the handle every time it is called to get a full
 // listing of directory contents.
-func (dir *Directory) List() (dirEntries, error) {
+func (dir *Directory) List() ([]*DirEntry, error) {
 	var (
 		err     error
 		entry   *DirEntry
-		entries = make(dirEntries, 0)
+		entries = make([]*DirEntry, 0)
 	)
 	dir.RewindDir()
 	for {
@@ -222,7 +217,7 @@ func (dir *Directory) List() (dirEntries, error) {
 }
 
 // Names returns a slice of only the name fields from dir entries.
-func (entries dirEntries) Names() []string {
+func Names(entries []*DirEntry) []string {
 	names := make([]string, len(entries))
 	for i, v := range entries {
 		names[i] = v.Name()

--- a/cephfs/directory.go
+++ b/cephfs/directory.go
@@ -196,9 +196,9 @@ func (dir *Directory) RewindDir() {
 // DirEntry slice.
 type dirEntries []*DirEntry
 
-// list returns all the contents of a directory as a dirEntries slice.
+// List returns all the contents of a directory as a dirEntries slice.
 //
-// list is implemented using ReadDir. If any of the calls to ReadDir returns
+// List is implemented using ReadDir. If any of the calls to ReadDir returns
 // an error List will return an error. However, all previous entries
 // collected will still be returned. Callers of this function may want to check
 // the entries return value even when an error is returned.
@@ -221,7 +221,7 @@ func (dir *Directory) List() (dirEntries, error) {
 	return entries, err
 }
 
-// names returns a slice of only the name fields from dir entries.
+// Names returns a slice of only the name fields from dir entries.
 func (entries dirEntries) Names() []string {
 	names := make([]string, len(entries))
 	for i, v := range entries {

--- a/cephfs/directory.go
+++ b/cephfs/directory.go
@@ -204,7 +204,7 @@ type dirEntries []*DirEntry
 // the entries return value even when an error is returned.
 // List rewinds the handle every time it is called to get a full
 // listing of directory contents.
-func (dir *Directory) list() (dirEntries, error) {
+func (dir *Directory) List() (dirEntries, error) {
 	var (
 		err     error
 		entry   *DirEntry
@@ -222,7 +222,7 @@ func (dir *Directory) list() (dirEntries, error) {
 }
 
 // names returns a slice of only the name fields from dir entries.
-func (entries dirEntries) names() []string {
+func (entries dirEntries) Names() []string {
 	names := make([]string, len(entries))
 	for i, v := range entries {
 		names[i] = v.Name()

--- a/cephfs/directory_test.go
+++ b/cephfs/directory_test.go
@@ -127,7 +127,7 @@ func TestDirectoryList(t *testing.T) {
 		entries, err := dir.List()
 		assert.NoError(t, err)
 		assert.Greater(t, len(entries), 1)
-		found := entries.Names()
+		found := Names(entries)
 		assert.Contains(t, found, "base")
 	})
 	t.Run("dir1", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestDirectoryList(t *testing.T) {
 		entries, err := dir.List()
 		assert.NoError(t, err)
 		assert.Greater(t, len(entries), 1)
-		found := entries.Names()
+		found := Names(entries)
 		assert.Subset(t, found, subdirs)
 	})
 	t.Run("dir1Twice", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestDirectoryList(t *testing.T) {
 		entries, err := dir.List()
 		assert.NoError(t, err)
 		assert.Greater(t, len(entries), 1)
-		found := entries.Names()
+		found := Names(entries)
 		assert.Subset(t, found, subdirs)
 
 		// verify that calling list gives a complete list
@@ -159,7 +159,7 @@ func TestDirectoryList(t *testing.T) {
 		entries, err = dir.List()
 		assert.NoError(t, err)
 		assert.Greater(t, len(entries), 1)
-		found = entries.Names()
+		found = Names(entries)
 		assert.Subset(t, found, subdirs)
 	})
 }

--- a/cephfs/directory_test.go
+++ b/cephfs/directory_test.go
@@ -124,10 +124,10 @@ func TestDirectoryList(t *testing.T) {
 		assert.NotNil(t, dir)
 		defer func() { assert.NoError(t, dir.Close()) }()
 
-		entries, err := dir.list()
+		entries, err := dir.List()
 		assert.NoError(t, err)
 		assert.Greater(t, len(entries), 1)
-		found := entries.names()
+		found := entries.Names()
 		assert.Contains(t, found, "base")
 	})
 	t.Run("dir1", func(t *testing.T) {
@@ -136,10 +136,10 @@ func TestDirectoryList(t *testing.T) {
 		assert.NotNil(t, dir)
 		defer func() { assert.NoError(t, dir.Close()) }()
 
-		entries, err := dir.list()
+		entries, err := dir.List()
 		assert.NoError(t, err)
 		assert.Greater(t, len(entries), 1)
-		found := entries.names()
+		found := entries.Names()
 		assert.Subset(t, found, subdirs)
 	})
 	t.Run("dir1Twice", func(t *testing.T) {
@@ -148,18 +148,18 @@ func TestDirectoryList(t *testing.T) {
 		assert.NotNil(t, dir)
 		defer func() { assert.NoError(t, dir.Close()) }()
 
-		entries, err := dir.list()
+		entries, err := dir.List()
 		assert.NoError(t, err)
 		assert.Greater(t, len(entries), 1)
-		found := entries.names()
+		found := entries.Names()
 		assert.Subset(t, found, subdirs)
 
 		// verify that calling list gives a complete list
 		// even after being used for the same directory already
-		entries, err = dir.list()
+		entries, err = dir.List()
 		assert.NoError(t, err)
 		assert.Greater(t, len(entries), 1)
-		found = entries.names()
+		found = entries.Names()
 		assert.Subset(t, found, subdirs)
 	})
 }


### PR DESCRIPTION
Cephfs Directory: export List and Names

Exports dir.list() and entries.names(). Becomes dir.List() and
entries.Names().

The current implementations for cephfs's list and names functions
are non-exported functions although they do not modify any private
fields.  The functions would be of much more use to the community
as exported functions.

Signed-off-by: Lincoln Thurlow <lincoln@isi.edu>