### PR TITLE
cephfs admin: add getpath functions for subvolume and subvolumegroup

### DIFF
--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -117,6 +117,24 @@ func unmarshalResponseJSON(res []byte, status string, err error, v interface{}) 
 	return json.Unmarshal(res, v)
 }
 
+// extractPathResponse returns a cleaned up path from requests that get a path
+// unless an error is encountered, then an error is returned.
+func extractPathResponse(res []byte, status string, err error) (string, error) {
+	if err != nil {
+		return "", err
+	}
+	if status != "" {
+		return "", fmt.Errorf("error status: %s", status)
+	}
+	// if there's a trailing newline in the buffer strip it.
+	// ceph assumes a CLI wants the output of the buffer and there's
+	// no format=json mode available currently.
+	for len(res) >= 1 && res[len(res)-1] == '\n' {
+		res = res[:len(res)-1]
+	}
+	return string(res), nil
+}
+
 // modeString converts a unix-style mode value to a string-ified version in an
 // octal representation (e.g. "777", "700", etc). This format is expected by
 // some of the ceph JSON command inputs.

--- a/cephfs/admin/subvolume.go
+++ b/cephfs/admin/subvolume.go
@@ -143,3 +143,20 @@ func (fsa *FSAdmin) ResizeSubVolume(
 	}
 	return result[0], nil
 }
+
+// SubVolumePath returns the path to the subvolume from the root of the file system.
+//
+// Similar To:
+//  ceph fs subvolume getpath <volume> --group-name=<group> <name>
+func (fsa *FSAdmin) SubVolumePath(volume, group, name string) (string, error) {
+	m := map[string]string{
+		"prefix":   "fs subvolume getpath",
+		"vol_name": volume,
+		"sub_name": name,
+		// ceph doesn't respond in json for this cmd (even if you ask)
+	}
+	if group != NoGroup {
+		m["group_name"] = group
+	}
+	return extractPathResponse(fsa.marshalMgrCommand(m))
+}

--- a/cephfs/admin/subvolume_test.go
+++ b/cephfs/admin/subvolume_test.go
@@ -173,3 +173,35 @@ func TestResizeSubVolume(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, rr)
 }
+
+func TestSubVolumePath(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	group := "svpGroup"
+	subname := "svp1"
+
+	err := fsa.CreateSubVolumeGroup(volume, group, nil)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeGroup(volume, group)
+		assert.NoError(t, err)
+	}()
+
+	err = fsa.CreateSubVolume(volume, group, subname, nil)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolume(volume, group, subname)
+		assert.NoError(t, err)
+	}()
+
+	path, err := fsa.SubVolumePath(volume, group, subname)
+	assert.NoError(t, err)
+	assert.Contains(t, path, group)
+	assert.Contains(t, path, subname)
+	assert.NotContains(t, path, "\n")
+
+	// invalid subname
+	path, err = fsa.SubVolumePath(volume, group, "oops")
+	assert.Error(t, err)
+	assert.Equal(t, "", path)
+}

--- a/cephfs/admin/subvolumegroup.go
+++ b/cephfs/admin/subvolumegroup.go
@@ -77,3 +77,18 @@ func (fsa *FSAdmin) RemoveSubVolumeGroup(volume, name string) error {
 	})
 	return checkEmptyResponseExpected(r, s, err)
 }
+
+// SubVolumeGroupPath returns the path to the subvolume from the root of the
+// file system.
+//
+// Similar To:
+//  ceph fs subvolumegroup getpath <volume> <group_name>
+func (fsa *FSAdmin) SubVolumeGroupPath(volume, name string) (string, error) {
+	m := map[string]string{
+		"prefix":     "fs subvolumegroup getpath",
+		"vol_name":   volume,
+		"group_name": name,
+		// ceph doesn't respond in json for this cmd (even if you ask)
+	}
+	return extractPathResponse(fsa.marshalMgrCommand(m))
+}

--- a/cephfs/admin/subvolumegroup_test.go
+++ b/cephfs/admin/subvolumegroup_test.go
@@ -87,3 +87,26 @@ func TestRemoveSubVolumeGroup(t *testing.T) {
 	nowCount := len(lsvg)
 	assert.Equal(t, beforeCount, nowCount)
 }
+
+func TestSubVolumeGroupPath(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	group := "grewp"
+
+	err := fsa.CreateSubVolumeGroup(volume, group, nil)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeGroup(volume, group)
+		assert.NoError(t, err)
+	}()
+
+	path, err := fsa.SubVolumeGroupPath(volume, group)
+	assert.NoError(t, err)
+	assert.Contains(t, path, "/volumes/"+group)
+	assert.NotContains(t, path, "\n")
+
+	// invalid group name
+	path, err = fsa.SubVolumeGroupPath(volume, "oops")
+	assert.Error(t, err)
+	assert.Equal(t, "", path)
+}


### PR DESCRIPTION
* Add a SubVolumePath function (fixes #355 )
* Add a SubVolumeGroupPath function (fixes #358 )

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
