### PR TITLE
General changes to error types

### DIFF
--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -7,7 +7,6 @@ import "C"
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/ceph/go-ceph/internal/errutil"
 )
@@ -17,11 +16,7 @@ type cephFSError int
 
 // Error returns the error string for the cephFSError type.
 func (e cephFSError) Error() string {
-	errno, s := errutil.FormatErrno(int(e))
-	if s == "" {
-		return fmt.Sprintf("cephfs: ret=%d", errno)
-	}
-	return fmt.Sprintf("cephfs: ret=%d, %s", errno, s)
+	return errutil.FormatErrorCode("cephfs", int(e))
 }
 
 func (e cephFSError) ErrorCode() int {

--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -24,7 +24,7 @@ func (e cephFSError) Error() string {
 	return fmt.Sprintf("cephfs: ret=%d, %s", errno, s)
 }
 
-func (e cephFSError) Errno() int {
+func (e cephFSError) ErrorCode() int {
 	return int(e)
 }
 

--- a/cephfs/errors_test.go
+++ b/cephfs/errors_test.go
@@ -13,7 +13,7 @@ func TestCephFSError(t *testing.T) {
 
 	err = getError(-5) // IO error
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "cephfs: ret=5, Input/output error")
+	assert.Equal(t, err.Error(), "cephfs: ret=-5, Input/output error")
 
 	errno, ok := err.(interface{ ErrorCode() int })
 	assert.True(t, ok)

--- a/cephfs/errors_test.go
+++ b/cephfs/errors_test.go
@@ -15,10 +15,10 @@ func TestCephFSError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "cephfs: ret=5, Input/output error")
 
-	errno, ok := err.(interface{ Errno() int })
+	errno, ok := err.(interface{ ErrorCode() int })
 	assert.True(t, ok)
 	require.NotNil(t, errno)
-	assert.Equal(t, errno.Errno(), -5)
+	assert.Equal(t, errno.ErrorCode(), -5)
 
 	err = getError(345) // no such errno
 	assert.Error(t, err)

--- a/internal/errutil/strerror.go
+++ b/internal/errutil/strerror.go
@@ -14,6 +14,7 @@ package errutil
 import "C"
 
 import (
+	"fmt"
 	"unsafe"
 )
 
@@ -37,9 +38,15 @@ func FormatErrno(errno int) (int, string) {
 	return errno, C.GoString((*C.char)(unsafe.Pointer(&buf[0])))
 }
 
-// StrError returns a string describing the errno. The string will be empty if
-// the errno is not known.
-func StrError(errno int) string {
-	_, s := FormatErrno(errno)
-	return s
+// FormatErrorCode returns a string that describes the supplied error source
+// and error code as a string. Suitable to use in Error() methods.  If the
+// error code maps to an errno the string will contain a description of the
+// error. Otherwise the string will only indicate the source and value if the
+// value does not map to a known errno.
+func FormatErrorCode(source string, errValue int) string {
+	_, s := FormatErrno(errValue)
+	if s == "" {
+		return fmt.Sprintf("%s: ret=%d", source, errValue)
+	}
+	return fmt.Sprintf("%s: ret=%d, %s", source, errValue, s)
 }

--- a/internal/errutil/strerror_test.go
+++ b/internal/errutil/strerror_test.go
@@ -20,13 +20,13 @@ func TestFormatError(t *testing.T) {
 	assert.Equal(t, msg, "")
 }
 
-func TestStrError(t *testing.T) {
-	msg := StrError(39)
-	assert.Equal(t, msg, "Directory not empty")
+func TestFormatErrorCode(t *testing.T) {
+	msg := FormatErrorCode("test", -39)
+	assert.Equal(t, msg, "test: ret=-39, Directory not empty")
 
-	msg = StrError(-5)
-	assert.Equal(t, msg, "Input/output error")
+	msg = FormatErrorCode("test", -5)
+	assert.Equal(t, msg, "test: ret=-5, Input/output error")
 
-	msg = StrError(345)
-	assert.Equal(t, msg, "")
+	msg = FormatErrorCode("boop", 345)
+	assert.Equal(t, msg, "boop: ret=345")
 }

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -7,7 +7,6 @@ import "C"
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/ceph/go-ceph/internal/errutil"
 )
@@ -17,11 +16,7 @@ type radosError int
 
 // Error returns the error string for the radosError type.
 func (e radosError) Error() string {
-	errno, s := errutil.FormatErrno(int(e))
-	if s == "" {
-		return fmt.Sprintf("rados: ret=%d", errno)
-	}
-	return fmt.Sprintf("rados: ret=%d, %s", errno, s)
+	return errutil.FormatErrorCode("rados", int(e))
 }
 
 func (e radosError) ErrorCode() int {

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -24,7 +24,7 @@ func (e radosError) Error() string {
 	return fmt.Sprintf("rados: ret=%d, %s", errno, s)
 }
 
-func (e radosError) Errno() int {
+func (e radosError) ErrorCode() int {
 	return int(e)
 }
 

--- a/rados/errors_test.go
+++ b/rados/errors_test.go
@@ -15,10 +15,10 @@ func TestRadosError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "rados: ret=5, Input/output error")
 
-	errno, ok := err.(interface{ Errno() int })
+	errno, ok := err.(interface{ ErrorCode() int })
 	assert.True(t, ok)
 	require.NotNil(t, errno)
-	assert.Equal(t, errno.Errno(), -5)
+	assert.Equal(t, errno.ErrorCode(), -5)
 
 	err = getError(345) // no such errno
 	assert.Error(t, err)

--- a/rados/errors_test.go
+++ b/rados/errors_test.go
@@ -13,7 +13,7 @@ func TestRadosError(t *testing.T) {
 
 	err = getError(-5) // IO error
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "rados: ret=5, Input/output error")
+	assert.Equal(t, err.Error(), "rados: ret=-5, Input/output error")
 
 	errno, ok := err.(interface{ ErrorCode() int })
 	assert.True(t, ok)

--- a/rbd/diff_iterate_test.go
+++ b/rbd/diff_iterate_test.go
@@ -335,8 +335,8 @@ func testDiffIterateEarlyExit(t *testing.T, ioctx *rados.IOContext) {
 			},
 		})
 	assert.Error(t, err)
-	if errno, ok := err.(interface{ Errno() int }); assert.True(t, ok) {
-		assert.EqualValues(t, -5, errno.Errno())
+	if errno, ok := err.(interface{ ErrorCode() int }); assert.True(t, ok) {
+		assert.EqualValues(t, -5, errno.ErrorCode())
 	}
 	if assert.Len(t, calls, 1) {
 		assert.EqualValues(t, 0, calls[0].offset)

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -7,7 +7,6 @@ import "C"
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/ceph/go-ceph/internal/errutil"
 )
@@ -16,11 +15,7 @@ import (
 type rbdError int
 
 func (e rbdError) Error() string {
-	errno, s := errutil.FormatErrno(int(e))
-	if s == "" {
-		return fmt.Sprintf("rbd: ret=%d", errno)
-	}
-	return fmt.Sprintf("rbd: ret=%d, %s", errno, s)
+	return errutil.FormatErrorCode("rbd", int(e))
 }
 
 func (e rbdError) ErrorCode() int {

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -23,7 +23,7 @@ func (e rbdError) Error() string {
 	return fmt.Sprintf("rbd: ret=%d, %s", errno, s)
 }
 
-func (e rbdError) Errno() int {
+func (e rbdError) ErrorCode() int {
 	return int(e)
 }
 

--- a/rbd/errors_test.go
+++ b/rbd/errors_test.go
@@ -15,10 +15,10 @@ func TestRBDError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "rbd: ret=39, Directory not empty")
 
-	errno, ok := err.(interface{ Errno() int })
+	errno, ok := err.(interface{ ErrorCode() int })
 	assert.True(t, ok)
 	require.NotNil(t, errno)
-	assert.Equal(t, errno.Errno(), -39)
+	assert.Equal(t, errno.ErrorCode(), -39)
 
 	err = getError(345) // no such errno
 	assert.Error(t, err)

--- a/rbd/errors_test.go
+++ b/rbd/errors_test.go
@@ -13,7 +13,7 @@ func TestRBDError(t *testing.T) {
 
 	err = getError(-39) // NOTEMPTY (image still has a snapshot)
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "rbd: ret=39, Directory not empty")
+	assert.Equal(t, err.Error(), "rbd: ret=-39, Directory not empty")
 
 	errno, ok := err.(interface{ ErrorCode() int })
 	assert.True(t, ok)


### PR DESCRIPTION
Fixes: #343 

These changes change the function that was formerly called `Errno` to `ErrorCode`.
For consistency with the above we now use a common formatting function for the three package error types and it prints negative numbers when the error code is negative (as it should typically be).

See linked issue for more context.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
