### PR TITLE
cephfs admin: add subvolume info function

### DIFF
--- a/cephfs/admin/bytecount.go
+++ b/cephfs/admin/bytecount.go
@@ -13,25 +13,25 @@ const (
 	tebiByte           = 1024 * gibiByte
 )
 
-// newSizeValue returns a size value as a string, as needed by the subvolume
+// resizeValue returns a size value as a string, as needed by the subvolume
 // resize command json.
-func (bc ByteCount) newSizeValue() string {
+func (bc ByteCount) resizeValue() string {
 	return uint64String(uint64(bc))
 }
 
-// NewSize interface values can be used to change the size of a volume.
-type NewSize interface {
-	newSizeValue() string
+// QuotaSize interface values can be used to change the size of a volume.
+type QuotaSize interface {
+	resizeValue() string
 }
 
-// specialSize is a custom non-numeric new size value.
+// specialSize is a custom non-numeric quota size value.
 type specialSize string
 
-// newSizeValue for a specialSize returns the literal string.
-func (s specialSize) newSizeValue() string {
+// resizeValue for a specialSize returns the original string value.
+func (s specialSize) resizeValue() string {
 	return string(s)
 }
 
-// Infinite is a special NewSize value that can be used to clear size limits on
-// a subvolume.
+// Infinite is a special QuotaSize value that can be used to clear size limits
+// on a subvolume.
 const Infinite = specialSize("infinite")

--- a/cephfs/admin/subvolume.go
+++ b/cephfs/admin/subvolume.go
@@ -125,7 +125,7 @@ type SubVolumeResizeResult struct {
 //  ceph fs subvolume resize <volume> --group-name=<group> <name> ...
 func (fsa *FSAdmin) ResizeSubVolume(
 	volume, group, name string,
-	newSize NewSize, noShrink bool) (*SubVolumeResizeResult, error) {
+	newSize QuotaSize, noShrink bool) (*SubVolumeResizeResult, error) {
 
 	f := &subVolumeResizeFields{
 		Prefix:    "fs subvolume resize",
@@ -133,7 +133,7 @@ func (fsa *FSAdmin) ResizeSubVolume(
 		VolName:   volume,
 		GroupName: group,
 		SubName:   name,
-		NewSize:   newSize.newSizeValue(),
+		NewSize:   newSize.resizeValue(),
 		NoShrink:  noShrink,
 	}
 	var result []*SubVolumeResizeResult

--- a/cephfs/admin/timestamp.go
+++ b/cephfs/admin/timestamp.go
@@ -1,0 +1,39 @@
+// +build !luminous,!mimic
+
+package admin
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// golang's date parsing approach is rather bizarre
+var cephTSLayout = "2006-01-02 15:04:05"
+
+// TimeStamp abstracts some of the details about date+time stamps
+// returned by ceph via JSON.
+type TimeStamp struct {
+	time.Time
+}
+
+// String returns a string representing the date+time as presented
+// by ceph.
+func (ts TimeStamp) String() string {
+	return ts.Format(cephTSLayout)
+}
+
+// UnmarshalJSON implements the json Unmarshaler interface.
+func (ts *TimeStamp) UnmarshalJSON(b []byte) error {
+	var raw string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	// AFAICT, ceph always returns the time in UTC so Parse, as opposed to
+	// ParseInLocation, is appropriate here.
+	t, err := time.Parse(cephTSLayout, raw)
+	if err != nil {
+		return err
+	}
+	*ts = TimeStamp{t}
+	return nil
+}

--- a/cephfs/admin/timestamp_test.go
+++ b/cephfs/admin/timestamp_test.go
@@ -1,0 +1,44 @@
+// +build !luminous,!mimic
+
+package admin
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeStampUnmarshal(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		j1 := []byte(`"2020-01-03 18:03:21"`)
+		var ts TimeStamp
+		err := json.Unmarshal(j1, &ts)
+		assert.NoError(t, err)
+		assert.Equal(t, 2020, ts.Year())
+		assert.Equal(t, time.Month(1), ts.Month())
+		assert.Equal(t, 3, ts.Day())
+	})
+	t.Run("badType", func(t *testing.T) {
+		j1 := []byte(`["2020-01-03 18:03:21"]`)
+		var ts TimeStamp
+		err := json.Unmarshal(j1, &ts)
+		assert.Error(t, err)
+	})
+	t.Run("badValue", func(t *testing.T) {
+		j1 := []byte(`"just another manic monday"`)
+		var ts TimeStamp
+		err := json.Unmarshal(j1, &ts)
+		assert.Error(t, err)
+	})
+}
+
+func TestTimeStampString(t *testing.T) {
+	s := "2020-11-06 11:33:56"
+	ti, err := time.Parse(cephTSLayout, s)
+	if assert.NoError(t, err) {
+		ts := TimeStamp{ti}
+		assert.Equal(t, s, ts.String())
+	}
+}


### PR DESCRIPTION
Fixes: #363

Add the SubVolumeInfo function, returning SubVolumeInfo type. There are two customization worth noting, the TimeStamp type is added to deal with the difference between Go JSON defaults for time.Time and ceph's, and the use of a placeholder type to unmarshal the value of the "bytes_quota" field, which can either be a string "infinite" or a numeric value. This maps well to the previously created interface, but interfaces can't unmarshal themselves. The placeholder type helps with this conversion. See commit msg for more details.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
