### PR TITLE
callbacks: replace index with unique ID

### DIFF
--- a/internal/callbacks/callbacks_test.go
+++ b/internal/callbacks/callbacks_test.go
@@ -53,6 +53,7 @@ func TestCallbacksIndexing(t *testing.T) {
 	_ = cbks.Add("wibble")
 	_ = cbks.Add("wabble")
 	assert.Len(t, cbks.cmap, 5)
+	assert.NotEqual(t, i1, i2)
 
 	// generally we assume that the callback data will be mostly LIFO
 	// but can't guarantee it. Thus we check that when we remove the
@@ -62,6 +63,8 @@ func TestCallbacksIndexing(t *testing.T) {
 	_ = cbks.Add("flim")
 	ilast := cbks.Add("flam")
 	assert.Len(t, cbks.cmap, 5)
+	assert.NotEqual(t, ilast, i1)
+	assert.NotEqual(t, ilast, i2)
 
 	x := cbks.Lookup(ilast)
 	assert.NotNil(t, x)


### PR DESCRIPTION
The former code assumed a LIFO usage, and otherwise always produced
collisions.  This change uses unique IDs instead, that as a
side-effect might make debugging easier.

Signed-off-by: Sven Anderson <sven@redhat.com>
