### PR TITLE
CI: add branch pattern 'pr/**' to PR test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,10 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      # run the CI also on PRs that are based on branches starting with pr/...
+      - 'pr/**'
   schedule:
     - cron: 1 1 * * *
 


### PR DESCRIPTION
In order to run CI jobs also on PRs that are based on other PRs, this
change adds the pattern 'pr/**' to the tested base branches.  That
means, if PRs are pushed that are based on branches that start with
pr/... these PRs are also get tested. So, if we - by convention - push
PRs to branches like for example pr/ansiwen/myfix42, then all PRs
that are not based on master but another PR get tested as well.

For reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags

Signed-off-by: Sven Anderson <sven@redhat.com>
