### PR TITLE
cutil: add PtrGuard for storing Go pointers in C memory

### DIFF
--- a/internal/cutil/aliases.go
+++ b/internal/cutil/aliases.go
@@ -1,12 +1,20 @@
 package cutil
 
+/*
+#include <stdlib.h>
+typedef void* voidptr;
+*/
 import "C"
 
 import (
 	"unsafe"
 )
 
-// Basic types from C that we can make "public" without too much fuss.
+// PtrSize is the size of a pointer
+const PtrSize = C.sizeof_voidptr
+
+// SizeTSize is the size of C.size_t
+const SizeTSize = C.sizeof_size_t
 
 // SizeT wraps size_t from C.
 type SizeT C.size_t
@@ -14,6 +22,9 @@ type SizeT C.size_t
 // This section contains a bunch of types that are basically just
 // unsafe.Pointer but have specific types to help "self document" what the
 // underlying pointer is really meant to represent.
+
+// CPtr is an unsafe.Pointer to C allocated memory
+type CPtr unsafe.Pointer
 
 // CharPtrPtr is an unsafe pointer wrapping C's `char**`.
 type CharPtrPtr unsafe.Pointer
@@ -26,3 +37,9 @@ type SizeTPtr unsafe.Pointer
 
 // FreeFunc is a wrapper around calls to, or act like, C's free function.
 type FreeFunc func(unsafe.Pointer)
+
+// Malloc is C.malloc
+func Malloc(s SizeT) CPtr { return CPtr(C.malloc(C.size_t(s))) }
+
+// Free is C.free
+func Free(p CPtr) { C.free(unsafe.Pointer(p)) }

--- a/internal/cutil/ptrguard.go
+++ b/internal/cutil/ptrguard.go
@@ -1,0 +1,82 @@
+package cutil
+
+/*
+extern void waitForReleaseSignal(void*);
+extern void sendStoredSignal(void*);
+
+static inline void storeUntilRelease(void** c_ptr, void* go_ptr, void* v) {
+	*c_ptr = go_ptr;         // store Go pointer in C memory at c_ptr
+	sendStoredSignal(v);     // send "stored" signal to main thread -->(1)
+  waitForReleaseSignal(v); // wait for "release" signal from main thread when
+                           // Release() has been called. <--(2)
+	*c_ptr = NULL;           // reset C memory to NULL
+	sendStoredSignal(v);     // send second "stored" signal to main thread -->(3)
+}
+*/
+import "C"
+
+import (
+	"sync"
+	"unsafe"
+)
+
+// PtrGuard respresents a guarded Go pointer (pointing to memory allocated by Go
+// runtime) stored in C memory (allocated by C)
+type PtrGuard struct {
+	// These mutexes will be used as binary semaphores for signalling events from
+	// one thread to another, which - in contrast to other languages like C++ - is
+	// possible in Go, that is a Mutex can be locked in one thread and unlocked in
+	// another.
+	stored, release sync.Mutex
+	released        bool
+}
+
+// WARNING: using binary semaphores (mutexes) for signalling like this is quite
+// a delicate task in order to avoid deadlocks or panics. Whenever changing the
+// code logic, please review at least three times that there is no unexpected
+// state possible. Usually the natural choice would be to use channels instead,
+// but these can not easily passed to C code because of the pointer-to-pointer
+// cgo rule, and would require the use of a Go object registry.
+
+// NewPtrGuard writes the goPtr (pointing to Go memory) into C memory at the
+// position cPtr, and returns a PtrGuard object.
+func NewPtrGuard(cPtr CPtr, goPtr unsafe.Pointer) *PtrGuard {
+	var v PtrGuard
+	// Since the mutexes are used for signalling, they have to be initialized to
+	// locked state, so that following lock attempts will block.
+	v.release.Lock()
+	v.stored.Lock()
+	// Start a background go routine that lives until Release is called. This
+	// calls a C function that stores goPtr into C memory at position cPtr and
+	// then waits until it reveices the "release" signal, after which it nulls out
+	// the C memory at cPtr and then exits.
+	go C.storeUntilRelease((*unsafe.Pointer)(cPtr), goPtr, unsafe.Pointer(&v))
+	// Wait for the "stored" signal from the go routine when the Go pointer has
+	// been stored to the C memory. <--(1)
+	v.stored.Lock()
+	return &v
+}
+
+// Release removes the guarded Go pointer from the C memory by overwriting it
+// with NULL.
+func (v *PtrGuard) Release() {
+	if !v.released {
+		v.released = true
+		v.release.Unlock() // Send the "release" signal to the go routine. -->(2)
+		// Wait for the second "stored" signal when the C memory has been nulled
+		// out. <--(3)
+		v.stored.Lock()
+	}
+}
+
+//export waitForReleaseSignal
+func waitForReleaseSignal(p unsafe.Pointer) {
+	v := (*PtrGuard)(p)
+	v.release.Lock()
+}
+
+//export sendStoredSignal
+func sendStoredSignal(p unsafe.Pointer) {
+	v := (*PtrGuard)(p)
+	v.stored.Unlock()
+}

--- a/internal/cutil/ptrguard_test.go
+++ b/internal/cutil/ptrguard_test.go
@@ -1,0 +1,66 @@
+package cutil
+
+import (
+	"math/rand"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPtrGuard(t *testing.T) {
+	t.Run("storeAndRelease", func(t *testing.T) {
+		s := "string"
+		goPtr := (unsafe.Pointer)(&s)
+		cPtr := Malloc(PtrSize)
+		defer Free(cPtr)
+		pg := NewPtrGuard(cPtr, goPtr)
+		assert.Equal(t, *(*unsafe.Pointer)(cPtr), goPtr)
+		pg.Release()
+		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
+	})
+
+	t.Run("multiRelease", func(t *testing.T) {
+		s := "string"
+		goPtr := (unsafe.Pointer)(&s)
+		cPtr := Malloc(PtrSize)
+		defer Free(cPtr)
+		pg := NewPtrGuard(cPtr, goPtr)
+		assert.Equal(t, *(*unsafe.Pointer)(cPtr), goPtr)
+		pg.Release()
+		pg.Release()
+		pg.Release()
+		pg.Release()
+		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
+	})
+
+	t.Run("stressTest", func(t *testing.T) {
+		const N = 1000
+		const M = 10000
+		var ptrGuards [N]*PtrGuard
+		cPtrArr := (*[N]CPtr)(unsafe.Pointer(Malloc(N * PtrSize)))
+		defer Free(CPtr(&cPtrArr[0]))
+		for n := 0; n < M; n++ {
+			i := uintptr(rand.Intn(N))
+			if ptrGuards[i] == nil {
+				goPtr := unsafe.Pointer(&(struct{ byte }{42}))
+				cPtrPtr := CPtr(&cPtrArr[i])
+				ptrGuards[i] = NewPtrGuard(cPtrPtr, goPtr)
+				assert.Equal(t, (unsafe.Pointer)(cPtrArr[i]), goPtr)
+			} else {
+				ptrGuards[i].Release()
+				ptrGuards[i] = nil
+				assert.Zero(t, cPtrArr[i])
+			}
+		}
+		for i := range ptrGuards {
+			if ptrGuards[i] != nil {
+				ptrGuards[i].Release()
+				ptrGuards[i] = nil
+			}
+		}
+		for i := uintptr(0); i < N; i++ {
+			assert.Zero(t, cPtrArr[i])
+		}
+	})
+}


### PR DESCRIPTION
PtrGuard is a type that allows to store a Go pointer (that is a pointer pointing to memory allocated by the Go runtime) in C memory (that is memory allocated by C, with malloc() for example). The pointer passing rules of cgo don't allow Go code to store Go pointer in C memory. However, C code is allowed to store Go pointer in C memory until the C function returns. PtrGuard takes advantage of this by calling a C function in a Goroutine that stores the Go pointer in the C memory and then waits for a release signal (implemented via a mutex). After the release signal is received, the C memory is overwritten with NULL and the C function returns.

Spin-off from #419 
Depends on #428 

## Checklist
- [X] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
