### PR TITLE
cephfs: enable test cases with ceph issues that have been fixed

### DIFF
--- a/cephfs/file_xattr.go
+++ b/cephfs/file_xattr.go
@@ -34,8 +34,9 @@ const (
 
 // SetXattr sets an extended attribute on the open file.
 //
-// NOTE: Attempting to set an xattr value with an empty value may cause
-// the xattr to be unset. Please refer to https://tracker.ceph.com/issues/46084
+// NOTE: Attempting to set an xattr value with an empty value may cause the
+// xattr to be unset on some older versions of ceph.
+// Please refer to https://tracker.ceph.com/issues/46084
 //
 // Implements:
 //  int ceph_fsetxattr(struct ceph_mount_info *cmount, int fd, const char *name,

--- a/cephfs/file_xattr_test.go
+++ b/cephfs/file_xattr_test.go
@@ -24,15 +24,12 @@ var xattrSamples = []struct {
 		name:  "user.x2kZeros",
 		value: make([]byte, 2048),
 	},
-	// Ceph's behavior when an empty value is supplied may be considered
-	// to have a bug in some versions. Using an empty value may cause
-	// the xattr to be unset. Please refer to:
-	// https://tracker.ceph.com/issues/46084
-	// So we avoid testing for that case explicitly here.
-	//{
-	//	name:  "user.xEmpty",
-	//	value: []byte(""),
-	//},
+	// Older versions of ceph had a bug where using an empty value caused the
+	// xattr to be unset. This has been fixed for nautilus and octopus.
+	{
+		name:  "user.xEmpty",
+		value: []byte(""),
+	},
 }
 
 func TestGetSetXattr(t *testing.T) {
@@ -111,10 +108,11 @@ func TestListXattr(t *testing.T) {
 		}
 		xl, err := f.ListXattr()
 		assert.NoError(t, err)
-		assert.Len(t, xl, 3)
+		assert.Len(t, xl, 4)
 		assert.Contains(t, xl, xattrSamples[0].name)
 		assert.Contains(t, xl, xattrSamples[1].name)
 		assert.Contains(t, xl, xattrSamples[2].name)
+		assert.Contains(t, xl, xattrSamples[3].name)
 	})
 
 	t.Run("invalidFile", func(t *testing.T) {

--- a/cephfs/path_xattr_test.go
+++ b/cephfs/path_xattr_test.go
@@ -84,10 +84,11 @@ func TestListXattrPath(t *testing.T) {
 		}
 		xl, err := mount.ListXattr(fname)
 		assert.NoError(t, err)
-		assert.Len(t, xl, 3)
+		assert.Len(t, xl, 4)
 		assert.Contains(t, xl, xattrSamples[0].name)
 		assert.Contains(t, xl, xattrSamples[1].name)
 		assert.Contains(t, xl, xattrSamples[2].name)
+		assert.Contains(t, xl, xattrSamples[3].name)
 	})
 
 	t.Run("invalidMount", func(t *testing.T) {
@@ -237,10 +238,11 @@ func TestListXattrLinkPath(t *testing.T) {
 		}
 		xl, err := mount.LlistXattr(lname)
 		assert.NoError(t, err)
-		assert.Len(t, xl, 3)
+		assert.Len(t, xl, 4)
 		assert.Contains(t, xl, xattrSamples[0].name)
 		assert.Contains(t, xl, xattrSamples[1].name)
 		assert.Contains(t, xl, xattrSamples[2].name)
+		assert.Contains(t, xl, xattrSamples[3].name)
 	})
 
 	t.Run("invalidMount", func(t *testing.T) {


### PR DESCRIPTION
Ceph issue https://tracker.ceph.com/issues/46084 has been fixed with
backports to nautilus and octopus. Re-enable the relevant test data
and fix up the tests to match.

Signed-off-by: John Mulligan <jmulligan@redhat.com>

Fixes: #207 


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
