### PR TITLE
cephfs admin: fix the json sent when flag RetainSnapshots is set

### DIFF
--- a/cephfs/admin/flags.go
+++ b/cephfs/admin/flags.go
@@ -41,7 +41,7 @@ func (f SubVolRmFlags) flags() map[string]bool {
 		o["force"] = true
 	}
 	if f.RetainSnapshots {
-		o["retain-snapshots"] = true
+		o["retain_snapshots"] = true
 	}
 	return o
 }


### PR DESCRIPTION
The json key sent to retain snapshots on subvolume remove was misspelled
and had a dash in it rather than an underscore. Fix the incorrect key
and add a test, that needs to be able to run on version of cephfs w/o
snapshot retention, and verifies that flag does the correct thing.

Octopus does not have snapshot retention while newer versions of nautilus does. :-\

See also: #451 


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
