### PR TITLE
rbd: test that cephIoctx helper panics when fed invalid inputs

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -95,7 +95,11 @@ type TrashInfo struct {
 
 // cephIoctx returns a ceph rados_ioctx_t given a go-ceph rados IOContext.
 func cephIoctx(radosIoctx *rados.IOContext) C.rados_ioctx_t {
-	return C.rados_ioctx_t(radosIoctx.Pointer())
+	p := radosIoctx.Pointer()
+	if p == nil {
+		panic("invalid IOContext pointer")
+	}
+	return C.rados_ioctx_t(p)
 }
 
 // test if a bit is set in the given value

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -1652,3 +1652,16 @@ func TestOpenImageById(t *testing.T) {
 	conn.DeletePool(poolname)
 	conn.Shutdown()
 }
+
+func TestRadosIoctxInvalid(t *testing.T) {
+	// ensure cephIoctx panics if passed a nil pointer
+	assert.Panics(t, func() {
+		_ = cephIoctx(nil)
+	})
+	// test that an invalid/incomplete (no actual backing C ioctx) will
+	// trigger a panic in cephIoctx when called.
+	ioctx := &rados.IOContext{}
+	assert.Panics(t, func() {
+		_ = cephIoctx(ioctx)
+	})
+}


### PR DESCRIPTION
As per go-ceph issue #427, and a discussion in #399 this change and
test ensure that the cephIoctx helper function, that extracts the
C.rados_ioctx_t from a Go rados.IOContext, never returns a nil/null
C type.
As these are always "programming errors" panicking is reasonable
behavior for this case.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
