### PR TITLE
cephfs: add functions for path and file Truncate

### DIFF
--- a/cephfs/path.go
+++ b/cephfs/path.go
@@ -173,3 +173,22 @@ func (mount *MountInfo) Rename(from, to string) error {
 	ret := C.ceph_rename(mount.mount, cFrom, cTo)
 	return getError(ret)
 }
+
+// Truncate sets the size of the specified file.
+//
+// Implements:
+//  int ceph_truncate(struct ceph_mount_info *cmount, const char *path, int64_t size);
+func (mount *MountInfo) Truncate(path string, size int64) error {
+	if err := mount.validate(); err != nil {
+		return err
+	}
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.ceph_truncate(
+		mount.mount,
+		cPath,
+		C.int64_t(size),
+	)
+	return getError(ret)
+}

--- a/cephfs/path_test.go
+++ b/cephfs/path_test.go
@@ -359,23 +359,31 @@ func TestReadlink(t *testing.T) {
 }
 
 func TestStatx(t *testing.T) {
-	mount := fsConnect(t)
-	defer fsDisconnect(t, mount)
+	t.Run("statPath", func(t *testing.T) {
+		mount := fsConnect(t)
+		defer fsDisconnect(t, mount)
 
-	dirname := "statme"
-	assert.NoError(t, mount.MakeDir(dirname, 0755))
+		dirname := "statme"
+		assert.NoError(t, mount.MakeDir(dirname, 0755))
 
-	st, err := mount.Statx(dirname, StatxBasicStats, 0)
-	assert.NoError(t, err)
-	assert.NotNil(t, st)
-	assert.Equal(t, uint16(0755), st.Mode&0777)
+		st, err := mount.Statx(dirname, StatxBasicStats, 0)
+		assert.NoError(t, err)
+		assert.NotNil(t, st)
+		assert.Equal(t, uint16(0755), st.Mode&0777)
 
-	assert.NoError(t, mount.RemoveDir(dirname))
+		assert.NoError(t, mount.RemoveDir(dirname))
 
-	st, err = mount.Statx(dirname, StatxBasicStats, 0)
-	assert.Error(t, err)
-	assert.Nil(t, st)
-	assert.Equal(t, errNoEntry, err)
+		st, err = mount.Statx(dirname, StatxBasicStats, 0)
+		assert.Error(t, err)
+		assert.Nil(t, st)
+		assert.Equal(t, errNoEntry, err)
+	})
+
+	t.Run("invalidMount", func(t *testing.T) {
+		m := &MountInfo{}
+		_, err := m.Statx("junk", StatxBasicStats, 0)
+		assert.Error(t, err)
+	})
 }
 
 func TestRename(t *testing.T) {


### PR DESCRIPTION
The cephfs packages gains new functions:
* File method Truncate implementing ceph_ftruncate
* Truncate implementing ceph_truncate

As a bonus, while adding the above I noted the coverage on path.go was nearly 100% but just missing an error condition check for Statx, so I added it here.

Fixes: #264 


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
