### PR TITLE
Include all status checks explicitly in the Mergify configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,7 +14,11 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - status-success=check
-      - status-success=test-suite
+      # each test should be listed separately, do not use regular expressions:
+      # https://docs.mergify.io/conditions.html#validating-all-status-check
+      - status-success=test-suite (mimic)
+      - status-success=test-suite (nautilus)
+      - status-success=test-suite (octopus)
     actions:
       merge:
         method: rebase


### PR DESCRIPTION
Unfortunately it is not recommended to use a regular expression to check
for the CI status of multiple tests. In case some tests do not run and
fail to report the status, Mergify will not know something is wrong and
PRs might get merged.

The only way to make sure all status checks have passed successfully, is
to list them all separately.

See-also: https://docs.mergify.io/conditions.html#validating-all-status-check
