### PR TITLE
CI: implement a multi-container test setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,8 @@ jobs:
       run: make test-container "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
     - name: Run ptrguard test container
       run: make test-container "USE_PTRGUARD=true" "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
+    - name: Run multi-container test
+      run: make test-multi-container "USE_PTRGUARD=true" "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
     - name: Archive coverage results
       uses: actions/upload-artifact@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ test-multi-container: $(BUILDFILE) $(RESULTS_DIR)
 	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm \
 		--net test_ceph_net -v test_ceph_a_data:/ceph_a -v test_ceph_b_data:/ceph_b \
 		-v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(RESULTS_VOLUME) \
-		$(CI_IMAGE_TAG) --wait-for=/ceph_a/.ready:/ceph_b/.ready --ceph-conf=/ceph_a/ceph.conf
+		$(CI_IMAGE_TAG) --wait-for=/ceph_a/.ready:/ceph_b/.ready --ceph-conf=/ceph_a/ceph.conf \
+		--mirror=/ceph_b/ceph.conf
 	$(CONTAINER_CMD) kill test_ceph_a test_ceph_b
 
 ifdef RESULTS_DIR

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,23 @@ fmt:
 test:
 	go test -v -tags $(BUILD_TAGS) ./...
 
-.PHONY: test-docker test-container
+.PHONY: test-docker test-container test-multi-container
 test-docker: test-container
 test-container: $(BUILDFILE) $(RESULTS_DIR)
 	$(CONTAINER_CMD) run $(CONTAINER_OPTS) --rm -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(RESULTS_VOLUME) $(CI_IMAGE_TAG)
+test-multi-container: $(BUILDFILE) $(RESULTS_DIR)
+	$(CONTAINER_CMD) kill test_ceph_a test_ceph_b 2>/dev/null || true
+	$(CONTAINER_CMD) volume remove test_ceph_a_data test_ceph_b_data 2>/dev/null || true
+	$(CONTAINER_CMD) network create test_ceph_net 2>/dev/null || true
+	$(CONTAINER_CMD) run $(CONTAINER_OPTS) --rm -d --name test_ceph_a --net test_ceph_net \
+		-v test_ceph_a_data:/tmp/ceph $(CI_IMAGE_TAG) --test-run=NONE --pause
+	$(CONTAINER_CMD) run $(CONTAINER_OPTS) --rm -d --name test_ceph_b --net test_ceph_net \
+		-v test_ceph_b_data:/tmp/ceph $(CI_IMAGE_TAG) --test-run=NONE --pause
+	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm \
+		--net test_ceph_net -v test_ceph_a_data:/ceph_a -v test_ceph_b_data:/ceph_b \
+		-v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(RESULTS_VOLUME) \
+		$(CI_IMAGE_TAG) --wait-for=/ceph_a/.ready:/ceph_b/.ready --ceph-conf=/ceph_a/ceph.conf
+	$(CONTAINER_CMD) kill test_ceph_a test_ceph_b
 
 ifdef RESULTS_DIR
 $(RESULTS_DIR):

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -9,6 +9,7 @@ RUN true && \
     yum install -y \
         git wget curl make \
         /usr/bin/cc /usr/bin/c++ \
+        rbd-fuse \
         "libcephfs-devel-${cv}" "librados-devel-${cv}" "librbd-devel-${cv}" && \
     true
 


### PR DESCRIPTION
This change implements the makefile target `test-multi-container` to run the test in a multi-container setup. This will allow us to implement tests that require two ceph clusters, like mirroring.

Two containers are started with micro-osd and then pause. Then a third container runs the tests against these ceph instances. (At the moment only against the first of them, because we don't have multi-cluster tests yet.) To share the configurations, the test container mounts the ceph data volumes from both of the ceph containers.

In case of octopus (and later) the test container also sets up and tests mirroring from container test_ceph_a to test_ceph_b, so that it can used in the tests later on.

Depends on: #468 