### PR TITLE
Add rbd admin package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ test-binaries: \
 	internal/errutil.test \
 	internal/retry.test \
 	rados.test \
-	rbd.test
+	rbd.test \
+	rbd/admin.test
 test-bins: test-binaries
 
 %.test: % force_go_build

--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -5,13 +5,14 @@ package admin
 import (
 	"strconv"
 
+	ccom "github.com/ceph/go-ceph/common/commands"
 	"github.com/ceph/go-ceph/internal/commands"
 	"github.com/ceph/go-ceph/rados"
 )
 
 // RadosCommander provides an interface to execute JSON-formatted commands that
 // allow the cephfs administrative functions to interact with the Ceph cluster.
-type RadosCommander = commands.RadosCommander
+type RadosCommander = ccom.RadosCommander
 
 // FSAdmin is used to administrate CephFS within a ceph cluster.
 type FSAdmin struct {

--- a/common/commands/doc.go
+++ b/common/commands/doc.go
@@ -1,0 +1,7 @@
+/*
+Package commands provides types and utility functions that are used for
+interfacing with the JSON based command infrastructure in Ceph.
+
+The *rados.Conn type implements many of the interfaces found in this package.
+*/
+package commands

--- a/common/commands/interfaces.go
+++ b/common/commands/interfaces.go
@@ -1,0 +1,20 @@
+package commands
+
+// MgrCommander in an interface for the API needed to execute JSON formatted
+// commands on the ceph mgr.
+type MgrCommander interface {
+	MgrCommand(buf [][]byte) ([]byte, string, error)
+}
+
+// MonCommander is an interface for the API needed to execute JSON formatted
+// commands on the ceph mon(s).
+type MonCommander interface {
+	MonCommand(buf []byte) ([]byte, string, error)
+}
+
+// RadosCommander provides an interface for APIs needed to execute JSON
+// formatted commands on the Ceph cluster.
+type RadosCommander interface {
+	MgrCommander
+	MonCommander
+}

--- a/doc.go
+++ b/doc.go
@@ -10,6 +10,9 @@ The "rbd" sub-package wraps APIs that handle RBD specific functions.
 
 The "cephfs" sub-package wraps APIs that handle CephFS specific functions.
 
+The "common" sub-package contains sub-packages related to implementing
+common interfaces and utilities shared across the above.
+
 Consult the documentation for each package for additional details.
 */
 package ceph

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -3,27 +3,9 @@ package commands
 import (
 	"encoding/json"
 
+	ccom "github.com/ceph/go-ceph/common/commands"
 	"github.com/ceph/go-ceph/rados"
 )
-
-// MgrCommander in an interface for the API needed to execute JSON formatted
-// commands on the ceph mgr.
-type MgrCommander interface {
-	MgrCommand(buf [][]byte) ([]byte, string, error)
-}
-
-// MonCommander is an interface for the API needed to execute JSON formatted
-// commands on the ceph mon(s).
-type MonCommander interface {
-	MonCommand(buf []byte) ([]byte, string, error)
-}
-
-// RadosCommander provides an interface for APIs needed to execute JSON
-// formatted commands on the Ceph cluster.
-type RadosCommander interface {
-	MgrCommander
-	MonCommander
-}
 
 func validate(m interface{}) error {
 	if m == nil {
@@ -34,7 +16,7 @@ func validate(m interface{}) error {
 
 // RawMgrCommand takes a byte buffer and sends it to the MGR as a command.
 // The buffer is expected to contain preformatted JSON.
-func RawMgrCommand(m MgrCommander, buf []byte) Response {
+func RawMgrCommand(m ccom.MgrCommander, buf []byte) Response {
 	if err := validate(m); err != nil {
 		return Response{err: err}
 	}
@@ -43,7 +25,7 @@ func RawMgrCommand(m MgrCommander, buf []byte) Response {
 
 // MarshalMgrCommand takes an generic interface{} value, converts it to JSON
 // and sends the json to the MGR as a command.
-func MarshalMgrCommand(m MgrCommander, v interface{}) Response {
+func MarshalMgrCommand(m ccom.MgrCommander, v interface{}) Response {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return Response{err: err}
@@ -53,7 +35,7 @@ func MarshalMgrCommand(m MgrCommander, v interface{}) Response {
 
 // RawMonCommand takes a byte buffer and sends it to the MON as a command.
 // The buffer is expected to contain preformatted JSON.
-func RawMonCommand(m MonCommander, buf []byte) Response {
+func RawMonCommand(m ccom.MonCommander, buf []byte) Response {
 	if err := validate(m); err != nil {
 		return Response{err: err}
 	}
@@ -62,7 +44,7 @@ func RawMonCommand(m MonCommander, buf []byte) Response {
 
 // MarshalMonCommand takes an generic interface{} value, converts it to JSON
 // and sends the json to the MGR as a command.
-func MarshalMonCommand(m MonCommander, v interface{}) Response {
+func MarshalMonCommand(m ccom.MonCommander, v interface{}) Response {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return Response{err: err}

--- a/internal/commands/trace.go
+++ b/internal/commands/trace.go
@@ -2,12 +2,14 @@ package commands
 
 import (
 	"fmt"
+
+	ccom "github.com/ceph/go-ceph/common/commands"
 )
 
 // NewTraceCommander is a RadosCommander that wraps a given RadosCommander
 // and when commands are executes prints debug level "traces" to the
 // standard output.
-func NewTraceCommander(c RadosCommander) RadosCommander {
+func NewTraceCommander(c ccom.RadosCommander) ccom.RadosCommander {
 	return &tracingCommander{c}
 }
 
@@ -17,7 +19,7 @@ func NewTraceCommander(c RadosCommander) RadosCommander {
 // interface in FSAdmin. You can layer any sort of debugging, error injection,
 // or whatnot between the FSAdmin layer and the RADOS layer.
 type tracingCommander struct {
-	conn RadosCommander
+	conn ccom.RadosCommander
 }
 
 func (t *tracingCommander) MgrCommand(buf [][]byte) ([]byte, string, error) {

--- a/rbd/admin/admin.go
+++ b/rbd/admin/admin.go
@@ -1,0 +1,51 @@
+// +build !nautilus
+
+package admin
+
+import (
+	"fmt"
+
+	ccom "github.com/ceph/go-ceph/common/commands"
+)
+
+// RBDAdmin is used to administrate rbd volumes and pools.
+type RBDAdmin struct {
+	conn ccom.RadosCommander
+}
+
+// NewFromConn creates an new management object from a preexisting
+// rados connection. The existing connection can be rados.Conn or any
+// type implementing the RadosCommander interface.
+func NewFromConn(conn ccom.RadosCommander) *RBDAdmin {
+	return &RBDAdmin{conn}
+}
+
+// LevelSpec values are used to identify RBD objects wherever Ceph APIs
+// require a levelspec to select an image, pool, or namespace.
+type LevelSpec struct {
+	spec string
+}
+
+// NewLevelSpec is used to construct a LevelSpec given a pool and
+// optional namespace and image names.
+func NewLevelSpec(pool, namespace, image string) LevelSpec {
+	var s string
+	if image != "" && namespace != "" {
+		s = fmt.Sprintf("%s/%s/%s", pool, namespace, image)
+	} else if image != "" {
+		s = fmt.Sprintf("%s/%s", pool, image)
+	} else if namespace != "" {
+		s = fmt.Sprintf("%s/%s/", pool, namespace)
+	} else {
+		s = fmt.Sprintf("%s/", pool)
+	}
+	return LevelSpec{s}
+}
+
+// NewRawLevelSpec returns a LevelSpec directly based on the spec string
+// argument without constructing it from component values. This should only be
+// used if NewLevelSpec can not create the levelspec value you want to pass to
+// ceph.
+func NewRawLevelSpec(spec string) LevelSpec {
+	return LevelSpec{spec}
+}

--- a/rbd/admin/admin_test.go
+++ b/rbd/admin/admin_test.go
@@ -1,0 +1,32 @@
+// +build !nautilus
+
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevelSpec(t *testing.T) {
+	ls := NewLevelSpec("bob", "", "")
+	assert.Equal(t, "bob/", ls.spec)
+
+	ls = NewLevelSpec("bob", "", "foo")
+	assert.Equal(t, "bob/foo", ls.spec)
+
+	ls = NewLevelSpec("bob", "ns", "foo")
+	assert.Equal(t, "bob/ns/foo", ls.spec)
+
+	ls = NewLevelSpec("bob", "ns", "")
+	assert.Equal(t, "bob/ns/", ls.spec)
+}
+
+func TestRawLevelSpec(t *testing.T) {
+	rls := NewRawLevelSpec("foo/bar")
+	assert.Equal(t, "foo/bar", rls.spec)
+
+	// NewRawLevelSpec takes whatever junk it's given and does not validate
+	rls = NewRawLevelSpec("totally! invalid! haha. ha...")
+	assert.Equal(t, "totally! invalid! haha. ha...", rls.spec)
+}

--- a/rbd/admin/common_test.go
+++ b/rbd/admin/common_test.go
@@ -1,0 +1,107 @@
+// +build !nautilus
+
+package admin
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	ccom "github.com/ceph/go-ceph/common/commands"
+	"github.com/ceph/go-ceph/internal/commands"
+	"github.com/ceph/go-ceph/rados"
+	"github.com/ceph/go-ceph/rbd"
+)
+
+var (
+	defaultPoolName = "rbd"
+	testImageSize   = uint64(1 << 22)
+	testImageOrder  = 22
+	alreadyExists   = -0x11
+
+	cachedRadosConn *rados.Conn
+	cachedRBDAdmin  *RBDAdmin
+	debugTrace      bool
+)
+
+func init() {
+	dt := os.Getenv("GO_CEPH_TEST_DEBUG_TRACE")
+	if ok, err := strconv.ParseBool(dt); ok && err == nil {
+		debugTrace = true
+	}
+}
+
+func getConn(t *testing.T) *rados.Conn {
+	if cachedRadosConn != nil {
+		return cachedRadosConn
+	}
+
+	conn, err := rados.NewConn()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	err = conn.ReadDefaultConfigFile()
+	require.NoError(t, err)
+
+	timeout := time.After(time.Second * 5)
+	ch := make(chan error)
+	go func(conn *rados.Conn) {
+		ch <- conn.Connect()
+	}(conn)
+	select {
+	case err = <-ch:
+	case <-timeout:
+		err = errors.New("timed out waiting for connect")
+	}
+	require.NoError(t, err)
+
+	cachedRadosConn = conn
+	return cachedRadosConn
+}
+
+func getAdmin(t *testing.T) *RBDAdmin {
+	if cachedRBDAdmin != nil {
+		return cachedRBDAdmin
+	}
+
+	var c ccom.RadosCommander = getConn(t)
+	if debugTrace {
+		c = commands.NewTraceCommander(c)
+	}
+	cachedRBDAdmin := NewFromConn(c)
+	require.NotNil(t, cachedRBDAdmin)
+	// We sleep briefly before returning in order to ensure we have a mgr map
+	// before we start executing the tests.
+	time.Sleep(50 * time.Millisecond)
+	return cachedRBDAdmin
+}
+
+func ensureDefaultPool(t *testing.T) {
+	t.Helper()
+	conn := getConn(t)
+	err := conn.MakePool(defaultPoolName)
+	if err == nil {
+		t.Logf("created pool: %s", defaultPoolName)
+		ioctx, err := conn.OpenIOContext(defaultPoolName)
+		require.NoError(t, err)
+		defer ioctx.Destroy()
+		// initialize rbd for the pool. if this is not done all mirror
+		// schedules can not be used on the pool or images in the pool
+		err = rbd.PoolInit(ioctx, false)
+		require.NoError(t, err)
+		// enable per image mirroring for the new pool
+		err = rbd.SetMirrorMode(ioctx, rbd.MirrorModeImage)
+		require.NoError(t, err)
+		return
+	}
+	ec, ok := err.(interface{ ErrorCode() int })
+	if ok && ec.ErrorCode() == alreadyExists {
+		t.Logf("pool already exists: %s", defaultPoolName)
+	} else {
+		t.Logf("failed to create pool: %s", defaultPoolName)
+		t.FailNow()
+	}
+}

--- a/rbd/admin/doc.go
+++ b/rbd/admin/doc.go
@@ -1,0 +1,10 @@
+/*
+Package admin is a convenience layer to support the administration of
+rbd volumes, snapshots, scheduling etc that is outside of the C api
+for librbd.
+
+Unlike the rbd package this API does not map to APIs provided by
+ceph libraries themselves. This API is not yet stable and is subject
+to change.
+*/
+package admin

--- a/rbd/admin/msschedule.go
+++ b/rbd/admin/msschedule.go
@@ -1,0 +1,170 @@
+// +build !nautilus
+
+package admin
+
+import (
+	ccom "github.com/ceph/go-ceph/common/commands"
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+// Interval of time between scheduled snapshots. Typically in the form
+// <num><m,h,d>. Exact content supported is defined internally on the ceph mgr.
+type Interval string
+
+// StartTime is the time the snapshot schedule begins. Exact content supported
+// is defined internally on the ceph mgr.
+type StartTime string
+
+var (
+	// NoInterval indicates no specific interval.
+	NoInterval = Interval("")
+
+	// NoStartTime indicates no specific start time.
+	NoStartTime = StartTime("")
+)
+
+// MirrorSnashotScheduleAdmin encapsulates management functions for
+// ceph rbd mirror snapshot schedules.
+type MirrorSnashotScheduleAdmin struct {
+	conn ccom.MgrCommander
+}
+
+// MirrorSnashotSchedule returns a MirrorSnashotScheduleAdmin type for
+// managing ceph rbd mirror snapshot schedules.
+func (ra *RBDAdmin) MirrorSnashotSchedule() *MirrorSnashotScheduleAdmin {
+	return &MirrorSnashotScheduleAdmin{conn: ra.conn}
+}
+
+// Add a new snapshot schedule to the given pool/image based on the supplied
+// level spec.
+//
+// Similar To:
+//  rbd mirror snapshot schedule add <level_spec> <interval> <start_time>
+func (mss *MirrorSnashotScheduleAdmin) Add(l LevelSpec, i Interval, s StartTime) error {
+	m := map[string]string{
+		"prefix":     "rbd mirror snapshot schedule add",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	if i != NoInterval {
+		m["interval"] = string(i)
+	}
+	if s != NoStartTime {
+		m["start_time"] = string(s)
+	}
+	return commands.MarshalMgrCommand(mss.conn, m).NoData().End()
+}
+
+// List the snapshot schedules based on the supplied level spec.
+//
+// Similar To:
+//  rbd mirror snapshot schedule list <level_spec>
+func (mss *MirrorSnashotScheduleAdmin) List(l LevelSpec) ([]SnapshotSchedule, error) {
+	m := map[string]string{
+		"prefix":     "rbd mirror snapshot schedule list",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	return parseMirrorSnapshotScheduleList(
+		commands.MarshalMgrCommand(mss.conn, m))
+}
+
+type snapshotScheduleMap map[string]snapshotScheduleSubsection
+
+type snapshotScheduleSubsection struct {
+	Name     string         `json:"name"`
+	Schedule []ScheduleTerm `json:"schedule"`
+}
+
+// ScheduleTerm represents the interval and start time component of
+// a snapshot schedule.
+type ScheduleTerm struct {
+	Interval  Interval  `json:"interval"`
+	StartTime StartTime `json:"start_time"`
+}
+
+// SnapshotSchedule contains values representing an entire snapshot schedule
+// for an image or pool.
+type SnapshotSchedule struct {
+	Name        string
+	LevelSpecID string
+	Schedule    []ScheduleTerm
+}
+
+func parseMirrorSnapshotScheduleList(res commands.Response) (
+	[]SnapshotSchedule, error) {
+
+	var ss snapshotScheduleMap
+	if err := res.NoStatus().Unmarshal(&ss).End(); err != nil {
+		return nil, err
+	}
+
+	var sched []SnapshotSchedule
+	for k, v := range ss {
+		sched = append(sched, SnapshotSchedule{
+			Name:        v.Name,
+			LevelSpecID: k,
+			Schedule:    v.Schedule,
+		})
+	}
+	return sched, nil
+}
+
+// Remove a snapshot schedule matching the supplied arguments.
+//
+// Similar To:
+//  rbd mirror snapshot schedule remove <level_spec> <interval> <start_time>
+func (mss *MirrorSnashotScheduleAdmin) Remove(
+	l LevelSpec, i Interval, s StartTime) error {
+
+	m := map[string]string{
+		"prefix":     "rbd mirror snapshot schedule remove",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	if i != NoInterval {
+		m["interval"] = string(i)
+	}
+	if s != NoStartTime {
+		m["start_time"] = string(s)
+	}
+	return commands.MarshalMgrCommand(mss.conn, m).NoData().End()
+}
+
+// Status returns the status of the snapshot (eg. when it will next take place)
+// matching the supplied level spec.
+//
+// Similar To:
+//  rbd mirror snapshot schedule status <level_spec>
+func (mss *MirrorSnashotScheduleAdmin) Status(l LevelSpec) ([]ScheduledImage, error) {
+	m := map[string]string{
+		"prefix":     "rbd mirror snapshot schedule status",
+		"level_spec": l.spec,
+		"format":     "json",
+	}
+	return parseMirrorSnapshotScheduleStatus(
+		commands.MarshalMgrCommand(mss.conn, m))
+}
+
+// ScheduleTime is the time a snapshot will occur.
+type ScheduleTime string
+
+// ScheduledImage contains the item scheduled and when it will next occur.
+type ScheduledImage struct {
+	Image        string       `json:"image"`
+	ScheduleTime ScheduleTime `json:"schedule_time"`
+}
+
+type scheduledImageWrapper struct {
+	ScheduledImages []ScheduledImage `json:"scheduled_images"`
+}
+
+func parseMirrorSnapshotScheduleStatus(res commands.Response) (
+	[]ScheduledImage, error) {
+
+	var siw scheduledImageWrapper
+	if err := res.NoStatus().Unmarshal(&siw).End(); err != nil {
+		return nil, err
+	}
+	return siw.ScheduledImages, nil
+}

--- a/rbd/admin/msschedule_complex_test.go
+++ b/rbd/admin/msschedule_complex_test.go
@@ -1,0 +1,77 @@
+// +build !nautilus
+
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/go-ceph/rbd"
+)
+
+func TestMirrorSnapshotScheduleStatus(t *testing.T) {
+	// note: the status function doesn't return anything "useful" unless
+	// there's an image in the pool. thus we require an image first.
+	ensureDefaultPool(t)
+	conn := getConn(t)
+
+	ioctx, err := conn.OpenIOContext(defaultPoolName)
+	require.NoError(t, err)
+	defer ioctx.Destroy()
+
+	imgName := "img1"
+	options := rbd.NewRbdImageOptions()
+	assert.NoError(t,
+		options.SetUint64(rbd.ImageOptionOrder, uint64(testImageOrder)))
+	err = rbd.CreateImage(ioctx, imgName, testImageSize, options)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rbd.RemoveImage(ioctx, imgName))
+	}()
+	img, err := rbd.OpenImage(ioctx, imgName, rbd.NoSnapshot)
+	assert.NoError(t, err)
+	err = img.MirrorEnable(rbd.ImageMirrorModeSnapshot)
+	assert.NoError(t, err)
+	assert.NoError(t, img.Close())
+
+	ra := getAdmin(t)
+	scheduler := ra.MirrorSnashotSchedule()
+	err = scheduler.Add(
+		NewLevelSpec(defaultPoolName, "", imgName),
+		Interval("1d"),
+		NoStartTime)
+	assert.NoError(t, err)
+	defer func() {
+		err = scheduler.Remove(
+			NewLevelSpec(defaultPoolName, "", imgName),
+			Interval("1d"),
+			NoStartTime)
+		assert.NoError(t, err)
+	}()
+
+	// This is one of those calls that depends on something async inside ceph
+	// and doesn't return the "expected result" immediately after the schedule
+	// is added. Loop on it for a while checking for the desired condition to
+	// become true.
+	// Unfortunately, this particular case is quite slow and doesn't
+	// seem to be ready until around a minute(!).
+	var status []ScheduledImage
+	for i := 0; i < 100; i++ {
+		status, err = scheduler.Status(
+			NewLevelSpec(defaultPoolName, "", imgName))
+		assert.NoError(t, err)
+		if len(status) == 1 {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+	if assert.Len(t, status, 1) {
+		assert.Equal(t, "rbd/img1", status[0].Image)
+		// we don't bother asserting the ScheduleTime value because
+		// it changes - and it's not worth messing with the system
+		// clock just for this kind of test.
+	}
+}

--- a/rbd/admin/msschedule_test.go
+++ b/rbd/admin/msschedule_test.go
@@ -1,0 +1,267 @@
+// +build !nautilus
+
+package admin
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+var ssList1 = `
+{
+    "4": {
+        "name": "rbd/",
+        "schedule": [
+            {
+                "interval": "70m",
+                "start_time": null
+            },
+            {
+                "interval": "30m",
+                "start_time": null
+            }
+        ]
+    },
+    "4//106ff127efdc": {
+        "name": "rbd/jumpy",
+        "schedule": [
+            {
+                "interval": "99m",
+                "start_time": null
+            }
+        ]
+    }
+}
+`
+
+var ssList2 = `
+{
+    "4": {
+        "name": "rbd/",
+        "schedule": [
+            {
+                "interval": "80m",
+                "start_time": null
+            }
+        ]
+    },
+    "4//104f1d296736": {
+        "name": "rbd/baz",
+        "schedule": [
+            {
+                "interval": "1d",
+                "start_time": "14:00:00-05:00"
+            }
+        ]
+    }
+}
+`
+
+var sStatus1 = `
+{
+    "scheduled_images": []
+}
+`
+var sStatus2 = `
+{
+    "scheduled_images": [
+        {
+            "image": "rbd/foo",
+            "schedule_time": "2021-03-02 16:30:00"
+        }
+    ]
+}
+`
+
+var sStatus3 = `
+{
+    "scheduled_images": [
+        {
+            "image": "rbd/bar",
+            "schedule_time": "2021-03-02 16:00:00"
+        },
+        {
+            "image": "rbd/foo",
+            "schedule_time": "2021-03-02 16:30:00"
+        }
+    ]
+}
+`
+
+func TestParseMirrorSnapshotScheduleList(t *testing.T) {
+	t.Run("list1", func(t *testing.T) {
+		r := commands.NewResponse([]byte(ssList1), "", nil)
+		l, err := parseMirrorSnapshotScheduleList(r)
+		assert.NoError(t, err)
+		if assert.Len(t, l, 2) {
+			s1 := l[0]
+			s2 := l[1]
+			if s1.Name != "rbd/" {
+				// just swap them.  it shouldn't matter to the test if the map has
+				// changed the order.
+				s1, s2 = s2, s1
+			}
+			assert.Equal(t, "rbd/", s1.Name)
+			assert.Equal(t, "4", s1.LevelSpecID)
+			if assert.Len(t, s1.Schedule, 2) {
+				assert.EqualValues(t, "70m", s1.Schedule[0].Interval)
+				assert.EqualValues(t, "", s1.Schedule[0].StartTime)
+				assert.EqualValues(t, "30m", s1.Schedule[1].Interval)
+				assert.EqualValues(t, "", s1.Schedule[1].StartTime)
+			}
+
+			assert.Equal(t, "rbd/jumpy", s2.Name)
+			assert.Equal(t, "4//106ff127efdc", s2.LevelSpecID)
+			if assert.Len(t, s2.Schedule, 1) {
+				assert.EqualValues(t, "99m", s2.Schedule[0].Interval)
+				assert.EqualValues(t, "", s2.Schedule[0].StartTime)
+			}
+		}
+	})
+	t.Run("list2", func(t *testing.T) {
+		r := commands.NewResponse([]byte(ssList2), "", nil)
+		l, err := parseMirrorSnapshotScheduleList(r)
+		assert.NoError(t, err)
+		if assert.Len(t, l, 2) {
+			s1 := l[0]
+			s2 := l[1]
+			if s1.Name != "rbd/" {
+				// just swap them.  it shouldn't matter to the test if the map has
+				// changed the order.
+				s1, s2 = s2, s1
+			}
+			assert.Equal(t, "rbd/", s1.Name)
+			assert.Equal(t, "4", s1.LevelSpecID)
+			if assert.Len(t, s1.Schedule, 1) {
+				assert.EqualValues(t, "80m", s1.Schedule[0].Interval)
+				assert.EqualValues(t, "", s1.Schedule[0].StartTime)
+			}
+
+			assert.Equal(t, "rbd/baz", s2.Name)
+			assert.Equal(t, "4//104f1d296736", s2.LevelSpecID)
+			if assert.Len(t, s2.Schedule, 1) {
+				assert.EqualValues(t, "1d", s2.Schedule[0].Interval)
+				assert.EqualValues(t, "14:00:00-05:00", s2.Schedule[0].StartTime)
+			}
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		r := commands.NewResponse([]byte("{}"), "", nil)
+		l, err := parseMirrorSnapshotScheduleList(r)
+		assert.NoError(t, err)
+		assert.Len(t, l, 0)
+	})
+	t.Run("error", func(t *testing.T) {
+		r := commands.NewResponse([]byte{}, "", errors.New("yikes"))
+		l, err := parseMirrorSnapshotScheduleList(r)
+		assert.Error(t, err)
+		assert.Len(t, l, 0)
+	})
+}
+
+func TestParseMirrorSnapshotScheduleStatus(t *testing.T) {
+	t.Run("status1", func(t *testing.T) {
+		r := commands.NewResponse([]byte(sStatus1), "", nil)
+		s, err := parseMirrorSnapshotScheduleStatus(r)
+		assert.NoError(t, err)
+		assert.Len(t, s, 0)
+	})
+	t.Run("status2", func(t *testing.T) {
+		r := commands.NewResponse([]byte(sStatus2), "", nil)
+		s, err := parseMirrorSnapshotScheduleStatus(r)
+		assert.NoError(t, err)
+		if assert.Len(t, s, 1) {
+			assert.Equal(t, "rbd/foo", s[0].Image)
+			assert.Contains(t, s[0].ScheduleTime, "16:30")
+		}
+	})
+	t.Run("status3", func(t *testing.T) {
+		r := commands.NewResponse([]byte(sStatus3), "", nil)
+		s, err := parseMirrorSnapshotScheduleStatus(r)
+		assert.NoError(t, err)
+		if assert.Len(t, s, 2) {
+			assert.Equal(t, "rbd/bar", s[0].Image)
+			assert.Contains(t, s[0].ScheduleTime, "16:00")
+			assert.Equal(t, "rbd/foo", s[1].Image)
+			assert.Contains(t, s[1].ScheduleTime, "16:30")
+		}
+	})
+	t.Run("error", func(t *testing.T) {
+		r := commands.NewResponse([]byte{}, "", errors.New("zrkk"))
+		s, err := parseMirrorSnapshotScheduleStatus(r)
+		assert.Error(t, err)
+		assert.Len(t, s, 0)
+	})
+}
+
+func TestMirrorSnapshotScheduleAddRemove(t *testing.T) {
+	ensureDefaultPool(t)
+	ra := getAdmin(t)
+	scheduler := ra.MirrorSnashotSchedule()
+	t.Run("noStartTime", func(t *testing.T) {
+		err := scheduler.Add(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), NoStartTime)
+		assert.NoError(t, err)
+		err = scheduler.Remove(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), NoStartTime)
+		assert.NoError(t, err)
+	})
+	t.Run("startTime", func(t *testing.T) {
+		stime := StartTime("12:00:00")
+		err := scheduler.Add(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), stime)
+		assert.NoError(t, err)
+		err = scheduler.Remove(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), stime)
+		assert.NoError(t, err)
+	})
+	t.Run("badStartTime", func(t *testing.T) {
+		stime := StartTime("henry")
+		err := scheduler.Add(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), stime)
+		assert.Error(t, err)
+	})
+}
+
+func TestMirrorSnapshotScheduleList(t *testing.T) {
+	ensureDefaultPool(t)
+	ra := getAdmin(t)
+	// assume a pool of "rbd" exists?
+	scheduler := ra.MirrorSnashotSchedule()
+	err := scheduler.Add(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), NoStartTime)
+	assert.NoError(t, err)
+	defer func() {
+		err = scheduler.Remove(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), NoStartTime)
+		assert.NoError(t, err)
+	}()
+	slist, err := scheduler.List(NewLevelSpec(defaultPoolName, "", ""))
+	assert.NoError(t, err)
+	if assert.Len(t, slist, 1) {
+		assert.Equal(t, "rbd/", slist[0].Name)
+		if assert.Len(t, slist[0].Schedule, 1) {
+			assert.Equal(t, Interval("1d"), slist[0].Schedule[0].Interval)
+		}
+	}
+
+	err = scheduler.Add(NewLevelSpec(defaultPoolName, "", ""), Interval("8h"), NoStartTime)
+	assert.NoError(t, err)
+	defer func() {
+		err = scheduler.Remove(NewLevelSpec(defaultPoolName, "", ""), Interval("8h"), NoStartTime)
+		assert.NoError(t, err)
+	}()
+	slist, err = scheduler.List(NewLevelSpec(defaultPoolName, "", ""))
+	assert.NoError(t, err)
+	if assert.Len(t, slist, 1) {
+		assert.Equal(t, "rbd/", slist[0].Name)
+		if assert.Len(t, slist[0].Schedule, 2) {
+			// ceph doesn't return the list in a "stable" order so we just
+			// take the lazy approach and sort by the interval value
+			sched := slist[0].Schedule
+			sort.Slice(sched, func(i, j int) bool {
+				return sched[i].Interval < sched[j].Interval
+			})
+			assert.Equal(t, Interval("1d"), sched[0].Interval)
+			assert.Equal(t, Interval("8h"), sched[1].Interval)
+		}
+	}
+}


### PR DESCRIPTION
Depends on #463 please review that first.

Resolves #396.

This adds the basic package which is similar to cephfs admin, but has a few improvements on that design (I hope).
The APIs covered are only related to rbd mirror snapshot scheduling as that is a need the ceph csi project has in the short(er) term.

In the future this package could also contain functions for managing rbd trash purge schedules, rbd task management, a few other assorted functions, and whatever gets added to the mgr (or any ceph service using the "json command api") in the future.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
