### PR TITLE
Add rbd_writesame()

### DIFF
--- a/rados/rados.go
+++ b/rados/rados.go
@@ -25,6 +25,33 @@ const (
 	RadosAllNamespaces = AllNamespaces
 )
 
+// OpFlags are flags that can be set on a per-op basis.
+type OpFlags uint
+
+const (
+	// OpFlagNone can be use to not set any flags.
+	OpFlagNone = OpFlags(0)
+	// OpFlagExcl marks an op to fail a create operation if the object
+	// already exists.
+	OpFlagExcl = OpFlags(C.LIBRADOS_OP_FLAG_EXCL)
+	// OpFlagFailOk allows the transaction to succeed even if the flagged
+	// op fails.
+	OpFlagFailOk = OpFlags(C.LIBRADOS_OP_FLAG_FAILOK)
+	// OpFlagFAdviseRandom indicates read/write op random.
+	OpFlagFAdviseRandom = OpFlags(C.LIBRADOS_OP_FLAG_FADVISE_RANDOM)
+	// OpFlagFAdviseSequential indicates read/write op sequential.
+	OpFlagFAdviseSequential = OpFlags(C.LIBRADOS_OP_FLAG_FADVISE_SEQUENTIAL)
+	// OpFlagFAdviseWillNeed indicates read/write data will be accessed in
+	// the near future (by someone).
+	OpFlagFAdviseWillNeed = OpFlags(C.LIBRADOS_OP_FLAG_FADVISE_WILLNEED)
+	// OpFlagFAdviseDontNeed indicates read/write data will not accessed in
+	// the near future (by anyone).
+	OpFlagFAdviseDontNeed = OpFlags(C.LIBRADOS_OP_FLAG_FADVISE_DONTNEED)
+	// OpFlagFAdviseNoCache indicates read/write data will not accessed
+	// again (by *this* client).
+	OpFlagFAdviseNoCache = OpFlags(C.LIBRADOS_OP_FLAG_FADVISE_NOCACHE)
+)
+
 // Version returns the major, minor, and patch components of the version of
 // the RADOS library linked against.
 func Version() (int, int, int) {

--- a/rados/rados_nautilus.go
+++ b/rados/rados_nautilus.go
@@ -1,0 +1,12 @@
+// +build !mimic
+
+package rados
+
+// #include <rados/librados.h>
+import "C"
+
+const (
+	// OpFlagFAdviseFUA optionally support FUA (force unit access) on write
+	// requests.
+	OpFlagFAdviseFUA = OpFlags(C.LIBRADOS_OP_FLAG_FADVISE_FUA)
+)


### PR DESCRIPTION
In order to provide the ability to do thick provisioning of RBD images,
Image.WriteSame() can be used. The `rbd` commandline utility calls the
rbd_writesame() function when an image is created with the
`--thick-provision` option.

See-also: ceph/ceph-csi#1675

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
