### PR TITLE
Some micro-osd.sh related cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 
 .PHONY: ci-image
 ci-image: $(BUILDFILE)
-$(BUILDFILE): $(CONTAINER_CONFIG_DIR)/Dockerfile entrypoint.sh
+$(BUILDFILE): $(CONTAINER_CONFIG_DIR)/Dockerfile entrypoint.sh micro-osd.sh
 	$(CONTAINER_CMD) build --build-arg CEPH_VERSION=$(CEPH_VERSION) -t $(CI_IMAGE_TAG) -f $(CONTAINER_CONFIG_DIR)/Dockerfile .
 	@$(CONTAINER_CMD) inspect -f '{{.Id}}' $(CI_IMAGE_TAG) > $(BUILDFILE)
 	echo $(CEPH_VERSION) >> $(BUILDFILE)

--- a/micro-osd.sh
+++ b/micro-osd.sh
@@ -52,6 +52,7 @@ log file = ${LOG_DIR}/mon.log
 chdir = ""
 mon cluster log file = ${LOG_DIR}/mon-cluster.log
 mon data = ${MON_DATA}
+mon data avail crit = 0
 mon addr = 127.0.0.1
 mon allow pool delete = true
 


### PR DESCRIPTION
This PR adds micro-osd.sh to the dependency list to the container build Makefile target, and disables the check for available free disk space, which in container context on a laptop can easily drop below 5%.