### PR TITLE
github: remove mergify rule checking for mimic as we have removed it

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -16,7 +16,6 @@ pull_request_rules:
       - status-success=check
       # each test should be listed separately, do not use regular expressions:
       # https://docs.mergify.io/conditions.html#validating-all-status-check
-      - status-success=test-suite (mimic)
       - status-success=test-suite (nautilus)
       - status-success=test-suite (octopus)
     actions:


### PR DESCRIPTION
The test case is gone from the CI. Remove it from the merigify config too.
