### PR TITLE
rados: add GetNamespace implementing rados_ioctx_get_namespace

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -109,6 +109,10 @@ func (ioctx *IOContext) Pointer() unsafe.Pointer {
 
 // SetNamespace sets the namespace for objects within this IO context (pool).
 // Setting namespace to a empty or zero length string sets the pool to the default namespace.
+//
+// Implements:
+//  void rados_ioctx_set_namespace(rados_ioctx_t io,
+//                                 const char *nspace);
 func (ioctx *IOContext) SetNamespace(namespace string) {
 	var c_ns *C.char
 	if len(namespace) > 0 {

--- a/rados/ioctx_nautilus.go
+++ b/rados/ioctx_nautilus.go
@@ -1,0 +1,43 @@
+// +build !luminous,!mimic
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+//
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/retry"
+)
+
+// GetNamespace gets the namespace used for objects within this IO context.
+//
+// Implements:
+//  int rados_ioctx_get_namespace(rados_ioctx_t io, char *buf,
+//                                unsigned maxlen);
+func (ioctx *IOContext) GetNamespace() (string, error) {
+	if err := ioctx.validate(); err != nil {
+		return "", err
+	}
+	var (
+		err error
+		buf []byte
+		ret C.int
+	)
+	retry.WithSizes(128, 8192, func(size int) retry.Hint {
+		buf = make([]byte, size)
+		ret = C.rados_ioctx_get_namespace(
+			ioctx.ioctx,
+			(*C.char)(unsafe.Pointer(&buf[0])),
+			C.unsigned(len(buf)))
+		err = getErrorIfNegative(ret)
+		return retry.DoubleSize.If(err == errRange)
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(buf[:ret]), nil
+}

--- a/rados/ioctx_nautilus_test.go
+++ b/rados/ioctx_nautilus_test.go
@@ -1,0 +1,34 @@
+// +build !luminous,!mimic
+
+package rados
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestSetGetNamespace() {
+	suite.SetupConnection()
+
+	suite.T().Run("validNS", func(t *testing.T) {
+		suite.ioctx.SetNamespace("space1")
+		ns, err := suite.ioctx.GetNamespace()
+		assert.NoError(t, err)
+		assert.Equal(t, "space1", ns)
+	})
+
+	suite.T().Run("allNamespaces", func(t *testing.T) {
+		suite.ioctx.SetNamespace(AllNamespaces)
+		ns, err := suite.ioctx.GetNamespace()
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), AllNamespaces, ns)
+	})
+
+	suite.T().Run("invalidIoctx", func(t *testing.T) {
+		i := &IOContext{}
+		ns, err := i.GetNamespace()
+		assert.Error(suite.T(), err)
+		assert.Equal(suite.T(), "", ns)
+	})
+}


### PR DESCRIPTION
Add implements section to doc comment for SetNamespace.
Add GetNamespace implementing rados_ioctx_get_namespace

Fixes: #267 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
