### PR TITLE
[DNM] cutil: add PtrGuard for storing Go pointers in C memory

### DIFF
--- a/cephfs/file.go
+++ b/cephfs/file.go
@@ -158,7 +158,6 @@ func (f *File) Preadv(data [][]byte, offset int64) (int, error) {
 	case ret == 0:
 		return 0, io.EOF
 	}
-	iov.SyncToData()
 	return int(ret), nil
 }
 

--- a/cephfs/file.go
+++ b/cephfs/file.go
@@ -158,6 +158,7 @@ func (f *File) Preadv(data [][]byte, offset int64) (int, error) {
 	case ret == 0:
 		return 0, io.EOF
 	}
+	iov.SyncToData()
 	return int(ret), nil
 }
 

--- a/internal/cutil/aliases.go
+++ b/internal/cutil/aliases.go
@@ -1,12 +1,20 @@
 package cutil
 
+/*
+#include <stdlib.h>
+typedef void* voidptr;
+*/
 import "C"
 
 import (
 	"unsafe"
 )
 
-// Basic types from C that we can make "public" without too much fuss.
+// PtrSize is the size of a pointer
+const PtrSize = C.sizeof_voidptr
+
+// SizeTSize is the size of C.size_t
+const SizeTSize = C.sizeof_size_t
 
 // SizeT wraps size_t from C.
 type SizeT C.size_t
@@ -14,6 +22,9 @@ type SizeT C.size_t
 // This section contains a bunch of types that are basically just
 // unsafe.Pointer but have specific types to help "self document" what the
 // underlying pointer is really meant to represent.
+
+// CPtr is an unsafe.Pointer to C allocated memory
+type CPtr unsafe.Pointer
 
 // CharPtrPtr is an unsafe pointer wrapping C's `char**`.
 type CharPtrPtr unsafe.Pointer
@@ -26,3 +37,9 @@ type SizeTPtr unsafe.Pointer
 
 // FreeFunc is a wrapper around calls to, or act like, C's free function.
 type FreeFunc func(unsafe.Pointer)
+
+// Malloc is C.malloc
+func Malloc(s SizeT) CPtr { return CPtr(C.malloc(C.size_t(s))) }
+
+// Free is C.free
+func Free(p CPtr) { C.free(unsafe.Pointer(p)) }

--- a/internal/cutil/cslice.go
+++ b/internal/cutil/cslice.go
@@ -1,0 +1,78 @@
+package cutil
+
+// The following code needs some explanation:
+// This creates slices on top of the C memory buffers allocated before in
+// order to safely and comfortably use them as arrays. First the void pointer
+// is cast to a pointer to an array of the type that will be stored in the
+// array. Because the size of an array is a constant, but the real array size
+// is dynamic, we just use the biggest possible index value maxIdx, to make
+// sure it's always big enough. (Nothing is allocated by casting, so the size
+// can be arbitrarily big.) So, if the array should store items of myType, the
+// cast would be (*[maxIdx]myItem)(myCMemPtr).
+// From that array pointer a slice is created with the [start:end:capacity]
+// syntax. The capacity must be set explicitly here, because by default it
+// would be set to the size of the original array, which is maxIdx, which
+// doesn't reflect reality in this case. This results in definitions like:
+// cSlice := (*[maxIdx]myItem)(myCMemPtr)[:numOfItems:numOfItems]
+
+const maxIdx = 1<<31 - 1 // 2GB, max int32 value, should be safe
+
+////////// CPtr //////////
+
+// CPtrCSlice is a C allocated slice of C pointers.
+type CPtrCSlice []CPtr
+
+// NewCPtrCSlice returns a CPtrSlice.
+// Similar to CString it must be freed with slice.Free()
+func NewCPtrCSlice(size int) CPtrCSlice {
+	if size == 0 {
+		return nil
+	}
+	cMem := Malloc(SizeT(size) * PtrSize)
+	cSlice := (*[maxIdx]CPtr)(cMem)[:size:size]
+	return cSlice
+}
+
+// Ptr returns a pointer to CPtrSlice
+func (v *CPtrCSlice) Ptr() CPtr {
+	if len(*v) == 0 {
+		return nil
+	}
+	return CPtr(&(*v)[0])
+}
+
+// Free frees a CPtrSlice
+func (v *CPtrCSlice) Free() {
+	Free(v.Ptr())
+	*v = nil
+}
+
+////////// SizeT //////////
+
+// SizeTCSlice is a C allocated slice of C.size_t.
+type SizeTCSlice []SizeT
+
+// NewSizeTCSlice returns a SizeTCSlice.
+// Similar to CString it must be freed with slice.Free()
+func NewSizeTCSlice(size int) SizeTCSlice {
+	if size == 0 {
+		return nil
+	}
+	cMem := Malloc(SizeT(size) * SizeTSize)
+	cSlice := (*[maxIdx]SizeT)(cMem)[:size:size]
+	return cSlice
+}
+
+// Ptr returns a pointer to SizeTCSlice
+func (v *SizeTCSlice) Ptr() CPtr {
+	if len(*v) == 0 {
+		return nil
+	}
+	return CPtr(&(*v)[0])
+}
+
+// Free frees a SizeTCSlice
+func (v *SizeTCSlice) Free() {
+	Free(v.Ptr())
+	*v = nil
+}

--- a/internal/cutil/cslice_test.go
+++ b/internal/cutil/cslice_test.go
@@ -1,0 +1,86 @@
+package cutil
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCPtrCSlice(t *testing.T) {
+	t.Run("Size", func(t *testing.T) {
+		const size = 256
+		slice := NewCPtrCSlice(size)
+		defer slice.Free()
+		assert.Len(t, slice, size)
+	})
+	t.Run("Fill", func(t *testing.T) {
+		const size = 256
+		slice := NewCPtrCSlice(size)
+		defer slice.Free()
+		for i := range slice {
+			slice[i] = CPtr(&slice[i])
+		}
+		for i := 0; i < size; i++ {
+			p := (*CPtr)(unsafe.Pointer(uintptr(slice.Ptr()) + uintptr(i)*uintptr(PtrSize)))
+			assert.Equal(t, slice[i], *p)
+		}
+	})
+	t.Run("OutOfBound", func(t *testing.T) {
+		const size = 1
+		slice := NewCPtrCSlice(size)
+		defer slice.Free()
+		assert.Panics(t, func() { slice[size] = nil })
+	})
+	t.Run("FreeSetsNil", func(t *testing.T) {
+		const size = 1
+		slice := NewCPtrCSlice(size)
+		slice.Free()
+		assert.Nil(t, slice)
+	})
+	t.Run("EmptySlice", func(t *testing.T) {
+		empty := NewCPtrCSlice(0)
+		assert.Len(t, empty, 0)
+		assert.Nil(t, empty)
+		assert.NotPanics(t, func() { empty.Free() })
+	})
+}
+
+func TestSizeTCSlice(t *testing.T) {
+	t.Run("Size", func(t *testing.T) {
+		const size = 256
+		slice := NewSizeTCSlice(size)
+		defer slice.Free()
+		assert.Len(t, slice, size)
+	})
+	t.Run("Fill", func(t *testing.T) {
+		const size = 256
+		slice := NewSizeTCSlice(size)
+		defer slice.Free()
+		for i := range slice {
+			slice[i] = SizeT(i)
+		}
+		for i := 0; i < size; i++ {
+			p := (*SizeT)(unsafe.Pointer(uintptr(slice.Ptr()) + uintptr(i)*uintptr(PtrSize)))
+			assert.Equal(t, slice[i], *p)
+		}
+	})
+	t.Run("OutOfBound", func(t *testing.T) {
+		const size = 1
+		slice := NewSizeTCSlice(size)
+		defer slice.Free()
+		assert.Panics(t, func() { slice[size] = 0 })
+	})
+	t.Run("FreeSetsNil", func(t *testing.T) {
+		const size = 1
+		slice := NewSizeTCSlice(size)
+		slice.Free()
+		assert.Nil(t, slice)
+	})
+	t.Run("EmptySlice", func(t *testing.T) {
+		empty := NewSizeTCSlice(0)
+		assert.Len(t, empty, 0)
+		assert.Nil(t, empty)
+		assert.NotPanics(t, func() { empty.Free() })
+	})
+}

--- a/internal/cutil/iovec.go
+++ b/internal/cutil/iovec.go
@@ -2,7 +2,6 @@ package cutil
 
 /*
 #include <stdlib.h>
-#include <string.h>
 #include <sys/uio.h>
 */
 import "C"
@@ -15,47 +14,43 @@ import (
 type Iovec struct {
 	iovec []C.struct_iovec
 	data  [][]byte
+	pgs   []*PtrGuard
 }
+
+const iovecSize = C.sizeof_struct_iovec
 
 // ByteSlicesToIovec creates an Iovec and links it to Go buffers in data.
 func ByteSlicesToIovec(data [][]byte) (v Iovec) {
-	v.iovec = make([]C.struct_iovec, len(data))
 	v.data = data
-	for i, b := range v.data {
-		v.iovec[i].iov_base = C.CBytes(b)
-		v.iovec[i].iov_len = C.size_t(len(b))
-	}
 	return
 }
 
-// SyncToData writes the iovec buffers into the linked Go buffers
-func (v Iovec) SyncToData() {
-	for i, b := range v.iovec {
-		if len(v.data[i]) != int(b.iov_len) {
-			panic("buffers have been modified")
-		}
-		C.memcpy(unsafe.Pointer(&v.data[i][0]), b.iov_base, b.iov_len)
-	}
-}
-
 // Pointer returns a pointer to the iovec
-func (v Iovec) Pointer() unsafe.Pointer {
-	if len(v.iovec) == 0 {
-		return nil
+func (v *Iovec) Pointer() unsafe.Pointer {
+	v.Free()
+	n := len(v.data)
+	iovecMem := C.malloc(iovecSize * C.size_t(n))
+	v.iovec = (*[maxIdx]C.struct_iovec)(iovecMem)[:n:n]
+	for i, b := range v.data {
+		pg := NewPtrGuard(&v.iovec[i].iov_base, unsafe.Pointer(&b[0]))
+		v.pgs = append(v.pgs, pg)
+		v.iovec[i].iov_len = C.size_t(len(b))
 	}
 	return unsafe.Pointer(&v.iovec[0])
 }
 
 // Len returns a pointer to the iovec
-func (v Iovec) Len() int {
-	return len(v.iovec)
+func (v *Iovec) Len() int {
+	return len(v.data)
 }
 
 // Free the C memory in the Iovec.
-func (v Iovec) Free() {
-	for i := range v.iovec {
-		C.free(v.iovec[i].iov_base)
-		v.iovec[i].iov_base = nil
-		v.iovec[i].iov_len = 0
+func (v *Iovec) Free() {
+	for _, pg := range v.pgs {
+		pg.Release()
 	}
+	if len(v.iovec) != 0 {
+		C.free(unsafe.Pointer(&v.iovec[0]))
+	}
+	v.iovec = nil
 }

--- a/internal/cutil/iovec.go
+++ b/internal/cutil/iovec.go
@@ -47,7 +47,7 @@ func (v *Iovec) Len() int {
 // Free the C memory in the Iovec.
 func (v *Iovec) Free() {
 	for _, pg := range v.pgs {
-		pg.Release()
+		pg.Free()
 	}
 	if len(v.iovec) != 0 {
 		C.free(unsafe.Pointer(&v.iovec[0]))

--- a/internal/cutil/iovec.go
+++ b/internal/cutil/iovec.go
@@ -32,7 +32,7 @@ func (v *Iovec) Pointer() unsafe.Pointer {
 	iovecMem := C.malloc(iovecSize * C.size_t(n))
 	v.iovec = (*[maxIdx]C.struct_iovec)(iovecMem)[:n:n]
 	for i, b := range v.data {
-		pg := NewPtrGuard(&v.iovec[i].iov_base, unsafe.Pointer(&b[0]))
+		pg := NewPtrGuard(CPtr(&v.iovec[i].iov_base), unsafe.Pointer(&b[0]))
 		v.pgs = append(v.pgs, pg)
 		v.iovec[i].iov_len = C.size_t(len(b))
 	}

--- a/internal/cutil/ptrguard.go
+++ b/internal/cutil/ptrguard.go
@@ -52,7 +52,8 @@ type PtrGuard struct {
 // cgo rule, and would require the use of a Go object registry.
 
 // NewPtrGuard writes the goPtr (pointing to Go memory) into C memory at the
-// position cPtr, and returns a PtrGuard object.
+// position cPtr, and returns a PtrGuard object. Must be freed with the Free()
+// method.
 func NewPtrGuard(cPtr CPtr, goPtr unsafe.Pointer) *PtrGuard {
 	var v PtrGuard
 	v.release.init()
@@ -62,9 +63,9 @@ func NewPtrGuard(cPtr CPtr, goPtr unsafe.Pointer) *PtrGuard {
 	return &v
 }
 
-// Release removes the guarded Go pointer from the C memory by overwriting it
+// Free removes the guarded Go pointer from the C memory by overwriting it
 // with NULL.
-func (v *PtrGuard) Release() {
+func (v *PtrGuard) Free() {
 	if !v.released {
 		v.released = true
 		v.release.signal() // send release signal

--- a/internal/cutil/ptrguard.go
+++ b/internal/cutil/ptrguard.go
@@ -1,6 +1,8 @@
 package cutil
 
 /*
+#include <stdlib.h>
+
 extern void release_wait(void*);
 extern void stored_signal(void*);
 
@@ -80,4 +82,13 @@ func release_wait(p unsafe.Pointer) {
 func stored_signal(p unsafe.Pointer) {
 	v := (*PtrGuard)(p)
 	v.stored.signal()
+}
+
+// for tests
+func cMalloc(n uintptr) unsafe.Pointer {
+	return C.malloc(C.size_t(n))
+}
+
+func cFree(p unsafe.Pointer) {
+	C.free(p)
 }

--- a/internal/cutil/ptrguard.go
+++ b/internal/cutil/ptrguard.go
@@ -53,11 +53,11 @@ type PtrGuard struct {
 
 // NewPtrGuard writes the goPtr (pointing to Go memory) into C memory at the
 // position cPtr, and returns a PtrGuard object.
-func NewPtrGuard(cPtr *unsafe.Pointer, goPtr unsafe.Pointer) *PtrGuard {
+func NewPtrGuard(cPtr CPtr, goPtr unsafe.Pointer) *PtrGuard {
 	var v PtrGuard
 	v.release.init()
 	v.stored.init()
-	go C.storeAndWait(cPtr, goPtr, unsafe.Pointer(&v))
+	go C.storeAndWait((*unsafe.Pointer)(cPtr), goPtr, unsafe.Pointer(&v))
 	v.stored.wait()
 	return &v
 }
@@ -82,13 +82,4 @@ func release_wait(p unsafe.Pointer) {
 func stored_signal(p unsafe.Pointer) {
 	v := (*PtrGuard)(p)
 	v.stored.signal()
-}
-
-// for tests
-func cMalloc(n uintptr) unsafe.Pointer {
-	return C.malloc(C.size_t(n))
-}
-
-func cFree(p unsafe.Pointer) {
-	C.free(p)
 }

--- a/internal/cutil/ptrguard.go
+++ b/internal/cutil/ptrguard.go
@@ -1,0 +1,83 @@
+package cutil
+
+/*
+extern void release_wait(void*);
+extern void stored_signal(void*);
+
+static inline void storeAndWait(void** c_ptr, void* go_ptr, void* v) {
+	*c_ptr = go_ptr;
+	stored_signal(v);
+	release_wait(v);
+	*c_ptr = NULL;
+	stored_signal(v);
+}
+*/
+import "C"
+
+import (
+	"sync"
+	"unsafe"
+)
+
+type semaphore struct {
+	sync.Mutex
+}
+
+func (v *semaphore) init() {
+	v.wait()
+}
+
+func (v *semaphore) wait() {
+	v.Lock()
+}
+
+func (v *semaphore) signal() {
+	v.Unlock()
+}
+
+// PtrGuard respresents a guarded Go pointer (pointing to memory allocated by Go
+// runtime) stored in C memory (allocated by C)
+type PtrGuard struct {
+	stored, release semaphore
+	released        bool
+}
+
+// WARNING: using binary semaphores (mutexes) for signalling like this is quite
+// a delicate task in order to avoid deadlocks or panics. Whenever changing the
+// code logic, please review at least three times that there is no unexpected
+// state possible. Usually the natural choice would be to use channels instead,
+// but these can not easily passed to C code because of the pointer-to-pointer
+// cgo rule, and would require the use of a Go object registry.
+
+// NewPtrGuard writes the goPtr (pointing to Go memory) into C memory at the
+// position cPtr, and returns a PtrGuard object.
+func NewPtrGuard(cPtr *unsafe.Pointer, goPtr unsafe.Pointer) *PtrGuard {
+	var v PtrGuard
+	v.release.init()
+	v.stored.init()
+	go C.storeAndWait(cPtr, goPtr, unsafe.Pointer(&v))
+	v.stored.wait()
+	return &v
+}
+
+// Release removes the guarded Go pointer from the C memory by overwriting it
+// with NULL.
+func (v *PtrGuard) Release() {
+	if !v.released {
+		v.released = true
+		v.release.signal() // send release signal
+		v.stored.wait()    // wait for stored signal
+	}
+}
+
+//export release_wait
+func release_wait(p unsafe.Pointer) {
+	v := (*PtrGuard)(p)
+	v.release.wait()
+}
+
+//export stored_signal
+func stored_signal(p unsafe.Pointer) {
+	v := (*PtrGuard)(p)
+	v.stored.signal()
+}

--- a/internal/cutil/ptrguard_test.go
+++ b/internal/cutil/ptrguard_test.go
@@ -1,0 +1,71 @@
+package cutil
+
+import (
+	"math/rand"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const ptrSize = unsafe.Sizeof(unsafe.Pointer(nil))
+
+func TestPtrGuard(t *testing.T) {
+	t.Run("storeAndRelease", func(t *testing.T) {
+		s := "string"
+		goPtr := (unsafe.Pointer)(&s)
+		cPtr := (*unsafe.Pointer)(cMalloc(unsafe.Sizeof(goPtr)))
+		defer cFree(unsafe.Pointer(cPtr))
+		pg := NewPtrGuard((*unsafe.Pointer)(cPtr), goPtr)
+		assert.Equal(t, *cPtr, goPtr)
+		pg.Release()
+		assert.Zero(t, *cPtr)
+	})
+
+	t.Run("multiRelease", func(t *testing.T) {
+		s := "string"
+		goPtr := (unsafe.Pointer)(&s)
+		cPtr := (*unsafe.Pointer)(cMalloc(unsafe.Sizeof(goPtr)))
+		defer cFree(unsafe.Pointer(cPtr))
+		pg := NewPtrGuard((*unsafe.Pointer)(cPtr), goPtr)
+		assert.Equal(t, *cPtr, goPtr)
+		pg.Release()
+		pg.Release()
+		pg.Release()
+		pg.Release()
+		assert.Zero(t, *cPtr)
+	})
+
+	t.Run("stressTest", func(t *testing.T) {
+		const N = 1000
+		const M = 10000
+		var ptrGuards [N]*PtrGuard
+		cPtrArr := cMalloc(N * ptrSize)
+		defer cFree(cPtrArr)
+		for n := 0; n < M; n++ {
+			i := uintptr(rand.Intn(N))
+			if ptrGuards[i] == nil {
+				goPtr := unsafe.Pointer(&(struct{ byte }{42}))
+				cPtr := (*unsafe.Pointer)(unsafe.Pointer(uintptr(cPtrArr) + i*ptrSize))
+				pg := NewPtrGuard((*unsafe.Pointer)(cPtr), goPtr)
+				ptrGuards[i] = pg
+				assert.Equal(t, *cPtr, goPtr)
+			} else {
+				ptrGuards[i].Release()
+				ptrGuards[i] = nil
+				cPtr := (*unsafe.Pointer)(unsafe.Pointer(uintptr(cPtrArr) + i*ptrSize))
+				assert.Zero(t, *cPtr)
+			}
+		}
+		for _, pg := range ptrGuards {
+			if pg != nil {
+				pg.Release()
+				pg = nil
+			}
+		}
+		for i := uintptr(0); i < N; i++ {
+			cPtr := (*unsafe.Pointer)(unsafe.Pointer(uintptr(cPtrArr) + i*ptrSize))
+			assert.Zero(t, *cPtr)
+		}
+	})
+}

--- a/internal/cutil/ptrguard_test.go
+++ b/internal/cutil/ptrguard_test.go
@@ -8,64 +8,59 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const ptrSize = unsafe.Sizeof(unsafe.Pointer(nil))
-
 func TestPtrGuard(t *testing.T) {
 	t.Run("storeAndRelease", func(t *testing.T) {
 		s := "string"
 		goPtr := (unsafe.Pointer)(&s)
-		cPtr := (*unsafe.Pointer)(cMalloc(unsafe.Sizeof(goPtr)))
-		defer cFree(unsafe.Pointer(cPtr))
-		pg := NewPtrGuard((*unsafe.Pointer)(cPtr), goPtr)
-		assert.Equal(t, *cPtr, goPtr)
+		cPtr := Malloc(PtrSize)
+		defer Free(cPtr)
+		pg := NewPtrGuard(cPtr, goPtr)
+		assert.Equal(t, *(*unsafe.Pointer)(cPtr), goPtr)
 		pg.Release()
-		assert.Zero(t, *cPtr)
+		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
 	})
 
 	t.Run("multiRelease", func(t *testing.T) {
 		s := "string"
 		goPtr := (unsafe.Pointer)(&s)
-		cPtr := (*unsafe.Pointer)(cMalloc(unsafe.Sizeof(goPtr)))
-		defer cFree(unsafe.Pointer(cPtr))
-		pg := NewPtrGuard((*unsafe.Pointer)(cPtr), goPtr)
-		assert.Equal(t, *cPtr, goPtr)
+		cPtr := Malloc(PtrSize)
+		defer Free(cPtr)
+		pg := NewPtrGuard(cPtr, goPtr)
+		assert.Equal(t, *(*unsafe.Pointer)(cPtr), goPtr)
 		pg.Release()
 		pg.Release()
 		pg.Release()
 		pg.Release()
-		assert.Zero(t, *cPtr)
+		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
 	})
 
 	t.Run("stressTest", func(t *testing.T) {
 		const N = 1000
 		const M = 10000
 		var ptrGuards [N]*PtrGuard
-		cPtrArr := cMalloc(N * ptrSize)
-		defer cFree(cPtrArr)
+		cPtrArr := (*[N]CPtr)(unsafe.Pointer(Malloc(N * PtrSize)))
+		defer Free(CPtr(&cPtrArr[0]))
 		for n := 0; n < M; n++ {
 			i := uintptr(rand.Intn(N))
 			if ptrGuards[i] == nil {
 				goPtr := unsafe.Pointer(&(struct{ byte }{42}))
-				cPtr := (*unsafe.Pointer)(unsafe.Pointer(uintptr(cPtrArr) + i*ptrSize))
-				pg := NewPtrGuard((*unsafe.Pointer)(cPtr), goPtr)
-				ptrGuards[i] = pg
-				assert.Equal(t, *cPtr, goPtr)
+				cPtrPtr := CPtr(&cPtrArr[i])
+				ptrGuards[i] = NewPtrGuard(cPtrPtr, goPtr)
+				assert.Equal(t, (unsafe.Pointer)(cPtrArr[i]), goPtr)
 			} else {
 				ptrGuards[i].Release()
 				ptrGuards[i] = nil
-				cPtr := (*unsafe.Pointer)(unsafe.Pointer(uintptr(cPtrArr) + i*ptrSize))
-				assert.Zero(t, *cPtr)
+				assert.Zero(t, cPtrArr[i])
 			}
 		}
-		for _, pg := range ptrGuards {
-			if pg != nil {
-				pg.Release()
-				pg = nil
+		for i := range ptrGuards {
+			if ptrGuards[i] != nil {
+				ptrGuards[i].Release()
+				ptrGuards[i] = nil
 			}
 		}
 		for i := uintptr(0); i < N; i++ {
-			cPtr := (*unsafe.Pointer)(unsafe.Pointer(uintptr(cPtrArr) + i*ptrSize))
-			assert.Zero(t, *cPtr)
+			assert.Zero(t, cPtrArr[i])
 		}
 	})
 }

--- a/internal/cutil/ptrguard_test.go
+++ b/internal/cutil/ptrguard_test.go
@@ -16,7 +16,7 @@ func TestPtrGuard(t *testing.T) {
 		defer Free(cPtr)
 		pg := NewPtrGuard(cPtr, goPtr)
 		assert.Equal(t, *(*unsafe.Pointer)(cPtr), goPtr)
-		pg.Release()
+		pg.Free()
 		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
 	})
 
@@ -27,10 +27,10 @@ func TestPtrGuard(t *testing.T) {
 		defer Free(cPtr)
 		pg := NewPtrGuard(cPtr, goPtr)
 		assert.Equal(t, *(*unsafe.Pointer)(cPtr), goPtr)
-		pg.Release()
-		pg.Release()
-		pg.Release()
-		pg.Release()
+		pg.Free()
+		pg.Free()
+		pg.Free()
+		pg.Free()
 		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
 	})
 
@@ -48,14 +48,14 @@ func TestPtrGuard(t *testing.T) {
 				ptrGuards[i] = NewPtrGuard(cPtrPtr, goPtr)
 				assert.Equal(t, (unsafe.Pointer)(cPtrArr[i]), goPtr)
 			} else {
-				ptrGuards[i].Release()
+				ptrGuards[i].Free()
 				ptrGuards[i] = nil
 				assert.Zero(t, cPtrArr[i])
 			}
 		}
 		for i := range ptrGuards {
 			if ptrGuards[i] != nil {
-				ptrGuards[i].Release()
+				ptrGuards[i].Free()
 				ptrGuards[i] = nil
 			}
 		}

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -13,6 +13,8 @@ import "C"
 import (
 	"runtime"
 	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/cutil"
 )
 
 const (
@@ -26,50 +28,44 @@ type setOmapStep struct {
 	withoutUpdate
 
 	// C arguments
-	cKeys    **C.char
-	cValues  **C.char
-	cLengths *C.size_t
+	cKeys    cutil.CPtrCSlice
+	cValues  cutil.CPtrCSlice
+	cLengths cutil.SizeTCSlice
 	cNum     C.size_t
 }
 
 func newSetOmapStep(pairs map[string][]byte) *setOmapStep {
 
-	maplen := C.size_t(len(pairs))
-	cKeys := C.malloc(maplen * ptrSize)
-	cValues := C.malloc(maplen * ptrSize)
-	cLengths := C.malloc(maplen * sizeTSize)
+	maplen := len(pairs)
+	cKeys := cutil.NewCPtrCSlice(maplen)
+	cValues := cutil.NewCPtrCSlice(maplen)
+	cLengths := cutil.NewSizeTCSlice(maplen)
 
 	sos := &setOmapStep{
-		cKeys:    (**C.char)(cKeys),
-		cValues:  (**C.char)(cValues),
-		cLengths: (*C.size_t)(cLengths),
-		cNum:     C.size_t(len(pairs)),
+		cKeys:    cKeys,
+		cValues:  cValues,
+		cLengths: cLengths,
+		cNum:     C.size_t(maplen),
 	}
-	sos.add(cKeys)
-	sos.add(cValues)
-	sos.add(cLengths)
 
 	var i uintptr
 	for key, value := range pairs {
 		// key
 		ck := C.CString(key)
 		sos.add(unsafe.Pointer(ck))
-		ckp := (**C.char)(unsafe.Pointer(uintptr(cKeys) + i*ptrSize))
-		*ckp = ck
+		cKeys[i] = cutil.CPtr(ck)
 
 		// value and its length
-		cvp := (**C.char)(unsafe.Pointer(uintptr(cValues) + i*ptrSize))
-		vlen := C.size_t(len(value))
+		vlen := cutil.SizeT(len(value))
 		if vlen > 0 {
 			cv := C.CBytes(value)
 			sos.add(cv)
-			*cvp = (*C.char)(cv)
+			cValues[i] = cutil.CPtr(cv)
 		} else {
-			*cvp = nil
+			cValues[i] = nil
 		}
 
-		clp := (*C.size_t)(unsafe.Pointer(uintptr(cLengths) + i*ptrSize))
-		*clp = vlen
+		cLengths[i] = vlen
 
 		i++
 	}
@@ -79,9 +75,9 @@ func newSetOmapStep(pairs map[string][]byte) *setOmapStep {
 }
 
 func (sos *setOmapStep) free() {
-	sos.cKeys = nil
-	sos.cValues = nil
-	sos.cLengths = nil
+	sos.cKeys.Free()
+	sos.cValues.Free()
+	sos.cLengths.Free()
 	sos.withRefs.free()
 }
 
@@ -190,23 +186,21 @@ type removeOmapKeysStep struct {
 	withoutUpdate
 
 	// arguments:
-	cKeys **C.char
+	cKeys cutil.CPtrCSlice
 	cNum  C.size_t
 }
 
 func newRemoveOmapKeysStep(keys []string) *removeOmapKeysStep {
-	cKeys := C.malloc(C.size_t(len(keys)) * ptrSize)
+	cKeys := cutil.NewCPtrCSlice(len(keys))
 	roks := &removeOmapKeysStep{
-		cKeys: (**C.char)(cKeys),
+		cKeys: cKeys,
 		cNum:  C.size_t(len(keys)),
 	}
-	roks.add(cKeys)
 
 	i := 0
 	for _, key := range keys {
-		ckp := (**C.char)(unsafe.Pointer(uintptr(cKeys) + uintptr(i)*ptrSize))
-		*ckp = C.CString(key)
-		roks.add(unsafe.Pointer(*ckp))
+		cKeys[i] = cutil.CPtr(C.CString(key))
+		roks.add(unsafe.Pointer(cKeys[i]))
 		i++
 	}
 
@@ -215,7 +209,7 @@ func newRemoveOmapKeysStep(keys []string) *removeOmapKeysStep {
 }
 
 func (roks *removeOmapKeysStep) free() {
-	roks.cKeys = nil
+	roks.cKeys.Free()
 	roks.withRefs.free()
 }
 

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -59,7 +59,7 @@ func newSetOmapStep(pairs map[string][]byte) *setOmapStep {
 		// value and its length
 		vlen := cutil.SizeT(len(value))
 		if vlen > 0 {
-			pg := cutil.NewPtrGuard((*unsafe.Pointer)(&cValues[i]), unsafe.Pointer(&value[0]))
+			pg := cutil.NewPtrGuard(cutil.CPtr(&cValues[i]), unsafe.Pointer(&value[0]))
 			sos.pgs = append(sos.pgs, pg)
 		} else {
 			cValues[i] = nil

--- a/rados/operation_test.go
+++ b/rados/operation_test.go
@@ -117,3 +117,21 @@ func TestOperationType(t *testing.T) {
 		assert.Equal(t, 2, x)
 	})
 }
+
+type refMock struct {
+	s   string
+	out *string
+}
+
+func (v refMock) Free() {
+	*v.out += v.s
+}
+
+func TestOperationRefFreeOrder(t *testing.T) {
+	r := withRefs{}
+	var out string
+	r.add(refMock{"bar", &out})
+	r.add(refMock{"foo", &out})
+	r.free()
+	assert.Equal(t, out, "foobar")
+}

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -90,15 +90,15 @@ func (w *WriteOp) Create(exclusive CreateOption) {
 	C.rados_write_op_create(w.op, C.int(exclusive), nil)
 }
 
-//  SetOmap appends the map `pairs` to the omap `oid`.
+// SetOmap appends the map `pairs` to the omap `oid`.
 func (w *WriteOp) SetOmap(pairs map[string][]byte) {
 	sos := newSetOmapStep(pairs)
 	w.steps = append(w.steps, sos)
 	C.rados_write_op_omap_set(
 		w.op,
-		sos.cKeys,
-		sos.cValues,
-		sos.cLengths,
+		(**C.char)(sos.cKeys.Ptr()),
+		(**C.char)(sos.cValues.Ptr()),
+		(*C.size_t)(sos.cLengths.Ptr()),
 		sos.cNum)
 }
 
@@ -108,7 +108,7 @@ func (w *WriteOp) RmOmapKeys(keys []string) {
 	w.steps = append(w.steps, roks)
 	C.rados_write_op_omap_rm_keys(
 		w.op,
-		roks.cKeys,
+		(**C.char)(roks.cKeys.Ptr()),
 		roks.cNum)
 }
 

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -23,6 +23,7 @@ ENV PATH="${PATH}:/opt/go/bin"
 ENV GOROOT=/opt/go
 ENV GO111MODULE=on
 ENV GOPATH /go
+ENV GODEBUG=cgocheck=2
 WORKDIR /go/src/github.com/ceph/go-ceph
 VOLUME /go/src/github.com/ceph/go-ceph
 


### PR DESCRIPTION
Update: this will be split into several smaller PRs

PtrGuard is a type that allows to store a Go pointer (that is a pointer pointing to memory allocated by the Go runtime) in C memory (that is memory allocated by C, with `malloc()` for example). The [pointer passing rules](https://golang.org/cmd/cgo/#hdr-Passing_pointers) of cgo don't allow Go code to store Go pointer in C memory. However, C code is allowed to store Go pointer in C memory until the C function returns. PtrGuard takes advantage of this by calling a C function in a Goroutine that stores the Go pointer in the C memory and then waits for a release signal (implemented via a mutex). After the release signal is received, the C memory is overwritten with `NULL` and the C function returns.

(Alternative to #415) 
Closes: #412 #413
