### PR TITLE
testing: use supported golang version in ci container images

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -10,7 +10,7 @@ RUN true && \
     (yum install -y /usr/bin/castxml || true) && \
     true
 
-ENV GOTAR=go1.12.17.linux-amd64.tar.gz
+ENV GOTAR=go1.14.7.linux-amd64.tar.gz
 RUN true && \
     curl -o /tmp/${GOTAR} https://dl.google.com/go/${GOTAR} && \
     tar -x -C /opt/ -f /tmp/${GOTAR} && \


### PR DESCRIPTION
Bump the golang version to 1.14.7. Go 1.14 is now the older supported
version, with the recent release of Go.
