### PR TITLE
Add a CephFS Administrative sub-package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ check-revive:
 # library code as well.
 test-binaries: \
 	cephfs.test \
+	cephfs/admin.test \
 	internal/callbacks.test \
 	internal/cutil.test \
 	internal/errutil.test \

--- a/cephfs/admin/bytecount.go
+++ b/cephfs/admin/bytecount.go
@@ -10,3 +10,26 @@ const (
 	gibiByte           = 1024 * mebiByte
 	tebiByte           = 1024 * gibiByte
 )
+
+// newSizeValue returns a size value as a string, as needed by the subvolume
+// resize command json.
+func (bc ByteCount) newSizeValue() string {
+	return uint64String(uint64(bc))
+}
+
+// NewSize interface values can be used to change the size of a volume.
+type NewSize interface {
+	newSizeValue() string
+}
+
+// specialSize is a custom non-numeric new size value.
+type specialSize string
+
+// newSizeValue for a specialSize returns the literal string.
+func (s specialSize) newSizeValue() string {
+	return string(s)
+}
+
+// Infinite is a special NewSize value that can be used to clear size limits on
+// a subvolume.
+const Infinite = specialSize("infinite")

--- a/cephfs/admin/bytecount.go
+++ b/cephfs/admin/bytecount.go
@@ -1,0 +1,12 @@
+package admin
+
+// ByteCount represents the size of a volume in bytes.
+type ByteCount uint64
+
+// SI byte size constants. keep these private for now.
+const (
+	kibiByte ByteCount = 1024
+	mebiByte           = 1024 * kibiByte
+	gibiByte           = 1024 * mebiByte
+	tebiByte           = 1024 * gibiByte
+)

--- a/cephfs/admin/bytecount.go
+++ b/cephfs/admin/bytecount.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 // ByteCount represents the size of a volume in bytes.

--- a/cephfs/admin/doc.go
+++ b/cephfs/admin/doc.go
@@ -1,0 +1,9 @@
+/*
+Package admin is a convenience layer to support the administration of
+CephFS volumes, subvolumes, etc.
+
+Unlike the cephfs package this API does not map to APIs provided by
+ceph libraries themselves. This API is not yet stable and is subject
+to change.
+*/
+package admin

--- a/cephfs/admin/doc.go
+++ b/cephfs/admin/doc.go
@@ -5,5 +5,7 @@ CephFS volumes, subvolumes, etc.
 Unlike the cephfs package this API does not map to APIs provided by
 ceph libraries themselves. This API is not yet stable and is subject
 to change.
+
+This package only supports ceph "nautilus" and "octopus" at this time.
 */
 package admin

--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -1,0 +1,122 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/ceph/go-ceph/rados"
+)
+
+// RadosCommander provides an interface to execute JSON-formatted commands that
+// allow the cephfs administrative functions to interact with the Ceph cluster.
+type RadosCommander interface {
+	MgrCommand(buf [][]byte) ([]byte, string, error)
+}
+
+// FSAdmin is used to administrate CephFS within a ceph cluster.
+type FSAdmin struct {
+	conn RadosCommander
+}
+
+// New creates an FSAdmin automatically based on the default ceph
+// configuration file. If more customization is needed, create a
+// *rados.Conn as you see fit and use NewFromConn to use that
+// connection with these administrative functions.
+func New() (*FSAdmin, error) {
+	conn, err := rados.NewConn()
+	if err != nil {
+		return nil, err
+	}
+	err = conn.ReadDefaultConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	err = conn.Connect()
+	if err != nil {
+		return nil, err
+	}
+	return NewFromConn(conn), nil
+}
+
+// NewFromConn creates an FSAdmin management object from a preexisting
+// rados connection. The existing connection can be rados.Conn or any
+// type implementing the RadosCommander interface. This may be useful
+// if the calling layer needs to inject additional logging, error handling,
+// fault injection, etc.
+func NewFromConn(conn RadosCommander) *FSAdmin {
+	return &FSAdmin{conn}
+}
+
+func (fsa *FSAdmin) validate() error {
+	if fsa.conn == nil {
+		return rados.ErrNotConnected
+	}
+	return nil
+}
+
+// rawMgrCommand takes a byte buffer and sends it to the MGR as a command.
+// The buffer is expected to contain preformatted JSON.
+func (fsa *FSAdmin) rawMgrCommand(buf []byte) ([]byte, string, error) {
+	if err := fsa.validate(); err != nil {
+		return nil, "", err
+	}
+	return fsa.conn.MgrCommand([][]byte{buf})
+}
+
+// marshalMgrCommand takes an generic interface{} value, converts it to JSON and
+// sends the json to the MGR as a command.
+func (fsa *FSAdmin) marshalMgrCommand(v interface{}) ([]byte, string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, "", err
+	}
+	return fsa.rawMgrCommand(b)
+}
+
+type listNamedResult struct {
+	Name string `json:"name"`
+}
+
+func parseListNames(res []byte, status string, err error) ([]string, error) {
+	if err != nil {
+		return nil, err
+	}
+	if status != "" {
+		return nil, fmt.Errorf("error status: %s", status)
+	}
+	var r []listNamedResult
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, err
+	}
+	vl := make([]string, len(r))
+	for i := range r {
+		vl[i] = r[i].Name
+	}
+	return vl, nil
+}
+
+// checkEmptyResponseExpected returns an error if the result or status
+// are non-empty.
+func checkEmptyResponseExpected(res []byte, status string, err error) error {
+	if err != nil {
+		return err
+	}
+	if len(res) != 0 {
+		return fmt.Errorf("unexpected response: %s", string(res))
+	}
+	if status != "" {
+		return fmt.Errorf("error status: %s", status)
+	}
+	return nil
+}
+
+// modeString converts a unix-style mode value to a string-ified version in an
+// octal representation (e.g. "777", "700", etc). This format is expected by
+// some of the ceph JSON command inputs.
+func modeString(m int, force bool) string {
+	if force || m != 0 {
+		return strconv.FormatInt(int64(m), 8)
+	}
+	return ""
+}

--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -124,3 +124,10 @@ func modeString(m int, force bool) string {
 	}
 	return ""
 }
+
+// uint64String converts a uint64 to a string. Some of the ceph json commands
+// can take a string or "int" (as a string). This is a common function for
+// doing that conversion.
+func uint64String(v uint64) string {
+	return strconv.FormatUint(uint64(v), 10)
+}

--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 import (

--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -79,14 +79,8 @@ type listNamedResult struct {
 }
 
 func parseListNames(res []byte, status string, err error) ([]string, error) {
-	if err != nil {
-		return nil, err
-	}
-	if status != "" {
-		return nil, fmt.Errorf("error status: %s", status)
-	}
 	var r []listNamedResult
-	if err := json.Unmarshal(res, &r); err != nil {
+	if err := unmarshalResponseJSON(res, status, err, &r); err != nil {
 		return nil, err
 	}
 	vl := make([]string, len(r))
@@ -109,6 +103,16 @@ func checkEmptyResponseExpected(res []byte, status string, err error) error {
 		return fmt.Errorf("error status: %s", status)
 	}
 	return nil
+}
+
+func unmarshalResponseJSON(res []byte, status string, err error, v interface{}) error {
+	if err != nil {
+		return err
+	}
+	if status != "" {
+		return fmt.Errorf("error status: %s", status)
+	}
+	return json.Unmarshal(res, v)
 }
 
 // modeString converts a unix-style mode value to a string-ified version in an

--- a/cephfs/admin/fsadmin_test.go
+++ b/cephfs/admin/fsadmin_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ var (
 
 func init() {
 	dt := os.Getenv("GO_CEPH_TEST_DEBUG_TRACE")
-	if dt == "yes" || dt == "true" {
+	if ok, err := strconv.ParseBool(dt); ok && err == nil {
 		debugTrace = true
 	}
 }

--- a/cephfs/admin/fsadmin_test.go
+++ b/cephfs/admin/fsadmin_test.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 import (

--- a/cephfs/admin/fsadmin_test.go
+++ b/cephfs/admin/fsadmin_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,12 +59,19 @@ func getFSAdmin(t *testing.T) *FSAdmin {
 	if cachedFSAdmin != nil {
 		return cachedFSAdmin
 	}
-	cachedFSAdmin, err := New()
+	fsa, err := New()
 	require.NoError(t, err)
-	require.NotNil(t, cachedFSAdmin)
+	require.NotNil(t, fsa)
+	// We steal the connection set up by the New() method and wrap it in an
+	// optional tracer.
+	c := fsa.conn
 	if debugTrace {
-		cachedFSAdmin = NewFromConn(tracer(cachedFSAdmin.conn))
+		c = tracer(c)
 	}
+	cachedFSAdmin = NewFromConn(c)
+	// We sleep briefly before returning in order to ensure we have a mgr map
+	// before we start executing the tests.
+	time.Sleep(50 * time.Millisecond)
 	return cachedFSAdmin
 }
 

--- a/cephfs/admin/fsadmin_test.go
+++ b/cephfs/admin/fsadmin_test.go
@@ -1,0 +1,85 @@
+package admin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var cachedFSAdmin *FSAdmin
+
+func getFSAdmin(t *testing.T) *FSAdmin {
+	if cachedFSAdmin != nil {
+		return cachedFSAdmin
+	}
+	var err error
+	cachedFSAdmin, err := New()
+	require.NoError(t, err)
+	require.NotNil(t, cachedFSAdmin)
+	return cachedFSAdmin
+}
+
+func TestInvalidFSAdmin(t *testing.T) {
+	fsa := &FSAdmin{}
+	_, _, err := fsa.rawMgrCommand([]byte("FOOBAR!"))
+	assert.Error(t, err)
+}
+
+type badMarshalType bool
+
+func (badMarshalType) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("Zowie! wow")
+}
+
+func TestBadMarshal(t *testing.T) {
+	fsa := getFSAdmin(t)
+
+	var bad badMarshalType
+	_, _, err := fsa.marshalMgrCommand(bad)
+	assert.Error(t, err)
+}
+
+func TestParseListNames(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
+		_, err := parseListNames(nil, "", errors.New("bonk"))
+		assert.Error(t, err)
+		assert.Equal(t, "bonk", err.Error())
+	})
+	t.Run("statusSet", func(t *testing.T) {
+		_, err := parseListNames(nil, "unexpected!", nil)
+		assert.Error(t, err)
+	})
+	t.Run("badJSON", func(t *testing.T) {
+		_, err := parseListNames([]byte("Foo[[["), "", nil)
+		assert.Error(t, err)
+	})
+	t.Run("ok", func(t *testing.T) {
+		l, err := parseListNames([]byte(`[{"name":"bob"}]`), "", nil)
+		assert.NoError(t, err)
+		if assert.Len(t, l, 1) {
+			assert.Equal(t, "bob", l[0])
+		}
+	})
+}
+
+func TestCheckEmptyResponseExpected(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
+		err := checkEmptyResponseExpected(nil, "", errors.New("bonk"))
+		assert.Error(t, err)
+		assert.Equal(t, "bonk", err.Error())
+	})
+	t.Run("statusSet", func(t *testing.T) {
+		err := checkEmptyResponseExpected(nil, "unexpected!", nil)
+		assert.Error(t, err)
+	})
+	t.Run("someJSON", func(t *testing.T) {
+		err := checkEmptyResponseExpected([]byte(`{"trouble": true}`), "", nil)
+		assert.Error(t, err)
+	})
+	t.Run("ok", func(t *testing.T) {
+		err := checkEmptyResponseExpected([]byte{}, "", nil)
+		assert.NoError(t, err)
+	})
+}

--- a/cephfs/admin/subvolume.go
+++ b/cephfs/admin/subvolume.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 // this is the internal type used to create JSON for ceph.

--- a/cephfs/admin/subvolume.go
+++ b/cephfs/admin/subvolume.go
@@ -53,6 +53,9 @@ const NoGroup = ""
 
 // CreateSubVolume sends a request to create a CephFS subvolume in a volume,
 // belonging to an optional subvolume group.
+//
+// Similar To:
+//  ceph fs subvolume create <volume> --group-name=<group> <name> ...
 func (fsa *FSAdmin) CreateSubVolume(volume, group, name string, o *SubVolumeOptions) error {
 	if o == nil {
 		o = &SubVolumeOptions{}
@@ -61,11 +64,11 @@ func (fsa *FSAdmin) CreateSubVolume(volume, group, name string, o *SubVolumeOpti
 	return checkEmptyResponseExpected(fsa.marshalMgrCommand(f))
 }
 
-// command:
-//   fs subvolume ls <vol_name> <group_name>
-
 // ListSubVolumes returns a list of subvolumes belonging to the volume and
 // optional subvolume group.
+//
+// Similar To:
+//  ceph fs subvolume ls <volume> --group-name=<group>
 func (fsa *FSAdmin) ListSubVolumes(volume, group string) ([]string, error) {
 	m := map[string]string{
 		"prefix":   "fs subvolume ls",
@@ -78,11 +81,11 @@ func (fsa *FSAdmin) ListSubVolumes(volume, group string) ([]string, error) {
 	return parseListNames(fsa.marshalMgrCommand(m))
 }
 
-// command:
-//   fs subvolume rm <vol_name> <sub_name> <group_name> <force>
-
 // RemoveSubVolume will delete a CephFS subvolume in a volume and optional
 // subvolume group.
+//
+// Similar To:
+//  ceph fs subvolume rm <volume> --group-name=<group> <name> ...
 func (fsa *FSAdmin) RemoveSubVolume(volume, group, name string) error {
 	m := map[string]string{
 		"prefix":   "fs subvolume rm",
@@ -117,6 +120,9 @@ type SubVolumeResizeResult struct {
 // ResizeSubVolume will resize a CephFS subvolume. The newSize value may be a
 // ByteCount or the special Infinite constant. Setting noShrink to true will
 // prevent reducing the size of the volume below the current used size.
+//
+// Similar To:
+//  ceph fs subvolume resize <volume> --group-name=<group> <name> ...
 func (fsa *FSAdmin) ResizeSubVolume(
 	volume, group, name string,
 	newSize NewSize, noShrink bool) (*SubVolumeResizeResult, error) {

--- a/cephfs/admin/subvolume.go
+++ b/cephfs/admin/subvolume.go
@@ -1,0 +1,95 @@
+package admin
+
+// this is the internal type used to create JSON for ceph.
+// See SubVolumeOptions for the type that users of the library
+// interact with.
+// note that the ceph json takes mode as a string.
+type subVolumeFields struct {
+	Prefix            string    `json:"prefix"`
+	Format            string    `json:"format"`
+	VolName           string    `json:"vol_name"`
+	GroupName         string    `json:"group_name,omitempty"`
+	SubName           string    `json:"sub_name"`
+	Size              ByteCount `json:"size,omitempty"`
+	Uid               int       `json:"uid,omitempty"`
+	Gid               int       `json:"gid,omitempty"`
+	Mode              string    `json:"mode,omitempty"`
+	PoolLayout        string    `json:"pool_layout,omitempty"`
+	NamespaceIsolated bool      `json:"namespace_isolated"`
+}
+
+// SubVolumeOptions are used to specify optional, non-identifying, values
+// to be used when creating a new subvolume.
+type SubVolumeOptions struct {
+	Size              ByteCount
+	Uid               int
+	Gid               int
+	Mode              int
+	PoolLayout        string
+	NamespaceIsolated bool
+}
+
+func (s *SubVolumeOptions) toFields(v, g, n string) *subVolumeFields {
+	return &subVolumeFields{
+		Prefix:            "fs subvolume create",
+		Format:            "json",
+		VolName:           v,
+		GroupName:         g,
+		SubName:           n,
+		Size:              s.Size,
+		Uid:               s.Uid,
+		Gid:               s.Gid,
+		Mode:              modeString(s.Mode, false),
+		PoolLayout:        s.PoolLayout,
+		NamespaceIsolated: s.NamespaceIsolated,
+	}
+}
+
+// NoGroup should be used when an optional subvolume group name is not
+// specified.
+const NoGroup = ""
+
+// CreateSubVolume sends a request to create a CephFS subvolume in a volume,
+// belonging to an optional subvolume group.
+func (fsa *FSAdmin) CreateSubVolume(volume, group, name string, o *SubVolumeOptions) error {
+	if o == nil {
+		o = &SubVolumeOptions{}
+	}
+	f := o.toFields(volume, group, name)
+	return checkEmptyResponseExpected(fsa.marshalMgrCommand(f))
+}
+
+// command:
+//   fs subvolume ls <vol_name> <group_name>
+
+// ListSubVolumes returns a list of subvolumes belonging to the volume and
+// optional subvolume group.
+func (fsa *FSAdmin) ListSubVolumes(volume, group string) ([]string, error) {
+	m := map[string]string{
+		"prefix":   "fs subvolume ls",
+		"vol_name": volume,
+		"format":   "json",
+	}
+	if group != NoGroup {
+		m["group_name"] = group
+	}
+	return parseListNames(fsa.marshalMgrCommand(m))
+}
+
+// command:
+//   fs subvolume rm <vol_name> <sub_name> <group_name> <force>
+
+// RemoveSubVolume will delete a CephFS subvolume in a volume and optional
+// subvolume group.
+func (fsa *FSAdmin) RemoveSubVolume(volume, group, name string) error {
+	m := map[string]string{
+		"prefix":   "fs subvolume rm",
+		"vol_name": volume,
+		"sub_name": name,
+		"format":   "json",
+	}
+	if group != NoGroup {
+		m["group_name"] = group
+	}
+	return checkEmptyResponseExpected(fsa.marshalMgrCommand(m))
+}

--- a/cephfs/admin/subvolume_test.go
+++ b/cephfs/admin/subvolume_test.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 import (

--- a/cephfs/admin/subvolume_test.go
+++ b/cephfs/admin/subvolume_test.go
@@ -1,0 +1,132 @@
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func delay() {
+	// ceph seems to do this (partly?) async. So for now, we cheat
+	// and sleep a little to make subsequent tests more reliable
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestCreateSubVolume(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	type gn struct {
+		group string
+		name  string
+	}
+	created := []gn{}
+	defer func() {
+		for _, c := range created {
+			err := fsa.RemoveSubVolume(volume, c.group, c.name)
+			assert.NoError(t, err)
+			delay()
+			if c.group != NoGroup {
+				err := fsa.RemoveSubVolumeGroup(volume, c.group)
+				assert.NoError(t, err)
+			}
+		}
+	}()
+
+	t.Run("simple", func(t *testing.T) {
+		subname := "SubVol1"
+		err := fsa.CreateSubVolume(volume, NoGroup, subname, nil)
+		assert.NoError(t, err)
+		created = append(created, gn{NoGroup, subname})
+
+		lsv, err := fsa.ListSubVolumes(volume, NoGroup)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(lsv), 1)
+		assert.Contains(t, lsv, subname)
+	})
+
+	t.Run("options", func(t *testing.T) {
+		subname := "SubVol2"
+		o := &SubVolumeOptions{
+			Mode: 0777,
+			Uid:  200,
+			Gid:  200,
+		}
+		err := fsa.CreateSubVolume(volume, NoGroup, subname, o)
+		assert.NoError(t, err)
+		created = append(created, gn{NoGroup, subname})
+
+		lsv, err := fsa.ListSubVolumes(volume, NoGroup)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(lsv), 1)
+		assert.Contains(t, lsv, subname)
+	})
+
+	t.Run("withGroup", func(t *testing.T) {
+		group := "withGroup1"
+		subname := "SubVol3"
+
+		err := fsa.CreateSubVolumeGroup(volume, group, nil)
+		assert.NoError(t, err)
+
+		err = fsa.CreateSubVolume(volume, group, subname, nil)
+		assert.NoError(t, err)
+		created = append(created, gn{group, subname})
+
+		lsv, err := fsa.ListSubVolumes(volume, group)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(lsv), 1)
+		assert.Contains(t, lsv, subname)
+	})
+
+	t.Run("groupAndOptions", func(t *testing.T) {
+		group := "withGroup2"
+		subname := "SubVol4"
+		err := fsa.CreateSubVolumeGroup(volume, group, nil)
+		assert.NoError(t, err)
+
+		o := &SubVolumeOptions{
+			Size: 5 * gibiByte,
+			Mode: 0777,
+			Uid:  200,
+			Gid:  200,
+		}
+		err = fsa.CreateSubVolume(volume, group, subname, o)
+		assert.NoError(t, err)
+		created = append(created, gn{group, subname})
+
+		lsv, err := fsa.ListSubVolumes(volume, group)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(lsv), 1)
+		assert.Contains(t, lsv, subname)
+	})
+}
+
+func TestRemoveSubVolume(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+
+	lsv, err := fsa.ListSubVolumes(volume, NoGroup)
+	assert.NoError(t, err)
+	beforeCount := len(lsv)
+
+	err = fsa.CreateSubVolume(volume, NoGroup, "deletemev1", nil)
+	assert.NoError(t, err)
+
+	lsv, err = fsa.ListSubVolumes(volume, NoGroup)
+	assert.NoError(t, err)
+	afterCount := len(lsv)
+	assert.Equal(t, beforeCount, afterCount-1)
+
+	err = fsa.RemoveSubVolume(volume, NoGroup, "deletemev1")
+	assert.NoError(t, err)
+
+	delay()
+	lsv, err = fsa.ListSubVolumes(volume, NoGroup)
+	assert.NoError(t, err)
+	nowCount := len(lsv)
+	if !assert.Equal(t, beforeCount, nowCount) {
+		// this is a hack for debugging a flapping test
+		assert.Equal(t, []string{}, lsv)
+	}
+}

--- a/cephfs/admin/subvolumegroup.go
+++ b/cephfs/admin/subvolumegroup.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 // this is the internal type used to create JSON for ceph.

--- a/cephfs/admin/subvolumegroup.go
+++ b/cephfs/admin/subvolumegroup.go
@@ -1,0 +1,69 @@
+package admin
+
+// this is the internal type used to create JSON for ceph.
+// See SubVolumeGroupOptions for the type that users of the library
+// interact with.
+// note that the ceph json takes mode as a string.
+type subVolumeGroupFields struct {
+	Prefix     string `json:"prefix"`
+	Format     string `json:"format"`
+	VolName    string `json:"vol_name"`
+	GroupName  string `json:"group_name"`
+	Uid        int    `json:"uid,omitempty"`
+	Gid        int    `json:"gid,omitempty"`
+	Mode       string `json:"mode,omitempty"`
+	PoolLayout string `json:"pool_layout,omitempty"`
+}
+
+// SubVolumeGroupOptions are used to specify optional, non-identifying, values
+// to be used when creating a new subvolume group.
+type SubVolumeGroupOptions struct {
+	Uid        int
+	Gid        int
+	Mode       int
+	PoolLayout string
+}
+
+func (s *SubVolumeGroupOptions) toFields(v, g string) *subVolumeGroupFields {
+	return &subVolumeGroupFields{
+		Prefix:     "fs subvolumegroup create",
+		Format:     "json",
+		VolName:    v,
+		GroupName:  g,
+		Uid:        s.Uid,
+		Gid:        s.Gid,
+		Mode:       modeString(s.Mode, false),
+		PoolLayout: s.PoolLayout,
+	}
+}
+
+// CreateSubVolumeGroup sends a request to create a subvolume group in a volume.
+func (fsa *FSAdmin) CreateSubVolumeGroup(volume, name string, o *SubVolumeGroupOptions) error {
+	if o == nil {
+		o = &SubVolumeGroupOptions{}
+	}
+	r, s, err := fsa.marshalMgrCommand(o.toFields(volume, name))
+	return checkEmptyResponseExpected(r, s, err)
+}
+
+// ListSubVolumeGroups returns a list of subvolume groups belonging to the
+// specified volume.
+func (fsa *FSAdmin) ListSubVolumeGroups(volume string) ([]string, error) {
+	r, s, err := fsa.marshalMgrCommand(map[string]string{
+		"prefix":   "fs subvolumegroup ls",
+		"vol_name": volume,
+		"format":   "json",
+	})
+	return parseListNames(r, s, err)
+}
+
+// RemoveSubVolumeGroup will delete a subvolume group in a volume.
+func (fsa *FSAdmin) RemoveSubVolumeGroup(volume, name string) error {
+	r, s, err := fsa.marshalMgrCommand(map[string]string{
+		"prefix":     "fs subvolumegroup rm",
+		"vol_name":   volume,
+		"group_name": name,
+		"format":     "json",
+	})
+	return checkEmptyResponseExpected(r, s, err)
+}

--- a/cephfs/admin/subvolumegroup.go
+++ b/cephfs/admin/subvolumegroup.go
@@ -40,6 +40,9 @@ func (s *SubVolumeGroupOptions) toFields(v, g string) *subVolumeGroupFields {
 }
 
 // CreateSubVolumeGroup sends a request to create a subvolume group in a volume.
+//
+// Similar To:
+//  ceph fs subvolumegroup create <volume> <group_name>  ...
 func (fsa *FSAdmin) CreateSubVolumeGroup(volume, name string, o *SubVolumeGroupOptions) error {
 	if o == nil {
 		o = &SubVolumeGroupOptions{}
@@ -50,6 +53,9 @@ func (fsa *FSAdmin) CreateSubVolumeGroup(volume, name string, o *SubVolumeGroupO
 
 // ListSubVolumeGroups returns a list of subvolume groups belonging to the
 // specified volume.
+//
+// Similar To:
+//  ceph fs subvolumegroup ls cephfs <volume>
 func (fsa *FSAdmin) ListSubVolumeGroups(volume string) ([]string, error) {
 	r, s, err := fsa.marshalMgrCommand(map[string]string{
 		"prefix":   "fs subvolumegroup ls",
@@ -60,6 +66,8 @@ func (fsa *FSAdmin) ListSubVolumeGroups(volume string) ([]string, error) {
 }
 
 // RemoveSubVolumeGroup will delete a subvolume group in a volume.
+// Similar To:
+//  ceph fs subvolumegroup rm <volume> <group_name>
 func (fsa *FSAdmin) RemoveSubVolumeGroup(volume, name string) error {
 	r, s, err := fsa.marshalMgrCommand(map[string]string{
 		"prefix":     "fs subvolumegroup rm",

--- a/cephfs/admin/subvolumegroup_test.go
+++ b/cephfs/admin/subvolumegroup_test.go
@@ -1,0 +1,87 @@
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateSubVolumeGroup(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	created := []string{}
+	defer func() {
+		for _, name := range created {
+			err := fsa.RemoveSubVolumeGroup(volume, name)
+			assert.NoError(t, err)
+		}
+	}()
+
+	t.Run("simple", func(t *testing.T) {
+		svgroup := "svg1"
+		err := fsa.CreateSubVolumeGroup(volume, svgroup, nil)
+		assert.NoError(t, err)
+		created = append(created, svgroup)
+
+		lsvg, err := fsa.ListSubVolumeGroups(volume)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(lsvg), 1)
+		assert.Contains(t, lsvg, svgroup)
+	})
+
+	t.Run("options1", func(t *testing.T) {
+		svgroup := "svg2"
+		err := fsa.CreateSubVolumeGroup(volume, svgroup, &SubVolumeGroupOptions{
+			Mode: 0777,
+		})
+		assert.NoError(t, err)
+		created = append(created, svgroup)
+
+		lsvg, err := fsa.ListSubVolumeGroups(volume)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(lsvg), 1)
+		assert.Contains(t, lsvg, svgroup)
+	})
+
+	t.Run("options2", func(t *testing.T) {
+		svgroup := "anotherSVG"
+		err := fsa.CreateSubVolumeGroup(volume, svgroup, &SubVolumeGroupOptions{
+			Uid:  200,
+			Gid:  200,
+			Mode: 0771,
+			// TODO: test pool_layout... I think its a pool name
+		})
+		assert.NoError(t, err)
+		created = append(created, svgroup)
+
+		lsvg, err := fsa.ListSubVolumeGroups(volume)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(lsvg), 1)
+		assert.Contains(t, lsvg, svgroup)
+	})
+}
+
+func TestRemoveSubVolumeGroup(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+
+	lsvg, err := fsa.ListSubVolumeGroups(volume)
+	assert.NoError(t, err)
+	beforeCount := len(lsvg)
+
+	err = fsa.CreateSubVolumeGroup(volume, "deleteme1", nil)
+	assert.NoError(t, err)
+
+	lsvg, err = fsa.ListSubVolumeGroups(volume)
+	assert.NoError(t, err)
+	afterCount := len(lsvg)
+	assert.Equal(t, beforeCount, afterCount-1)
+
+	err = fsa.RemoveSubVolumeGroup(volume, "deleteme1")
+	assert.NoError(t, err)
+
+	lsvg, err = fsa.ListSubVolumeGroups(volume)
+	assert.NoError(t, err)
+	nowCount := len(lsvg)
+	assert.Equal(t, beforeCount, nowCount)
+}

--- a/cephfs/admin/subvolumegroup_test.go
+++ b/cephfs/admin/subvolumegroup_test.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 import (

--- a/cephfs/admin/volume.go
+++ b/cephfs/admin/volume.go
@@ -5,6 +5,9 @@ package admin
 var listVolumesCmd = []byte(`{"prefix":"fs volume ls"}`)
 
 // ListVolumes return a list of volumes in this Ceph cluster.
+//
+// Similar To:
+//  ceph fs volume ls
 func (fsa *FSAdmin) ListVolumes() ([]string, error) {
 	r, s, err := fsa.rawMgrCommand(listVolumesCmd)
 	return parseListNames(r, s, err)

--- a/cephfs/admin/volume.go
+++ b/cephfs/admin/volume.go
@@ -1,0 +1,44 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+var listVolumesCmd = []byte(`{"prefix":"fs volume ls"}`)
+
+// ListVolumes return a list of volumes in this Ceph cluster.
+func (fsa *FSAdmin) ListVolumes() ([]string, error) {
+	r, s, err := fsa.rawMgrCommand(listVolumesCmd)
+	return parseListNames(r, s, err)
+}
+
+// VolumeStatus reports various properties of a CephFS volume.
+// TODO: Fill in.
+type VolumeStatus struct {
+	MDSVersion string `json:"mds_version"`
+}
+
+func parseVolumeStatus(res []byte, status string, err error) (*VolumeStatus, error) {
+	if err != nil {
+		return nil, err
+	}
+	if status != "" {
+		return nil, fmt.Errorf("error status: %s", status)
+	}
+	var vs VolumeStatus
+	if err := json.Unmarshal(res, &vs); err != nil {
+		return nil, err
+	}
+	return &vs, nil
+}
+
+// VolumeStatus returns a VolumeStatus object for the given volume name.
+func (fsa *FSAdmin) VolumeStatus(name string) (*VolumeStatus, error) {
+	r, s, err := fsa.marshalMgrCommand(map[string]string{
+		"fs":     name,
+		"prefix": "fs status",
+		"format": "json",
+	})
+	return parseVolumeStatus(r, s, err)
+}

--- a/cephfs/admin/volume.go
+++ b/cephfs/admin/volume.go
@@ -9,35 +9,3 @@ func (fsa *FSAdmin) ListVolumes() ([]string, error) {
 	r, s, err := fsa.rawMgrCommand(listVolumesCmd)
 	return parseListNames(r, s, err)
 }
-
-// VolumePool reports on the pool status for a CephFS volume.
-type VolumePool struct {
-	ID        int    `json:"id"`
-	Name      string `json:"name"`
-	Type      string `json:"type"`
-	Available uint64 `json:"avail"`
-	Used      uint64 `json:"used"`
-}
-
-// VolumeStatus reports various properties of a CephFS volume.
-// TODO: Fill in.
-type VolumeStatus struct {
-	MDSVersion string       `json:"mds_version"`
-	Pools      []VolumePool `json:"pools"`
-}
-
-func parseVolumeStatus(res []byte, status string, err error) (*VolumeStatus, error) {
-	var vs VolumeStatus
-	err = unmarshalResponseJSON(res, status, err, &vs)
-	return &vs, err
-}
-
-// VolumeStatus returns a VolumeStatus object for the given volume name.
-func (fsa *FSAdmin) VolumeStatus(name string) (*VolumeStatus, error) {
-	r, s, err := fsa.marshalMgrCommand(map[string]string{
-		"fs":     name,
-		"prefix": "fs status",
-		"format": "json",
-	})
-	return parseVolumeStatus(r, s, err)
-}

--- a/cephfs/admin/volume.go
+++ b/cephfs/admin/volume.go
@@ -1,10 +1,5 @@
 package admin
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 var listVolumesCmd = []byte(`{"prefix":"fs volume ls"}`)
 
 // ListVolumes return a list of volumes in this Ceph cluster.
@@ -13,24 +8,26 @@ func (fsa *FSAdmin) ListVolumes() ([]string, error) {
 	return parseListNames(r, s, err)
 }
 
+// VolumePool reports on the pool status for a CephFS volume.
+type VolumePool struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Available uint64 `json:"avail"`
+	Used      uint64 `json:"used"`
+}
+
 // VolumeStatus reports various properties of a CephFS volume.
 // TODO: Fill in.
 type VolumeStatus struct {
-	MDSVersion string `json:"mds_version"`
+	MDSVersion string       `json:"mds_version"`
+	Pools      []VolumePool `json:"pools"`
 }
 
 func parseVolumeStatus(res []byte, status string, err error) (*VolumeStatus, error) {
-	if err != nil {
-		return nil, err
-	}
-	if status != "" {
-		return nil, fmt.Errorf("error status: %s", status)
-	}
 	var vs VolumeStatus
-	if err := json.Unmarshal(res, &vs); err != nil {
-		return nil, err
-	}
-	return &vs, nil
+	err = unmarshalResponseJSON(res, status, err, &vs)
+	return &vs, err
 }
 
 // VolumeStatus returns a VolumeStatus object for the given volume name.

--- a/cephfs/admin/volume.go
+++ b/cephfs/admin/volume.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 var listVolumesCmd = []byte(`{"prefix":"fs volume ls"}`)

--- a/cephfs/admin/volume_octopus.go
+++ b/cephfs/admin/volume_octopus.go
@@ -25,6 +25,9 @@ func parseVolumeStatus(res []byte, status string, err error) (*VolumeStatus, err
 }
 
 // VolumeStatus returns a VolumeStatus object for the given volume name.
+//
+// Similar To:
+//  ceph fs status cephfs <name>
 func (fsa *FSAdmin) VolumeStatus(name string) (*VolumeStatus, error) {
 	r, s, err := fsa.marshalMgrCommand(map[string]string{
 		"fs":     name,

--- a/cephfs/admin/volume_octopus.go
+++ b/cephfs/admin/volume_octopus.go
@@ -1,0 +1,35 @@
+// +build octopus
+
+package admin
+
+// VolumePool reports on the pool status for a CephFS volume.
+type VolumePool struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Available uint64 `json:"avail"`
+	Used      uint64 `json:"used"`
+}
+
+// VolumeStatus reports various properties of a CephFS volume.
+// TODO: Fill in.
+type VolumeStatus struct {
+	MDSVersion string       `json:"mds_version"`
+	Pools      []VolumePool `json:"pools"`
+}
+
+func parseVolumeStatus(res []byte, status string, err error) (*VolumeStatus, error) {
+	var vs VolumeStatus
+	err = unmarshalResponseJSON(res, status, err, &vs)
+	return &vs, err
+}
+
+// VolumeStatus returns a VolumeStatus object for the given volume name.
+func (fsa *FSAdmin) VolumeStatus(name string) (*VolumeStatus, error) {
+	r, s, err := fsa.marshalMgrCommand(map[string]string{
+		"fs":     name,
+		"prefix": "fs status",
+		"format": "json",
+	})
+	return parseVolumeStatus(r, s, err)
+}

--- a/cephfs/admin/volume_octopus_test.go
+++ b/cephfs/admin/volume_octopus_test.go
@@ -1,0 +1,51 @@
+// +build octopus
+
+package admin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVolumeStatus(t *testing.T) {
+	fsa := getFSAdmin(t)
+
+	vs, err := fsa.VolumeStatus("cephfs")
+	assert.NoError(t, err)
+	assert.Contains(t, vs.MDSVersion, "version")
+}
+
+var sampleVolumeStatus1 = []byte(`
+{
+"clients": [{"clients": 1, "fs": "cephfs"}],
+"mds_version": "ceph version 15.2.4 (7447c15c6ff58d7fce91843b705a268a1917325c) octopus (stable)",
+"mdsmap": [{"dns": 76, "inos": 19, "name": "Z", "rank": 0, "rate": 0.0, "state": "active"}],
+"pools": [{"avail": 1017799872, "id": 2, "name": "cephfs_metadata", "type": "metadata", "used": 2204126}, {"avail": 1017799872, "id": 1, "name": "cephfs_data", "type": "data", "used": 0}]
+}
+`)
+
+func TestParseVolumeStatus(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
+		_, err := parseVolumeStatus(nil, "", errors.New("bonk"))
+		assert.Error(t, err)
+		assert.Equal(t, "bonk", err.Error())
+	})
+	t.Run("statusSet", func(t *testing.T) {
+		_, err := parseVolumeStatus(nil, "unexpected!", nil)
+		assert.Error(t, err)
+	})
+	t.Run("badJSON", func(t *testing.T) {
+		_, err := parseVolumeStatus([]byte("_XxXxX"), "", nil)
+		assert.Error(t, err)
+	})
+	t.Run("ok", func(t *testing.T) {
+		s, err := parseVolumeStatus(sampleVolumeStatus1, "", nil)
+		assert.NoError(t, err)
+		if assert.NotNil(t, s) {
+			assert.Contains(t, s.MDSVersion, "ceph version 15.2.4")
+			assert.Contains(t, s.MDSVersion, "octopus")
+		}
+	})
+}

--- a/cephfs/admin/volume_test.go
+++ b/cephfs/admin/volume_test.go
@@ -1,3 +1,5 @@
+// +build !luminous,!mimic
+
 package admin
 
 import (

--- a/cephfs/admin/volume_test.go
+++ b/cephfs/admin/volume_test.go
@@ -3,7 +3,6 @@
 package admin
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,45 +15,4 @@ func TestListVolumes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, vl, 1)
 	assert.Equal(t, "cephfs", vl[0])
-}
-
-func TestVolumeStatus(t *testing.T) {
-	fsa := getFSAdmin(t)
-
-	vs, err := fsa.VolumeStatus("cephfs")
-	assert.NoError(t, err)
-	assert.Contains(t, vs.MDSVersion, "version")
-}
-
-var sampleVolumeStatus1 = []byte(`
-{
-"clients": [{"clients": 1, "fs": "cephfs"}],
-"mds_version": "ceph version 15.2.4 (7447c15c6ff58d7fce91843b705a268a1917325c) octopus (stable)",
-"mdsmap": [{"dns": 76, "inos": 19, "name": "Z", "rank": 0, "rate": 0.0, "state": "active"}],
-"pools": [{"avail": 1017799872, "id": 2, "name": "cephfs_metadata", "type": "metadata", "used": 2204126}, {"avail": 1017799872, "id": 1, "name": "cephfs_data", "type": "data", "used": 0}]
-}
-`)
-
-func TestParseVolumeStatus(t *testing.T) {
-	t.Run("error", func(t *testing.T) {
-		_, err := parseVolumeStatus(nil, "", errors.New("bonk"))
-		assert.Error(t, err)
-		assert.Equal(t, "bonk", err.Error())
-	})
-	t.Run("statusSet", func(t *testing.T) {
-		_, err := parseVolumeStatus(nil, "unexpected!", nil)
-		assert.Error(t, err)
-	})
-	t.Run("badJSON", func(t *testing.T) {
-		_, err := parseVolumeStatus([]byte("_XxXxX"), "", nil)
-		assert.Error(t, err)
-	})
-	t.Run("ok", func(t *testing.T) {
-		s, err := parseVolumeStatus(sampleVolumeStatus1, "", nil)
-		assert.NoError(t, err)
-		if assert.NotNil(t, s) {
-			assert.Contains(t, s.MDSVersion, "ceph version 15.2.4")
-			assert.Contains(t, s.MDSVersion, "octopus")
-		}
-	})
 }

--- a/cephfs/admin/volume_test.go
+++ b/cephfs/admin/volume_test.go
@@ -1,0 +1,58 @@
+package admin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListVolumes(t *testing.T) {
+	fsa := getFSAdmin(t)
+
+	vl, err := fsa.ListVolumes()
+	assert.NoError(t, err)
+	assert.Len(t, vl, 1)
+	assert.Equal(t, "cephfs", vl[0])
+}
+
+func TestVolumeStatus(t *testing.T) {
+	fsa := getFSAdmin(t)
+
+	vs, err := fsa.VolumeStatus("cephfs")
+	assert.NoError(t, err)
+	assert.Contains(t, vs.MDSVersion, "version")
+}
+
+var sampleVolumeStatus1 = []byte(`
+{
+"clients": [{"clients": 1, "fs": "cephfs"}],
+"mds_version": "ceph version 15.2.4 (7447c15c6ff58d7fce91843b705a268a1917325c) octopus (stable)",
+"mdsmap": [{"dns": 76, "inos": 19, "name": "Z", "rank": 0, "rate": 0.0, "state": "active"}],
+"pools": [{"avail": 1017799872, "id": 2, "name": "cephfs_metadata", "type": "metadata", "used": 2204126}, {"avail": 1017799872, "id": 1, "name": "cephfs_data", "type": "data", "used": 0}]
+}
+`)
+
+func TestParseVolumeStatus(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
+		_, err := parseVolumeStatus(nil, "", errors.New("bonk"))
+		assert.Error(t, err)
+		assert.Equal(t, "bonk", err.Error())
+	})
+	t.Run("statusSet", func(t *testing.T) {
+		_, err := parseVolumeStatus(nil, "unexpected!", nil)
+		assert.Error(t, err)
+	})
+	t.Run("badJSON", func(t *testing.T) {
+		_, err := parseVolumeStatus([]byte("_XxXxX"), "", nil)
+		assert.Error(t, err)
+	})
+	t.Run("ok", func(t *testing.T) {
+		s, err := parseVolumeStatus(sampleVolumeStatus1, "", nil)
+		assert.NoError(t, err)
+		if assert.NotNil(t, s) {
+			assert.Contains(t, s.MDSVersion, "ceph version 15.2.4")
+			assert.Contains(t, s.MDSVersion, "octopus")
+		}
+	})
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -184,6 +184,7 @@ test_go_ceph() {
     P=github.com/ceph/go-ceph
     pkgs=(\
         "cephfs" \
+        "cephfs/admin" \
         "internal/callbacks" \
         "internal/cutil" \
         "internal/errutil" \


### PR DESCRIPTION
Fixes: #341 (it's a beginning at least)
Fixes: #202 

This is a RFC / design review PR for a new package, named "cephfs/admin", that aims to provide a simple API for administrating CephFS volumes. The focus is on functions needed to create/remove/update/view subvolumes and subvoulme groups. As noted in the linked issue, the first consumer is expected to be ceph-csi but the aim to have a general API that can be consumed by any Go code that wants to manage cephfs volumes. Ideally, this module should be both more efficient and more convenient than shelling out to the `ceph` cli tool.

Functions currently covered:
* CreateSubVolume
* CreateSubVolumeGroup
* ListSubVolumeGroups
* ListSubVolumes
* ListVolumes
* RemoveSubVolume
* RemoveSubVolumeGroup
* ResizeSubVolume
* VolumeStatus

I'll try and resist the temptation to add more functions at this point and wait for reviews/discussion. I'm happy to hear any suggestions around the API style, naming, etc. as this API is more under go-ceph's direct control rather than needing to hew closely to the ceph C apis, like our other packages.

There are still a few small gaps in the tests but most of them can be improved in follow on PRs and as we add additional functions to the module. These are not all the functions ceph-csi will need, but mainly just a start and demonstration of the approach I'd like to go with.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
