### PR TITLE
cephfs admin: add support for a list of features in SubVolumeInfo

### DIFF
--- a/cephfs/admin/subvolume.go
+++ b/cephfs/admin/subvolume.go
@@ -174,6 +174,21 @@ func (fsa *FSAdmin) SubVolumePath(volume, group, name string) (string, error) {
 	return parsePathResponse(fsa.marshalMgrCommand(m))
 }
 
+// Feature is used to define constant values for optional features on
+// subvolumes.
+type Feature string
+
+const (
+	// SnapshotCloneFeature indicates a subvolume supports cloning.
+	SnapshotCloneFeature = Feature("snapshot-clone")
+	// SnapshotAutoprotectFeature indicates a subvolume does not require
+	// manually protecting a subvolume before cloning.
+	SnapshotAutoprotectFeature = Feature("snapshot-autoprotect")
+	// SnapshotRetentionFeature indicates a subvolume supports retaining
+	// snapshots on subvolume removal.
+	SnapshotRetentionFeature = Feature("snapshot-retention")
+)
+
 // SubVolumeInfo reports various informational values about a subvolume.
 type SubVolumeInfo struct {
 	Type          string    `json:"type"`
@@ -190,6 +205,7 @@ type SubVolumeInfo struct {
 	Mtime         TimeStamp `json:"mtime"`
 	Ctime         TimeStamp `json:"ctime"`
 	CreatedAt     TimeStamp `json:"created_at"`
+	Features      []Feature `json:"features"`
 }
 
 type subVolumeInfoWrapper struct {

--- a/cephfs/admin/subvolume_test.go
+++ b/cephfs/admin/subvolume_test.go
@@ -260,6 +260,32 @@ var sampleSubVolumeInfo2 = []byte(`
 }
 `)
 
+var sampleSubVolumeInfo3 = []byte(`
+{
+    "atime": "2020-10-02 13:48:17",
+    "bytes_pcent": "undefined",
+    "bytes_quota": "infinite",
+    "bytes_used": 0,
+    "created_at": "2020-10-02 13:48:17",
+    "ctime": "2020-10-02 13:48:17",
+    "data_pool": "cephfs_data",
+    "features": [
+        "snapshot-clone",
+        "snapshot-autoprotect"
+    ],
+    "gid": 0,
+    "mode": 16877,
+    "mon_addrs": [
+        "127.0.0.1:6789"
+    ],
+    "mtime": "2020-10-02 13:48:17",
+    "path": "/volumes/igotta/boogie/0302e067-e7fb-4d9b-8388-aae46164d8b0",
+    "pool_namespace": "",
+    "type": "subvolume",
+    "uid": 0
+}
+`)
+
 var badSampleSubVolumeInfo1 = []byte(`
 {
     "bytes_quota": "fishy",
@@ -311,6 +337,22 @@ func TestParseSubVolumeInfo(t *testing.T) {
 			assert.Equal(t, 040755, info.Mode)
 			assert.Equal(t, 2020, info.Ctime.Year())
 			assert.Equal(t, "2020-09-01 23:49:22", info.Ctime.String())
+		}
+	})
+	t.Run("ok3", func(t *testing.T) {
+		info, err := parseSubVolumeInfo(R(sampleSubVolumeInfo3, "", nil))
+		assert.NoError(t, err)
+		if assert.NotNil(t, info) {
+			assert.Equal(t,
+				"/volumes/igotta/boogie/0302e067-e7fb-4d9b-8388-aae46164d8b0",
+				info.Path)
+			assert.Equal(t, 0, info.Uid)
+			assert.Equal(t, Infinite, info.BytesQuota)
+			assert.Equal(t, 040755, info.Mode)
+			assert.Equal(t, 2020, info.Ctime.Year())
+			assert.Equal(t, "2020-10-02 13:48:17", info.Ctime.String())
+			assert.Contains(t, info.Features, SnapshotCloneFeature)
+			assert.Contains(t, info.Features, SnapshotAutoprotectFeature)
 		}
 	})
 	t.Run("invalidBytesQuotaValue", func(t *testing.T) {


### PR DESCRIPTION
Some versions of ceph return a list of supported features for a
subvolume. On versions that don't return this field the list will always
be empty.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
