### PR TITLE
testing: simplify package update, but require matching versions

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -5,8 +5,11 @@ ENV CEPH_VERSION=${CEPH_VERSION:-nautilus}
 
 RUN true && \
     yum clean all && \
-    ( if [ "${CEPH_VERSION}" = "octopus" ]; then dnf install -y --repo BaseOS 'dnf-command(config-manager)' && dnf config-manager --set-disabled epel && dnf update -y; fi ) && \
-    yum install -y git wget curl libcephfs-devel librados-devel librbd-devel /usr/bin/cc /usr/bin/c++ make && \
+    cv="$(rpm -q --queryformat '%{version}-%{release}' ceph-common)" && \
+    yum install -y \
+        git wget curl make \
+        /usr/bin/cc /usr/bin/c++ \
+        "libcephfs-devel-${cv}" "librados-devel-${cv}" "librbd-devel-${cv}" && \
     (yum install -y /usr/bin/castxml || true) && \
     true
 

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -10,7 +10,6 @@ RUN true && \
         git wget curl make \
         /usr/bin/cc /usr/bin/c++ \
         "libcephfs-devel-${cv}" "librados-devel-${cv}" "librbd-devel-${cv}" && \
-    (yum install -y /usr/bin/castxml || true) && \
     true
 
 ENV GOTAR=go1.12.17.linux-amd64.tar.gz


### PR DESCRIPTION
Now that ceph/daemon-base:latest-octopus is on v15.2.4 we can
stop the need to update already installed packages in the container.
To make things "safer" and fail early with errors rather than mysterious
compatibility problems, I am adding explicit versions to the
lib{cephfs,rados,rbd}-devel-* packages. Now if the container can't find
these packages it will fail rather than partially upgrade the ceph
packages.

