### PR TITLE
Make error types unexported

### DIFF
--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -11,15 +11,11 @@ import (
 	"github.com/ceph/go-ceph/internal/errutil"
 )
 
-// revive:disable:exported Temporarily live with stuttering
+// cephFSError represents an error condition returned from the CephFS APIs.
+type cephFSError int
 
-// CephFSError represents an error condition returned from the CephFS APIs.
-type CephFSError int
-
-// revive:enable:exported
-
-// Error returns the error string for the CephFSError type.
-func (e CephFSError) Error() string {
+// Error returns the error string for the cephFSError type.
+func (e cephFSError) Error() string {
 	errno, s := errutil.FormatErrno(int(e))
 	if s == "" {
 		return fmt.Sprintf("cephfs: ret=%d", errno)
@@ -27,11 +23,15 @@ func (e CephFSError) Error() string {
 	return fmt.Sprintf("cephfs: ret=%d, %s", errno, s)
 }
 
+func (e cephFSError) Errno() int {
+	return int(e)
+}
+
 func getError(e C.int) error {
 	if e == 0 {
 		return nil
 	}
-	return CephFSError(e)
+	return cephFSError(e)
 }
 
 // Public go errors:
@@ -39,13 +39,13 @@ func getError(e C.int) error {
 const (
 	// ErrNotConnected may be returned when client is not connected
 	// to a cluster.
-	ErrNotConnected = CephFSError(-C.ENOTCONN)
+	ErrNotConnected = cephFSError(-C.ENOTCONN)
 )
 
 // Private errors:
 
 const (
-	errInvalid     = CephFSError(-C.EINVAL)
-	errNameTooLong = CephFSError(-C.ENAMETOOLONG)
-	errNoEntry     = CephFSError(-C.ENOENT)
+	errInvalid     = cephFSError(-C.EINVAL)
+	errNameTooLong = cephFSError(-C.ENAMETOOLONG)
+	errNoEntry     = cephFSError(-C.ENOENT)
 )

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -273,7 +273,7 @@ func (c *Conn) GetPoolByName(name string) (int64, error) {
 	defer C.free(unsafe.Pointer(c_name))
 	ret := int64(C.rados_pool_lookup(c.cluster, c_name))
 	if ret < 0 {
-		return 0, RadosError(ret)
+		return 0, radosError(ret)
 	}
 	return ret, nil
 }
@@ -287,7 +287,7 @@ func (c *Conn) GetPoolByID(id int64) (string, error) {
 	c_id := C.int64_t(id)
 	ret := int(C.rados_pool_reverse_lookup(c.cluster, c_id, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf))))
 	if ret < 0 {
-		return "", RadosError(ret)
+		return "", radosError(ret)
 	}
 	return C.GoString((*C.char)(unsafe.Pointer(&buf[0]))), nil
 }

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -12,15 +12,11 @@ import (
 	"github.com/ceph/go-ceph/internal/errutil"
 )
 
-// revive:disable:exported Temporarily live with stuttering
+// radosError represents an error condition returned from the Ceph RADOS APIs.
+type radosError int
 
-// RadosError represents an error condition returned from the Ceph RADOS APIs.
-type RadosError int
-
-// revive:enable:exported
-
-// Error returns the error string for the RadosError type.
-func (e RadosError) Error() string {
+// Error returns the error string for the radosError type.
+func (e radosError) Error() string {
 	errno, s := errutil.FormatErrno(int(e))
 	if s == "" {
 		return fmt.Sprintf("rados: ret=%d", errno)
@@ -28,11 +24,15 @@ func (e RadosError) Error() string {
 	return fmt.Sprintf("rados: ret=%d, %s", errno, s)
 }
 
+func (e radosError) Errno() int {
+	return int(e)
+}
+
 func getError(e C.int) error {
 	if e == 0 {
 		return nil
 	}
-	return RadosError(e)
+	return radosError(e)
 }
 
 // getErrorIfNegative converts a ceph return code to error if negative.
@@ -52,15 +52,15 @@ var (
 	ErrNotConnected = errors.New("RADOS not connected")
 )
 
-// Public RadosErrors:
+// Public radosErrors:
 
 const (
 	// ErrNotFound indicates a missing resource.
-	ErrNotFound = RadosError(-C.ENOENT)
+	ErrNotFound = radosError(-C.ENOENT)
 	// ErrPermissionDenied indicates a permissions issue.
-	ErrPermissionDenied = RadosError(-C.EPERM)
+	ErrPermissionDenied = radosError(-C.EPERM)
 	// ErrObjectExists indicates that an exclusive object creation failed.
-	ErrObjectExists = RadosError(-C.EEXIST)
+	ErrObjectExists = radosError(-C.EEXIST)
 
 	// RadosErrorNotFound indicates a missing resource.
 	//
@@ -75,7 +75,7 @@ const (
 // Private errors:
 
 const (
-	errNameTooLong = RadosError(-C.ENAMETOOLONG)
+	errNameTooLong = radosError(-C.ENAMETOOLONG)
 
-	errRange = RadosError(-C.ERANGE)
+	errRange = radosError(-C.ERANGE)
 )

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -589,7 +589,7 @@ func (ioctx *IOContext) ListLockers(oid, name string) (*LockInfo, error) {
 	}
 
 	if ret < 0 {
-		return nil, RadosError(ret)
+		return nil, radosError(ret)
 	}
 	return &LockInfo{int(ret), c_exclusive == 1, C.GoString(c_tag), splitCString(c_clients, c_clients_len), splitCString(c_cookies, c_cookies_len), splitCString(c_addrs, c_addrs_len)}, nil
 }

--- a/rbd/diff_iterate.go
+++ b/rbd/diff_iterate.go
@@ -99,7 +99,7 @@ func (image *Image) DiffIterate(config DiffIterateConfig) error {
 		return err
 	}
 	if config.Callback == nil {
-		return RBDError(C.EINVAL)
+		return rbdError(C.EINVAL)
 	}
 
 	var cSnapName *C.char

--- a/rbd/diff_iterate_test.go
+++ b/rbd/diff_iterate_test.go
@@ -335,8 +335,8 @@ func testDiffIterateEarlyExit(t *testing.T, ioctx *rados.IOContext) {
 			},
 		})
 	assert.Error(t, err)
-	if rbderr, ok := err.(RBDError); assert.True(t, ok) {
-		assert.EqualValues(t, -5, int(rbderr))
+	if errno, ok := err.(interface{ Errno() int }); assert.True(t, ok) {
+		assert.EqualValues(t, -5, errno.Errno())
 	}
 	if assert.Len(t, calls, 1) {
 		assert.EqualValues(t, 0, calls[0].offset)

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -12,14 +12,10 @@ import (
 	"github.com/ceph/go-ceph/internal/errutil"
 )
 
-// revive:disable:exported Temporarily live with stuttering
+// rbdError represents an error condition returned from the librbd APIs.
+type rbdError int
 
-// RBDError represents an error condition returned from the librbd APIs.
-type RBDError int
-
-// revive:enable:exported
-
-func (e RBDError) Error() string {
+func (e rbdError) Error() string {
 	errno, s := errutil.FormatErrno(int(e))
 	if s == "" {
 		return fmt.Sprintf("rbd: ret=%d", errno)
@@ -27,12 +23,16 @@ func (e RBDError) Error() string {
 	return fmt.Sprintf("rbd: ret=%d, %s", errno, s)
 }
 
+func (e rbdError) Errno() int {
+	return int(e)
+}
+
 func getError(err C.int) error {
 	if err != 0 {
 		if err == -C.ENOENT {
 			return ErrNotFound
 		}
-		return RBDError(err)
+		return rbdError(err)
 	}
 	return nil
 }
@@ -79,5 +79,5 @@ var (
 // Private errors:
 
 const (
-	errRange = RBDError(-C.ERANGE)
+	errRange = rbdError(-C.ERANGE)
 )

--- a/rbd/features.go
+++ b/rbd/features.go
@@ -152,7 +152,7 @@ func (image *Image) GetFeatures() (features uint64, err error) {
 	}
 
 	if ret := C.rbd_get_features(image.image, (*C.uint64_t)(&features)); ret < 0 {
-		return 0, RBDError(ret)
+		return 0, rbdError(ret)
 	}
 
 	return features, nil

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -182,7 +182,7 @@ func Create(ioctx *rados.IOContext, name string, size uint64, order int,
 	}
 
 	if ret < 0 {
-		return nil, RBDError(ret)
+		return nil, rbdError(ret)
 	}
 
 	return &Image{
@@ -208,7 +208,7 @@ func Create2(ioctx *rados.IOContext, name string, size uint64, features uint64,
 	ret = C.rbd_create2(cephIoctx(ioctx), c_name,
 		C.uint64_t(size), C.uint64_t(features), &c_order)
 	if ret < 0 {
-		return nil, RBDError(ret)
+		return nil, rbdError(ret)
 	}
 
 	return &Image{
@@ -237,7 +237,7 @@ func Create3(ioctx *rados.IOContext, name string, size uint64, features uint64,
 		C.uint64_t(size), C.uint64_t(features), &c_order,
 		C.uint64_t(stripe_unit), C.uint64_t(stripe_count))
 	if ret < 0 {
-		return nil, RBDError(ret)
+		return nil, rbdError(ret)
 	}
 
 	return &Image{
@@ -271,7 +271,7 @@ func (image *Image) Clone(snapname string, c_ioctx *rados.IOContext, c_name stri
 		cephIoctx(c_ioctx),
 		c_c_name, C.uint64_t(features), &c_order)
 	if ret < 0 {
-		return nil, RBDError(ret)
+		return nil, rbdError(ret)
 	}
 
 	return &Image{
@@ -320,7 +320,7 @@ func (image *Image) Rename(destname string) error {
 	defer C.free(unsafe.Pointer(c_srcname))
 	defer C.free(unsafe.Pointer(c_destname))
 
-	err := RBDError(C.rbd_rename(cephIoctx(image.ioctx),
+	err := rbdError(C.rbd_rename(cephIoctx(image.ioctx),
 		c_srcname, c_destname))
 	if err == 0 {
 		image.name = destname
@@ -381,7 +381,7 @@ func (image *Image) Close() error {
 	}
 
 	if ret := C.rbd_close(image.image); ret != 0 {
-		return RBDError(ret)
+		return rbdError(ret)
 	}
 
 	image.image = nil
@@ -412,7 +412,7 @@ func (image *Image) Stat() (info *ImageInfo, err error) {
 	var c_stat C.rbd_image_info_t
 
 	if ret := C.rbd_stat(image.image, &c_stat, C.size_t(unsafe.Sizeof(info))); ret < 0 {
-		return info, RBDError(ret)
+		return info, rbdError(ret)
 	}
 
 	return &ImageInfo{
@@ -438,7 +438,7 @@ func (image *Image) IsOldFormat() (old_format bool, err error) {
 	ret := C.rbd_get_old_format(image.image,
 		&c_old_format)
 	if ret < 0 {
-		return false, RBDError(ret)
+		return false, rbdError(ret)
 	}
 
 	return c_old_format != 0, nil
@@ -454,7 +454,7 @@ func (image *Image) GetSize() (size uint64, err error) {
 	}
 
 	if ret := C.rbd_get_size(image.image, (*C.uint64_t)(&size)); ret < 0 {
-		return 0, RBDError(ret)
+		return 0, rbdError(ret)
 	}
 
 	return size, nil
@@ -470,7 +470,7 @@ func (image *Image) GetStripeUnit() (stripe_unit uint64, err error) {
 	}
 
 	if ret := C.rbd_get_stripe_unit(image.image, (*C.uint64_t)(&stripe_unit)); ret < 0 {
-		return 0, RBDError(ret)
+		return 0, rbdError(ret)
 	}
 
 	return stripe_unit, nil
@@ -486,7 +486,7 @@ func (image *Image) GetStripeCount() (stripe_count uint64, err error) {
 	}
 
 	if ret := C.rbd_get_stripe_count(image.image, (*C.uint64_t)(&stripe_count)); ret < 0 {
-		return 0, RBDError(ret)
+		return 0, rbdError(ret)
 	}
 
 	return stripe_count, nil
@@ -503,7 +503,7 @@ func (image *Image) GetOverlap() (overlap uint64, err error) {
 	}
 
 	if ret := C.rbd_get_overlap(image.image, (*C.uint64_t)(&overlap)); ret < 0 {
-		return overlap, RBDError(ret)
+		return overlap, rbdError(ret)
 	}
 
 	return overlap, nil
@@ -602,7 +602,7 @@ func (image *Image) ListLockers() (tag string, lockers []Locker, err error) {
 	// but *0* is unexpected here because first rbd_list_lockers already
 	// dealt with no locker case
 	if int(c_locker_cnt) <= 0 {
-		return "", nil, RBDError(c_locker_cnt)
+		return "", nil, rbdError(c_locker_cnt)
 	}
 
 	clients := split(clients_buf)
@@ -708,7 +708,7 @@ func (image *Image) Read(data []byte) (int, error) {
 		(*C.char)(unsafe.Pointer(&data[0]))))
 
 	if ret < 0 {
-		return 0, RBDError(ret)
+		return 0, rbdError(ret)
 	}
 
 	image.offset += int64(ret)
@@ -733,7 +733,7 @@ func (image *Image) Write(data []byte) (n int, err error) {
 	}
 
 	if ret != len(data) {
-		err = RBDError(-C.EPERM)
+		err = rbdError(-C.EPERM)
 	}
 
 	return ret, err
@@ -771,7 +771,7 @@ func (image *Image) Discard(ofs uint64, length uint64) (int, error) {
 
 	ret := C.rbd_discard(image.image, C.uint64_t(ofs), C.uint64_t(length))
 	if ret < 0 {
-		return 0, RBDError(ret)
+		return 0, rbdError(ret)
 	}
 
 	return int(ret), nil
@@ -794,7 +794,7 @@ func (image *Image) ReadAt(data []byte, off int64) (int, error) {
 		(*C.char)(unsafe.Pointer(&data[0]))))
 
 	if ret < 0 {
-		return 0, RBDError(ret)
+		return 0, rbdError(ret)
 	}
 
 	if ret < len(data) {
@@ -818,7 +818,7 @@ func (image *Image) WriteAt(data []byte, off int64) (n int, err error) {
 		C.size_t(len(data)), (*C.char)(unsafe.Pointer(&data[0]))))
 
 	if ret != len(data) {
-		err = RBDError(-C.EPERM)
+		err = rbdError(-C.EPERM)
 	}
 
 	return ret, err
@@ -856,7 +856,7 @@ func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 	ret = C.rbd_snap_list(image.image,
 		&c_snaps[0], &c_max_snaps)
 	if ret < 0 {
-		return nil, RBDError(ret)
+		return nil, rbdError(ret)
 	}
 
 	for i, s := range c_snaps {
@@ -917,7 +917,7 @@ func (image *Image) SetMetadata(key string, value string) error {
 
 	ret := C.rbd_metadata_set(image.image, c_key, c_value)
 	if ret < 0 {
-		return RBDError(ret)
+		return rbdError(ret)
 	}
 
 	return nil
@@ -937,7 +937,7 @@ func (image *Image) RemoveMetadata(key string) error {
 
 	ret := C.rbd_metadata_remove(image.image, c_key)
 	if ret < 0 {
-		return RBDError(ret)
+		return rbdError(ret)
 	}
 
 	return nil
@@ -1209,7 +1209,7 @@ func CreateImage(ioctx *rados.IOContext, name string, size uint64, rio *ImageOpt
 		return ErrNoName
 	}
 	if rio == nil {
-		return RBDError(C.EINVAL)
+		return rbdError(C.EINVAL)
 	}
 
 	c_name := C.CString(name)
@@ -1248,7 +1248,7 @@ func CloneImage(ioctx *rados.IOContext, parentName, snapName string,
 	destctx *rados.IOContext, name string, rio *ImageOptions) error {
 
 	if rio == nil {
-		return RBDError(C.EINVAL)
+		return rbdError(C.EINVAL)
 	}
 
 	cParentName := C.CString(parentName)

--- a/rbd/rbd_nautilus_test.go
+++ b/rbd/rbd_nautilus_test.go
@@ -66,7 +66,7 @@ func TestClosedImageNautilus(t *testing.T) {
 	err = image.Close()
 	assert.NoError(t, err)
 
-	// functions should now fail with an RBDError
+	// functions should now fail with an rbdError
 
 	_, err = image.GetCreateTimestamp()
 	assert.Error(t, err)

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -30,7 +30,7 @@ func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
 
 	ret := C.rbd_snap_create(image.image, c_snapname)
 	if ret < 0 {
-		return nil, RBDError(ret)
+		return nil, rbdError(ret)
 	}
 
 	return &Snapshot{
@@ -139,7 +139,7 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 	ret := C.rbd_snap_is_protected(snapshot.image.image, c_snapname,
 		&c_is_protected)
 	if ret < 0 {
-		return false, RBDError(ret)
+		return false, rbdError(ret)
 	}
 
 	return c_is_protected != 0, nil

--- a/rbd/snapshot_mimic.go
+++ b/rbd/snapshot_mimic.go
@@ -40,7 +40,7 @@ func (image *Image) GetParentInfo(p_pool, p_name, p_snapname []byte) error {
 	if ret == 0 {
 		return nil
 	} else {
-		return RBDError(ret)
+		return rbdError(ret)
 	}
 }
 
@@ -66,7 +66,7 @@ func (image *Image) ListChildren() (pools []string, images []string, err error) 
 		return nil, nil, nil
 	}
 	if ret < 0 && ret != -C.ERANGE {
-		return nil, nil, RBDError(ret)
+		return nil, nil, rbdError(ret)
 	}
 
 	pools_buf := make([]byte, c_pools_len)
@@ -78,7 +78,7 @@ func (image *Image) ListChildren() (pools []string, images []string, err error) 
 		(*C.char)(unsafe.Pointer(&images_buf[0])),
 		&c_images_len)
 	if ret < 0 {
-		return nil, nil, RBDError(ret)
+		return nil, nil, rbdError(ret)
 	}
 
 	tmp := bytes.Split(pools_buf[:c_pools_len-1], []byte{0})

--- a/rbd/snapshot_nautilus.go
+++ b/rbd/snapshot_nautilus.go
@@ -32,7 +32,7 @@ func (image *Image) GetParentInfo(pool, name, snapname []byte) error {
 	parentSnap := C.rbd_snap_spec_t{}
 	ret := C.rbd_get_parent(image.image, &parentImage, &parentSnap)
 	if ret != 0 {
-		return RBDError(ret)
+		return rbdError(ret)
 	}
 
 	defer C.rbd_linked_image_spec_cleanup(&parentImage)
@@ -40,26 +40,26 @@ func (image *Image) GetParentInfo(pool, name, snapname []byte) error {
 
 	strlen := int(C.strlen(parentImage.pool_name))
 	if len(pool) < strlen {
-		return RBDError(C.ERANGE)
+		return rbdError(C.ERANGE)
 	}
 	if copy(pool, C.GoString(parentImage.pool_name)) != strlen {
-		return RBDError(C.ERANGE)
+		return rbdError(C.ERANGE)
 	}
 
 	strlen = int(C.strlen(parentImage.image_name))
 	if len(name) < strlen {
-		return RBDError(C.ERANGE)
+		return rbdError(C.ERANGE)
 	}
 	if copy(name, C.GoString(parentImage.image_name)) != strlen {
-		return RBDError(C.ERANGE)
+		return rbdError(C.ERANGE)
 	}
 
 	strlen = int(C.strlen(parentSnap.name))
 	if len(snapname) < strlen {
-		return RBDError(C.ERANGE)
+		return rbdError(C.ERANGE)
 	}
 	if copy(snapname, C.GoString(parentSnap.name)) != strlen {
-		return RBDError(C.ERANGE)
+		return rbdError(C.ERANGE)
 	}
 
 	return nil


### PR DESCRIPTION
In order to avoid external dependencies on implementation details, this change replaces the error types with the unexported versions. In case some application really needs access to the integer value, it can use the pattern

```
var intErr interface{ Int() int }
if errors.As(err, intErr) { ... intErr.Int() ... }
```

Signed-off-by: Sven Anderson <sven@redhat.com>
