### PR TITLE
readme: document v0.6.0 and supported ceph versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ go test -tags nautilus ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.6.0          | nautilus, octopus       | mimic                    |
 | v0.5.0          | nautilus, octopus       | luminous, mimic          |
 | v0.4.0          | luminous, mimic, nautilus, octopus | |
 | v0.3.0          | luminous, mimic, nautilus, octopus | |


### PR DESCRIPTION
Adds v0.6.0 to library versions matrix.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
