### PR TITLE
cutil: add PtrGuard for storing Go pointers in C memory

### DIFF
--- a/internal/cutil/ptrguard.go
+++ b/internal/cutil/ptrguard.go
@@ -1,0 +1,79 @@
+package cutil
+
+import (
+	"sync"
+	"unsafe"
+)
+
+// PtrGuard respresents a guarded Go pointer (pointing to memory allocated by Go
+// runtime) stored in C memory (allocated by C)
+type PtrGuard struct {
+	// These mutexes will be used as binary semaphores for signalling events from
+	// one thread to another, which - in contrast to other languages like C++ - is
+	// possible in Go, that is a Mutex can be locked in one thread and unlocked in
+	// another.
+	stored, release sync.Mutex
+	released        bool
+}
+
+// WARNING: using binary semaphores (mutexes) for signalling like this is quite
+// a delicate task in order to avoid deadlocks or panics. Whenever changing the
+// code logic, please review at least three times that there is no unexpected
+// state possible. Usually the natural choice would be to use channels instead,
+// but these can not easily passed to C code because of the pointer-to-pointer
+// cgo rule, and would require the use of a Go object registry.
+
+// NewPtrGuard writes the goPtr (pointing to Go memory) into C memory at the
+// position cPtr, and returns a PtrGuard object.
+func NewPtrGuard(cPtr CPtr, goPtr unsafe.Pointer) *PtrGuard {
+	var v PtrGuard
+	// Since the mutexes are used for signalling, they have to be initialized to
+	// locked state, so that following lock attempts will block.
+	v.release.Lock()
+	v.stored.Lock()
+	// Start a background go routine that lives until Release is called. This
+	// calls a special function that makes sure the garbage collector doesn't touch
+	// goPtr, stores it into C memory at position cPtr and then waits until it
+	// reveices the "release" signal, after which it nulls out the C memory at
+	// cPtr and then exits.
+	go func() {
+		storeUntilRelease(&v, (*CPtr)(cPtr), uintptr(goPtr))
+	}()
+	// Wait for the "stored" signal from the go routine when the Go pointer has
+	// been stored to the C memory. <--(1)
+	v.stored.Lock()
+	return &v
+}
+
+// Release removes the guarded Go pointer from the C memory by overwriting it
+// with NULL.
+func (v *PtrGuard) Release() {
+	if !v.released {
+		v.released = true
+		v.release.Unlock() // Send the "release" signal to the go routine. -->(2)
+		v.stored.Lock()    // Wait for the second "stored" signal when the C memory
+		//                    has been nulled out. <--(3)
+
+	}
+}
+
+//go:uintptrescapes
+
+// From https://golang.org/src/cmd/compile/internal/gc/lex.go:
+// For the next function declared in the file any uintptr arguments may be
+// pointer values converted to uintptr. This directive ensures that the
+// referenced allocated object, if any, is retained and not moved until the call
+// completes, even though from the types alone it would appear that the object
+// is no longer needed during the call. The conversion to uintptr must appear in
+// the argument list.
+// Also see https://golang.org/cmd/compile/#hdr-Compiler_Directives
+
+func storeUntilRelease(v *PtrGuard, cPtr *CPtr, goPtr uintptr) {
+	uip := (*uintptr)(unsafe.Pointer(cPtr))
+	*uip = goPtr      // store Go pointer in C memory at c_ptr
+	v.stored.Unlock() // send "stored" signal to main thread -->(1)
+	v.release.Lock()  // wait for "release" signal from main thread when
+	//                   Release() has been called. <--(2)
+	*uip = 0          // reset C memory to NULL
+	v.stored.Unlock() // send second "stored" signal to main thread -->(3)
+}

--- a/internal/cutil/ptrguard_test.go
+++ b/internal/cutil/ptrguard_test.go
@@ -1,0 +1,75 @@
+package cutil
+
+import (
+	"math/rand"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPtrGuard(t *testing.T) {
+	t.Run("storeAndRelease", func(t *testing.T) {
+		s := "string"
+		goPtr := (unsafe.Pointer)(&s)
+		cPtr := Malloc(PtrSize)
+		defer Free(cPtr)
+		pg := NewPtrGuard(cPtr, goPtr)
+		assert.Equal(t, *(*unsafe.Pointer)(cPtr), goPtr)
+		pg.Release()
+		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
+	})
+
+	t.Run("multiRelease", func(t *testing.T) {
+		s := "string"
+		goPtr := (unsafe.Pointer)(&s)
+		cPtr := Malloc(PtrSize)
+		defer Free(cPtr)
+		pg := NewPtrGuard(cPtr, goPtr)
+		assert.Equal(t, *(*unsafe.Pointer)(cPtr), goPtr)
+		pg.Release()
+		pg.Release()
+		pg.Release()
+		pg.Release()
+		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
+	})
+
+	t.Run("stressTest", func(t *testing.T) {
+		// Because the default thread limit of the Go runtime is 10000, creating
+		// 20000 parallel PtrGuards asserts, that Go routines of PtrGuards don't
+		// create threads.
+		const N = 20000  // Number of parallel PtrGuards
+		const M = 100000 // Number of loops
+		var ptrGuards [N]*PtrGuard
+		cPtrArr := (*[N]CPtr)(unsafe.Pointer(Malloc(N * PtrSize)))
+		defer Free(CPtr(&cPtrArr[0]))
+		toggle := func(i int) {
+			if ptrGuards[i] == nil {
+				goPtr := unsafe.Pointer(&(struct{ byte }{42}))
+				cPtrPtr := CPtr(&cPtrArr[i])
+				ptrGuards[i] = NewPtrGuard(cPtrPtr, goPtr)
+				assert.Equal(t, (unsafe.Pointer)(cPtrArr[i]), goPtr)
+			} else {
+				ptrGuards[i].Release()
+				ptrGuards[i] = nil
+				assert.Zero(t, cPtrArr[i])
+			}
+		}
+		for i := range ptrGuards {
+			toggle(i)
+		}
+		for n := 0; n < M; n++ {
+			i := rand.Intn(N)
+			toggle(i)
+		}
+		for i := range ptrGuards {
+			if ptrGuards[i] != nil {
+				ptrGuards[i].Release()
+				ptrGuards[i] = nil
+			}
+		}
+		for i := uintptr(0); i < N; i++ {
+			assert.Zero(t, cPtrArr[i])
+		}
+	})
+}


### PR DESCRIPTION
PtrGuard is a type that allows to store a Go pointer (that is a pointer pointing to memory allocated by the Go runtime) in C memory (that is memory allocated by C, with malloc() for example). The pointer passing rules of cgo don't allow Go code to store Go pointer in C memory. However, there is a compiler directive for functions that tells the GC not to touch a pointer stored in a uintptr argument until the function returns. PtrGuard takes advantage of this by calling such a function in a Goroutine that stores the uintptr containing the Go pointer in the provided C memory and then waits for a release signal (implemented via a mutex). After the release signal is received, the C memory is overwritten with NULL and the function returns, which makes the pointer accessible to the GC again.

Spin-off from #419 
Depends on #428 

## Checklist
- [X] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
