### PR TITLE
github: do not dismiss reviews on rebase

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,5 @@
 ---
 pull_request_rules:
-  - name: remove outdated approvals
-    conditions:
-      - base=master
-    actions:
-      dismiss_reviews:
-        approved: true
-        changes_requested: false
   - name: automatic merge
     conditions:
       - label!=do-not-merge
@@ -25,9 +18,6 @@ pull_request_rules:
         rebase_fallback: merge
         strict: smart
         strict_method: rebase
-      dismiss_reviews:
-        approved: false
-        changes_requested: false
       delete_head_branch: {}
   - name: ask to resolve conflict
     conditions:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,7 +25,9 @@ pull_request_rules:
         rebase_fallback: merge
         strict: smart
         strict_method: rebase
-      dismiss_reviews: {}
+      dismiss_reviews:
+        approved: false
+        changes_requested: false
       delete_head_branch: {}
   - name: ask to resolve conflict
     conditions:


### PR DESCRIPTION
When Mergify does a rebase, the approvals are suddenly getting dropped
from the PR. The approvals used to stick around when Mergify did the
rebase, but did get dropped when a PR was updated an other way.

By explicitly listing the options in the `dismiss_reviews` section,
default changes on the Mergify side should not affect the configuration
of this repository.

Doc-URL: https://docs.mergify.io/actions.html#dismiss-reviews
