### PR TITLE
rados: remove pointer arithmetic on c-buffers

### DIFF
--- a/internal/cutil/aliases.go
+++ b/internal/cutil/aliases.go
@@ -8,12 +8,13 @@ typedef void* voidptr;
 import "C"
 
 import (
+	"math"
 	"unsafe"
 )
 
 const (
 	// MaxIdx is the maximum index on 32 bit systems
-	MaxIdx = 1<<31 - 1 // 2GB, max int32 value, should be safe
+	MaxIdx = math.MaxInt32 // 2GB, max int32 value, should be safe
 
 	// PtrSize is the size of a pointer
 	PtrSize = C.sizeof_voidptr

--- a/internal/cutil/cslice.go
+++ b/internal/cutil/cslice.go
@@ -1,0 +1,76 @@
+package cutil
+
+// The following code needs some explanation:
+// This creates slices on top of the C memory buffers allocated before in
+// order to safely and comfortably use them as arrays. First the void pointer
+// is cast to a pointer to an array of the type that will be stored in the
+// array. Because the size of an array is a constant, but the real array size
+// is dynamic, we just use the biggest possible index value MaxIdx, to make
+// sure it's always big enough. (Nothing is allocated by casting, so the size
+// can be arbitrarily big.) So, if the array should store items of myType, the
+// cast would be (*[MaxIdx]myItem)(myCMemPtr).
+// From that array pointer a slice is created with the [start:end:capacity]
+// syntax. The capacity must be set explicitly here, because by default it
+// would be set to the size of the original array, which is MaxIdx, which
+// doesn't reflect reality in this case. This results in definitions like:
+// cSlice := (*[MaxIdx]myItem)(myCMemPtr)[:numOfItems:numOfItems]
+
+////////// CPtr //////////
+
+// CPtrCSlice is a C allocated slice of C pointers.
+type CPtrCSlice []CPtr
+
+// NewCPtrCSlice returns a CPtrSlice.
+// Similar to CString it must be freed with slice.Free()
+func NewCPtrCSlice(size int) CPtrCSlice {
+	if size == 0 {
+		return nil
+	}
+	cMem := Malloc(SizeT(size) * PtrSize)
+	cSlice := (*[MaxIdx]CPtr)(cMem)[:size:size]
+	return cSlice
+}
+
+// Ptr returns a pointer to CPtrSlice
+func (v *CPtrCSlice) Ptr() CPtr {
+	if len(*v) == 0 {
+		return nil
+	}
+	return CPtr(&(*v)[0])
+}
+
+// Free frees a CPtrSlice
+func (v *CPtrCSlice) Free() {
+	Free(v.Ptr())
+	*v = nil
+}
+
+////////// SizeT //////////
+
+// SizeTCSlice is a C allocated slice of C.size_t.
+type SizeTCSlice []SizeT
+
+// NewSizeTCSlice returns a SizeTCSlice.
+// Similar to CString it must be freed with slice.Free()
+func NewSizeTCSlice(size int) SizeTCSlice {
+	if size == 0 {
+		return nil
+	}
+	cMem := Malloc(SizeT(size) * SizeTSize)
+	cSlice := (*[MaxIdx]SizeT)(cMem)[:size:size]
+	return cSlice
+}
+
+// Ptr returns a pointer to SizeTCSlice
+func (v *SizeTCSlice) Ptr() CPtr {
+	if len(*v) == 0 {
+		return nil
+	}
+	return CPtr(&(*v)[0])
+}
+
+// Free frees a SizeTCSlice
+func (v *SizeTCSlice) Free() {
+	Free(v.Ptr())
+	*v = nil
+}

--- a/internal/cutil/cslice_test.go
+++ b/internal/cutil/cslice_test.go
@@ -1,0 +1,88 @@
+package cutil
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCPtrCSlice(t *testing.T) {
+	t.Run("Size", func(t *testing.T) {
+		const size = 256
+		slice := NewCPtrCSlice(size)
+		defer slice.Free()
+		assert.Len(t, slice, size)
+	})
+	t.Run("Fill", func(t *testing.T) {
+		const size = 256
+		slice := NewCPtrCSlice(size)
+		defer slice.Free()
+		for i := range slice {
+			// In order to fill the array with valid C pointers we simply use
+			// the addresses of the array elements themselves.
+			slice[i] = CPtr(&slice[i])
+		}
+		for i := 0; i < size; i++ {
+			p := (*CPtr)(unsafe.Pointer(uintptr(slice.Ptr()) + uintptr(i)*uintptr(PtrSize)))
+			assert.Equal(t, slice[i], *p)
+		}
+	})
+	t.Run("OutOfBound", func(t *testing.T) {
+		const size = 1
+		slice := NewCPtrCSlice(size)
+		defer slice.Free()
+		assert.Panics(t, func() { slice[size] = nil })
+	})
+	t.Run("FreeSetsNil", func(t *testing.T) {
+		const size = 1
+		slice := NewCPtrCSlice(size)
+		slice.Free()
+		assert.Nil(t, slice)
+	})
+	t.Run("EmptySlice", func(t *testing.T) {
+		empty := NewCPtrCSlice(0)
+		assert.Len(t, empty, 0)
+		assert.Nil(t, empty)
+		assert.NotPanics(t, func() { empty.Free() })
+	})
+}
+
+func TestSizeTCSlice(t *testing.T) {
+	t.Run("Size", func(t *testing.T) {
+		const size = 256
+		slice := NewSizeTCSlice(size)
+		defer slice.Free()
+		assert.Len(t, slice, size)
+	})
+	t.Run("Fill", func(t *testing.T) {
+		const size = 256
+		slice := NewSizeTCSlice(size)
+		defer slice.Free()
+		for i := range slice {
+			slice[i] = SizeT(i)
+		}
+		for i := 0; i < size; i++ {
+			p := (*SizeT)(unsafe.Pointer(uintptr(slice.Ptr()) + uintptr(i)*uintptr(PtrSize)))
+			assert.Equal(t, slice[i], *p)
+		}
+	})
+	t.Run("OutOfBound", func(t *testing.T) {
+		const size = 1
+		slice := NewSizeTCSlice(size)
+		defer slice.Free()
+		assert.Panics(t, func() { slice[size] = 0 })
+	})
+	t.Run("FreeSetsNil", func(t *testing.T) {
+		const size = 1
+		slice := NewSizeTCSlice(size)
+		slice.Free()
+		assert.Nil(t, slice)
+	})
+	t.Run("EmptySlice", func(t *testing.T) {
+		empty := NewSizeTCSlice(0)
+		assert.Len(t, empty, 0)
+		assert.Nil(t, empty)
+		assert.NotPanics(t, func() { empty.Free() })
+	})
+}

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -90,15 +90,15 @@ func (w *WriteOp) Create(exclusive CreateOption) {
 	C.rados_write_op_create(w.op, C.int(exclusive), nil)
 }
 
-//  SetOmap appends the map `pairs` to the omap `oid`.
+// SetOmap appends the map `pairs` to the omap `oid`.
 func (w *WriteOp) SetOmap(pairs map[string][]byte) {
 	sos := newSetOmapStep(pairs)
 	w.steps = append(w.steps, sos)
 	C.rados_write_op_omap_set(
 		w.op,
-		sos.cKeys,
-		sos.cValues,
-		sos.cLengths,
+		(**C.char)(sos.cKeys.Ptr()),
+		(**C.char)(sos.cValues.Ptr()),
+		(*C.size_t)(sos.cLengths.Ptr()),
 		sos.cNum)
 }
 
@@ -108,7 +108,7 @@ func (w *WriteOp) RmOmapKeys(keys []string) {
 	w.steps = append(w.steps, roks)
 	C.rados_write_op_omap_rm_keys(
 		w.op,
-		roks.cKeys,
+		(**C.char)(roks.cKeys.Ptr()),
 		roks.cNum)
 }
 

--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -14,9 +14,9 @@ import "C"
 
 import (
 	"fmt"
-	"math"
 	"unsafe"
 
+	"github.com/ceph/go-ceph/internal/cutil"
 	"github.com/ceph/go-ceph/internal/retry"
 	"github.com/ceph/go-ceph/rados"
 )
@@ -364,7 +364,7 @@ func (gmis GlobalMirrorImageStatus) LocalStatus() (SiteMirrorImageStatus, error)
 	return ss, err
 }
 
-type siteArray [math.MaxInt32]C.rbd_mirror_image_site_status_t
+type siteArray [cutil.MaxIdx]C.rbd_mirror_image_site_status_t
 
 // GetGlobalMirrorStatus returns status information pertaining to the state
 // of the images's mirroring.


### PR DESCRIPTION
This change uses slices on top of C allocated array memory in order
to have a simple (no pointer arithmetic) and safe (boundary-checked)
access to its elements.

Based on #428 

Signed-off-by: Sven Anderson <sven@redhat.com>
