### PR TITLE
rbd: fix typo in comment & improve comment consistency

### DIFF
--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -38,8 +38,8 @@ const (
 	// ImageMirrorModeJournal uses journaling to propagate RBD images between
 	// ceph clusters.
 	ImageMirrorModeJournal = ImageMirrorMode(C.RBD_MIRROR_IMAGE_MODE_JOURNAL)
-	// ImageMirrorModeSnapshot uses snapshot RDB images to propagate images
-	// between ceph clusters.
+	// ImageMirrorModeSnapshot uses snapshots to propagate RBD images between
+	// ceph clusters.
 	ImageMirrorModeSnapshot = ImageMirrorMode(C.RBD_MIRROR_IMAGE_MODE_SNAPSHOT)
 )
 


### PR DESCRIPTION
RBD was misspelled as RDB. While I was there I made the comments
for both constants more consistently worded.



## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
