### PR TITLE
rbd: add functions to fetch mirroring status of a RBD image

### DIFF
--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -219,3 +219,17 @@ func (image *Image) GetMirrorImageInfo() (*MirrorImageInfo, error) {
 	C.rbd_mirror_image_get_info_cleanup(&cInfo)
 	return &mii, nil
 }
+
+// GetImageMirrorMode fetches the mirroring approach for an RBD image.
+//
+// Implements:
+//  int rbd_mirror_image_get_mode(rbd_image_t image, rbd_mirror_image_mode_t *mode);
+func (image *Image) GetImageMirrorMode() (ImageMirrorMode, error) {
+	var mode C.rbd_mirror_image_mode_t
+	if err := image.validate(imageIsOpen); err != nil {
+		return ImageMirrorMode(mode), err
+	}
+
+	ret := C.rbd_mirror_image_get_mode(image.image, &mode)
+	return ImageMirrorMode(mode), getError(ret)
+}

--- a/rbd/mirror_test.go
+++ b/rbd/mirror_test.go
@@ -91,6 +91,11 @@ func TestMirroring(t *testing.T) {
 
 		err = img.MirrorEnable(ImageMirrorModeSnapshot)
 		assert.NoError(t, err)
+
+		mode, err := img.GetImageMirrorMode()
+		assert.NoError(t, err)
+		assert.Equal(t, mode, ImageMirrorModeSnapshot)
+
 		err = img.MirrorDisable(false)
 		assert.NoError(t, err)
 	})
@@ -102,6 +107,8 @@ func TestMirroring(t *testing.T) {
 		err = img.MirrorEnable(ImageMirrorModeSnapshot)
 		assert.Error(t, err)
 		err = img.MirrorDisable(false)
+		assert.Error(t, err)
+		_, err = img.GetImageMirrorMode()
 		assert.Error(t, err)
 	})
 	t.Run("promoteDemote", func(t *testing.T) {


### PR DESCRIPTION
Added two functions:
1. GetMirrorImageInfo()
2. GetImageMirrorMode()

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

Fixes: #379 

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
