### PR TITLE
ci: add GODEBUG=cgocheck=2 to the test container environment

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -23,6 +23,7 @@ ENV PATH="${PATH}:/opt/go/bin"
 ENV GOROOT=/opt/go
 ENV GO111MODULE=on
 ENV GOPATH /go
+ENV GODEBUG=cgocheck=2
 WORKDIR /go/src/github.com/ceph/go-ceph
 VOLUME /go/src/github.com/ceph/go-ceph
 


### PR DESCRIPTION
This change sets GODEBUG to cgocheck=2 which enables complete checking of pointer handling (at some cost in run time). See [here](https://golang.org/cmd/cgo/#hdr-Passing_pointers) for more details.

The CI for this PR will fail first, because we are violating the rules already at some places. Let's fix these until we can merge this PR, and then we will have an insurance, that it will not happen again.

Depends on #441

Signed-off-by: Sven Anderson <sven@redhat.com>