### PR TITLE
rbd: add GetGlobalMirrorStatus implementing rbd_mirror_image_get_global_status

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -259,6 +259,7 @@ test_go_ceph() {
     fi
     if [[ ${MIRROR_CONF} && ${CEPH_VERSION} != nautilus ]]; then
         setup_mirroring
+        export MIRROR_CONF
     fi
     for pkg in "${pkgs[@]}"; do
         test_pkg "${pkg}" || test_failed "${pkg}"

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -71,6 +71,12 @@ var (
 	// revive:enable:exported
 )
 
+// Public general error
+const (
+	// ErrNotExist indicates a non-specific missing resource.
+	ErrNotExist = rbdError(-C.ENOENT)
+)
+
 // Private errors:
 
 const (

--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -408,3 +408,16 @@ func (image *Image) GetGlobalMirrorStatus() (GlobalMirrorImageStatus, error) {
 	}
 	return status, nil
 }
+
+// CreateMirrorSnapshot creates a snapshot for image propagation to mirrors.
+//
+// Implements:
+//  int rbd_mirror_image_create_snapshot(rbd_image_t image,
+//                                       uint64_t *snap_id);
+func (image *Image) CreateMirrorSnapshot() (uint64, error) {
+	var snapID C.uint64_t
+	ret := C.rbd_mirror_image_create_snapshot(
+		image.image,
+		&snapID)
+	return uint64(snapID), getError(ret)
+}

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -37,8 +37,22 @@ func radosConnect(t *testing.T) *rados.Conn {
 	require.NoError(t, err)
 	err = conn.ReadDefaultConfigFile()
 	require.NoError(t, err)
+	waitForRadosConn(t, conn)
+	return conn
+}
 
-	timeout := time.After(time.Second * 5)
+func radosConnectConfig(t *testing.T, p string) *rados.Conn {
+	conn, err := rados.NewConn()
+	require.NoError(t, err)
+	err = conn.ReadConfigFile(p)
+	require.NoError(t, err)
+	waitForRadosConn(t, conn)
+	return conn
+}
+
+func waitForRadosConn(t *testing.T, conn *rados.Conn) {
+	var err error
+	timeout := time.After(time.Second * 15)
 	ch := make(chan error)
 	go func(conn *rados.Conn) {
 		ch <- conn.Connect()
@@ -49,7 +63,6 @@ func radosConnect(t *testing.T) *rados.Conn {
 		err = fmt.Errorf("timed out waiting for connect")
 	}
 	require.NoError(t, err)
-	return conn
 }
 
 func TestImageCreate(t *testing.T) {


### PR DESCRIPTION

This function is added, along with required return types and some helper
functions, to support fetching the global mirroring status component
that makes up a major part of `rbd mirror image status` command's
output.

Part of: #460 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
