### PR TITLE
cephfs: remove external fuse mount fs from tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test:
 .PHONY: test-docker test-container
 test-docker: test-container
 test-container: $(BUILDFILE) $(RESULTS_DIR)
-	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(RESULTS_VOLUME) $(CI_IMAGE_TAG)
+	$(CONTAINER_CMD) run $(CONTAINER_OPTS) --rm -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(RESULTS_VOLUME) $(CI_IMAGE_TAG)
 
 ifdef RESULTS_DIR
 $(RESULTS_DIR):

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -3,8 +3,6 @@ package cephfs
 import (
 	"fmt"
 	"os"
-	"path"
-	"syscall"
 	"testing"
 	"time"
 
@@ -15,51 +13,13 @@ import (
 )
 
 var (
-	CephMountDir     = "/tmp/ceph/mds/mnt/"
-	requireCephMount = false
-	testMdsName      = "Z"
+	testMdsName = "Z"
 )
 
 func init() {
-	mdir := os.Getenv("GO_CEPH_TEST_MOUNT_DIR")
-	if mdir != "" {
-		CephMountDir = mdir
-	}
-	reqMount := os.Getenv("GO_CEPH_TEST_REQUIRE_MOUNT")
-	if reqMount == "yes" || reqMount == "true" {
-		requireCephMount = true
-	}
 	mdsName := os.Getenv("GO_CEPH_TEST_MDS_NAME")
 	if mdsName != "" {
 		testMdsName = mdsName
-	}
-}
-
-func useMount(t *testing.T) {
-	fail := func(m string) {
-		if requireCephMount {
-			t.Fatalf("cephfs mount required: %s %s", CephMountDir, m)
-		} else {
-			t.Skipf("cephfs mount needed: %s %s", CephMountDir, m)
-		}
-	}
-
-	s, err := os.Stat(CephMountDir)
-	if err != nil || !s.IsDir() {
-		fail("missing or not a directory")
-	}
-
-	if us, ok := s.Sys().(*syscall.Stat_t); ok {
-		ps, err := os.Stat(path.Dir(path.Clean(CephMountDir)))
-		if err != nil {
-			fail("missing parent directory (race condition?)")
-		}
-		if ps.Sys().(*syscall.Stat_t).Dev == us.Dev {
-			fail("not a mount point")
-		}
-	} else {
-		fail("not a unix-like file system? how did you even compile this?" +
-			"no, seriously please contact us or file an issue and let us know!")
 	}
 }
 

--- a/cephfs/mount_perms_mimic_test.go
+++ b/cephfs/mount_perms_mimic_test.go
@@ -3,9 +3,6 @@
 package cephfs
 
 import (
-	"os"
-	"path"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,13 +30,12 @@ func TestSetMountPerms(t *testing.T) {
 	defer func() { assert.NoError(t, mount.Unmount()) }()
 
 	t.Run("checkStat", func(t *testing.T) {
-		useMount(t)
 		dirname := "/check-mount-perms"
 		err := mount.MakeDir(dirname, 0755)
 		assert.NoError(t, err)
 		defer mount.RemoveDir(dirname)
-		s, err := os.Stat(path.Join(CephMountDir, dirname))
+		sx, err := mount.Statx(dirname, StatxBasicStats, 0)
 		require.NoError(t, err)
-		assert.EqualValues(t, s.Sys().(*syscall.Stat_t).Gid, 500)
+		assert.EqualValues(t, sx.Gid, 500)
 	})
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,6 @@ BUILD_TAGS=""
 RESULTS_DIR=/results
 CEPH_CONF=/tmp/ceph/ceph.conf
 
-# env vars consumed by go code directly.
-# set defaults if they are currently unset in the environment
-: "${GO_CEPH_TEST_REQUIRE_MOUNT:=yes}"
 
 # Default env vars that are not currently changed by this script
 # but can be used to change the test behavior:
@@ -182,7 +179,7 @@ post_all_tests() {
 test_go_ceph() {
     mkdir -p /tmp/ceph
     show "${MICRO_OSD_PATH}" /tmp/ceph
-    export CEPH_CONF GO_CEPH_TEST_REQUIRE_MOUNT
+    export CEPH_CONF
 
     if [[ ${TEST_RUN} == NONE ]]; then
         echo "skipping test execution"

--- a/micro-osd.sh
+++ b/micro-osd.sh
@@ -90,9 +90,6 @@ ceph fs ls
 ceph-mds -i ${MDS_NAME}
 ceph status
 while [[ ! $(ceph mds stat | grep "up:active") ]]; do sleep 1; done
-# fuse: device not found, try 'modprobe fuse' first
-# Make sure to run with --privileged or --cap-add SYS_ADMIN --device /dev/fuse --security apparmor:unconfined for docker
-ceph-fuse ${MOUNTPT}
 
 
 # start a manager


### PR DESCRIPTION
The external mount point was mainly used for stat prior to a Stat function being part of go-ceph's cephfs package. Now that we have Statx, we can replace the need for the external mount and os.Stat.

These changes remove the use of the external fuse mount, the useMount helper function, and then finally the set up code for fuse in the test container and makefile.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
