### PR TITLE
rados: add GetLastVersion implementing rados_get_last_version

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -92,6 +92,15 @@ type IOContext struct {
 	ioctx C.rados_ioctx_t
 }
 
+// validate returns an error if the ioctx is not ready to be used
+// with ceph C calls.
+func (ioctx *IOContext) validate() error {
+	if ioctx.ioctx == nil {
+		return ErrNotConnected
+	}
+	return nil
+}
+
 // Pointer returns a pointer reference to an internal structure.
 // This function should NOT be used outside of go-ceph itself.
 func (ioctx *IOContext) Pointer() unsafe.Pointer {

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -646,3 +646,16 @@ func (ioctx *IOContext) BreakLock(oid, name, client, cookie string) (int, error)
 		return int(ret), getError(ret)
 	}
 }
+
+// GetLastVersion will return the version number of the last object read or
+// written to.
+//
+// Implements:
+//  uint64_t rados_get_last_version(rados_ioctx_t io);
+func (ioctx *IOContext) GetLastVersion() (uint64, error) {
+	if err := ioctx.validate(); err != nil {
+		return 0, err
+	}
+	v := C.rados_get_last_version(ioctx.ioctx)
+	return uint64(v), nil
+}


### PR DESCRIPTION
The GetLastVersion returns a number representing the most recent
read/write version for the io context.

This will become more useful later on when more write op and read op functions are implemented.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
