### PR TITLE
rbd: enable test cases with ceph issues that have been fixed

### DIFF
--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -1550,14 +1550,12 @@ func TestOpenImageById(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run("ReadWriteBadId", func(t *testing.T) {
-		t.Skip("segfaults due to https://tracker.ceph.com/issues/43178")
 		// phony id
 		img, err := OpenImageById(ioctx, "102f00aaabbbccd", NoSnapshot)
 		require.Error(t, err)
 		require.Nil(t, img)
 	})
 	t.Run("ReadOnlyBadId", func(t *testing.T) {
-		t.Skip("segfaults due to https://tracker.ceph.com/issues/43178")
 		// phony id
 		img, err := OpenImageByIdReadOnly(ioctx, "blubb", NoSnapshot)
 		require.Error(t, err)


### PR DESCRIPTION
Ceph issue https://tracker.ceph.com/issues/43178 has been fixed for
a while with backports. No reason not to enable these test cases now.

Fixes: #207 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
