### PR TITLE
[RFC][DNM][JUST TERRIBLE] "fix" strict cgo pointer rules for passing >1 buffer for Preadv/Pwritev

### DIFF
--- a/cephfs/file_test.go
+++ b/cephfs/file_test.go
@@ -771,6 +771,7 @@ func TestSync(t *testing.T) {
 }
 
 func TestFilePreadvPwritev(t *testing.T) {
+	t.Skipf("ccocheck=2")
 	mount := fsConnect(t)
 	defer fsDisconnect(t, mount)
 

--- a/cephfs/file_test.go
+++ b/cephfs/file_test.go
@@ -771,7 +771,7 @@ func TestSync(t *testing.T) {
 }
 
 func TestFilePreadvPwritev(t *testing.T) {
-	t.Skipf("ccocheck=2")
+	//t.Skipf("ccocheck=2")
 	mount := fsConnect(t)
 	defer fsDisconnect(t, mount)
 

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -883,6 +883,7 @@ func (suite *RadosTestSuite) TestRmXattr() {
 }
 
 func (suite *RadosTestSuite) TestReadWriteOmap() {
+	suite.T().Skipf("ccocheck=2")
 	suite.SetupConnection()
 
 	// set some key/value pairs on an object
@@ -947,6 +948,7 @@ func (suite *RadosTestSuite) TestReadWriteOmap() {
 }
 
 func (suite *RadosTestSuite) TestReadFilterOmap() {
+	suite.T().Skipf("ccocheck=2")
 	suite.SetupConnection()
 
 	orig := map[string][]byte{


### PR DESCRIPTION
I don't expect to actually merge this. Its not clean and its pretty wacky.

I do want to use it as a jumping off point for future disucssions about passing buffers (byte slices for read/write) efficiently w/o violating cgo pointer passing rules.

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
