### PR TITLE
rados: implement rados pool snapshot functionality

### DIFF
--- a/rados/errors.go
+++ b/rados/errors.go
@@ -48,7 +48,8 @@ func getErrorIfNegative(ret C.int) error {
 // Public go errors:
 
 var (
-	// ErrNotConnected is returned when functions are called without a RADOS connection
+	// ErrNotConnected is returned when functions are called
+	// without a RADOS connection.
 	ErrNotConnected = errors.New("RADOS not connected")
 	// ErrEmptyArgument may be returned if a function argument is passed
 	// a zero-length slice or map.

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -54,6 +54,9 @@ var (
 	// ErrEmptyArgument may be returned if a function argument is passed
 	// a zero-length slice or map.
 	ErrEmptyArgument = errors.New("Argument must contain at least one item")
+	// ErrInvalidIOContext may be returned if an api call requires an IOContext
+	// but IOContext is not ready for use.
+	ErrInvalidIOContext = errors.New("IOContext is not ready for use")
 )
 
 // Public radosErrors:

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -96,7 +96,7 @@ type IOContext struct {
 // with ceph C calls.
 func (ioctx *IOContext) validate() error {
 	if ioctx.ioctx == nil {
-		return ErrNotConnected
+		return ErrInvalidIOContext
 	}
 	return nil
 }

--- a/rados/snapshot.go
+++ b/rados/snapshot.go
@@ -168,3 +168,22 @@ func (ioctx *IOContext) RollbackSnap(oid, snapName string) error {
 	ret := C.rados_ioctx_snap_rollback(ioctx.ioctx, coid, cSnapName)
 	return getError(ret)
 }
+
+// SnapHead is the representation of LIBRADOS_SNAP_HEAD from librados.
+// SnapHead can be used to reset the IOContext to stop reading from a snapshot.
+const SnapHead = SnapID(C.LIBRADOS_SNAP_HEAD)
+
+// SetReadSnap sets the snapshot from which reads are performed.
+// Subsequent reads will return data as it was at the time of that snapshot.
+// Pass SnapHead for no snapshot (i.e. normal operation).
+//
+// Implements:
+//  void rados_ioctx_snap_set_read(rados_ioctx_t io, rados_snap_t snap);
+func (ioctx *IOContext) SetReadSnap(snapID SnapID) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	C.rados_ioctx_snap_set_read(ioctx.ioctx, (C.rados_snap_t)(snapID))
+	return nil
+}

--- a/rados/snapshot.go
+++ b/rados/snapshot.go
@@ -149,3 +149,22 @@ func (ioctx *IOContext) ListSnaps() ([]SnapID, error) {
 	}
 	return snapList[:ret], nil
 }
+
+// RollbackSnap rollbacks the object with key oID to the pool snapshot.
+// The contents of the object will be the same as when the snapshot was taken.
+//
+// Implements:
+//  int rados_ioctx_snap_rollback(rados_ioctx_t io, const char *oid, const char *snapname);
+func (ioctx *IOContext) RollbackSnap(oid, snapName string) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	coid := C.CString(oid)
+	defer C.free(unsafe.Pointer(coid))
+	cSnapName := C.CString(snapName)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	ret := C.rados_ioctx_snap_rollback(ioctx.ioctx, coid, cSnapName)
+	return getError(ret)
+}

--- a/rados/snapshot.go
+++ b/rados/snapshot.go
@@ -1,0 +1,40 @@
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <stdlib.h>
+// #include <rados/librados.h>
+import "C"
+
+import "unsafe"
+
+// CreateSnap creates a pool-wide snapshot.
+//
+// Implements:
+// int rados_ioctx_snap_create(rados_ioctx_t io, const char *snapname)
+func (ioctx *IOContext) CreateSnap(snapName string) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	cSnapName := C.CString(snapName)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	ret := C.rados_ioctx_snap_create(ioctx.ioctx, cSnapName)
+	return getError(ret)
+}
+
+// RemoveSnap deletes the pool snapshot.
+//
+// Implements:
+//  int rados_ioctx_snap_remove(rados_ioctx_t io, const char *snapname)
+func (ioctx *IOContext) RemoveSnap(snapName string) error {
+	if err := ioctx.validate(); err != nil {
+		return err
+	}
+
+	cSnapName := C.CString(snapName)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	ret := C.rados_ioctx_snap_remove(ioctx.ioctx, cSnapName)
+	return getError(ret)
+}

--- a/rados/snapshot_test.go
+++ b/rados/snapshot_test.go
@@ -1,0 +1,66 @@
+package rados
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *RadosTestSuite) TestCreateRemoveSnapshot() {
+	suite.SetupConnection()
+
+	suite.T().Run("invalidIOCtx", func(t *testing.T) {
+		ioctx := &IOContext{}
+		err := ioctx.CreateSnap("someSnap")
+		assert.Error(t, err)
+		err = ioctx.RemoveSnap("someSnap")
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidIOContext)
+	})
+
+	suite.T().Run("NewSnap", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		snapName := "mySnap"
+		err = ioctx.CreateSnap(snapName)
+		assert.NoError(t, err)
+		err = ioctx.RemoveSnap(snapName)
+		assert.NoError(t, err)
+	})
+
+	suite.T().Run("ExistingSnap", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		snapName := "mySnap"
+		err = ioctx.CreateSnap(snapName)
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, ioctx.RemoveSnap(snapName))
+		}()
+		err = ioctx.CreateSnap(snapName)
+		assert.Error(t, err)
+	})
+
+	suite.T().Run("NonExistingSnap", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		err = ioctx.RemoveSnap("someSnapName")
+		assert.Error(t, err)
+	})
+
+	// Strangely, this works!!
+	suite.T().Run("EmptySnapNameString", func(t *testing.T) {
+		ioctx, err := suite.conn.OpenIOContext(suite.pool)
+		require.NoError(suite.T(), err)
+
+		err = ioctx.CreateSnap("")
+		assert.NoError(t, err)
+
+		err = ioctx.RemoveSnap("")
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Implemented following rados API components:

- rados_ioctx_snap_create
- rados_ioctx_snap_get_name
- rados_ioctx_snap_get_stamp
- rados_ioctx_snap_list
- rados_ioctx_snap_lookup
- rados_ioctx_snap_remove
- rados_ioctx_snap_rollback
- rados_ioctx_snap_set_read

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

Fixes: #269 

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
