### PR TITLE
[outdated] cutil: use C.CBytes in Iovec

### DIFF
--- a/cephfs/file.go
+++ b/cephfs/file.go
@@ -158,6 +158,7 @@ func (f *File) Preadv(data [][]byte, offset int64) (int, error) {
 	case ret == 0:
 		return 0, io.EOF
 	}
+	iov.SyncToData()
 	return int(ret), nil
 }
 

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -23,6 +23,7 @@ ENV PATH="${PATH}:/opt/go/bin"
 ENV GOROOT=/opt/go
 ENV GO111MODULE=on
 ENV GOPATH /go
+ENV GODEBUG=cgocheck=2
 WORKDIR /go/src/github.com/ceph/go-ceph
 VOLUME /go/src/github.com/ceph/go-ceph
 


### PR DESCRIPTION
Update: superseded by #441 

As a stop gap solution this change uses C.CBytes in Iovec in order to
stop breaking the pointer passing rules of cgo, that don't allow
storing Go pointer in C allocated memory, until a more performant
solution is agreed upon.

Fixes: #412

Signed-off-by: Sven Anderson <sven@redhat.com>
