### PR TITLE
rbd: remove deprecated fields from ImageInfo struct

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -56,8 +56,6 @@ type ImageInfo struct {
 	Num_objs          uint64
 	Order             int
 	Block_name_prefix string
-	Parent_pool       int64
-	Parent_name       string
 }
 
 // SnapInfo represents the status information for a snapshot.
@@ -408,9 +406,7 @@ func (image *Image) Stat() (info *ImageInfo, err error) {
 		Obj_size:          uint64(c_stat.obj_size),
 		Num_objs:          uint64(c_stat.num_objs),
 		Order:             int(c_stat.order),
-		Block_name_prefix: C.GoString((*C.char)(&c_stat.block_name_prefix[0])),
-		Parent_pool:       int64(c_stat.parent_pool),
-		Parent_name:       C.GoString((*C.char)(&c_stat.parent_name[0]))}, nil
+		Block_name_prefix: C.GoString((*C.char)(&c_stat.block_name_prefix[0]))}, nil
 }
 
 // IsOldFormat returns true if the rbd image uses the old format.


### PR DESCRIPTION
Corresponding fields for Parent_pool and Parent_name have been deprecated from
ceph's rbd_image_info_t stuct, removing the same from go-ceph's ImageInfo struct.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

Fixes: #312 


## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
