### PR TITLE
github: do not automatically merge on "extended-review" label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,6 +10,7 @@ pull_request_rules:
   - name: automatic merge
     conditions:
       - label!=do-not-merge
+      - label!=extended-review
       - base=master
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
The "extended-review" label indicates that review is likely to take
an extended period of time and for bots (or even humans) to not automatically take
a PR.

This avoid the need to preemptively mark a PR as changes needed or
give a false impression with a "do-not-merge" label, which has a subtle
lack-of-quality implication.
