### PR TITLE
ci: remove "mimic" from testing matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
     strategy:
       matrix:
         ceph_version:
-        - "mimic"
         - "nautilus"
         - "octopus"
     steps:


### PR DESCRIPTION
Mimic is not a supported build target in v0.7 and as such there's no need to keep testing it any more.
