### PR TITLE
Add configuration for Github stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: "Stale issue handler"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 14 days if no further activity occurs. Thank you for your contribution.'
+        days-before-stale: 30
+        days-before-close: 14
+        only-labels: 'question'
+


### PR DESCRIPTION
For stale issues: stale after 30 days, close after 14 days of stale
Details: https://github.com/actions/stale/blob/main/README.md
Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>


## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
