### PR TITLE
rbd: add String methods to some mirroring constants

### DIFF
--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -57,6 +57,18 @@ const (
 	ImageMirrorModeSnapshot = ImageMirrorMode(C.RBD_MIRROR_IMAGE_MODE_SNAPSHOT)
 )
 
+// String representation of ImageMirrorMode.
+func (imm ImageMirrorMode) String() string {
+	switch imm {
+	case ImageMirrorModeJournal:
+		return "journal"
+	case ImageMirrorModeSnapshot:
+		return "snapshot"
+	default:
+		return "<unknown>"
+	}
+}
+
 // SetMirrorMode is used to enable or disable pool level mirroring with either
 // an automatic or per-image behavior.
 //

--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -207,6 +207,20 @@ const (
 	MirrorImageDisabled = MirrorImageState(C.RBD_MIRROR_IMAGE_DISABLED)
 )
 
+// String representation of MirrorImageState.
+func (mis MirrorImageState) String() string {
+	switch mis {
+	case MirrorImageDisabling:
+		return "disabling"
+	case MirrorImageEnabled:
+		return "enabled"
+	case MirrorImageDisabled:
+		return "disabled"
+	default:
+		return "<unknown>"
+	}
+}
+
 // MirrorImageInfo represents the mirroring status information of a RBD image.
 type MirrorImageInfo struct {
 	GlobalID string

--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -31,6 +31,20 @@ const (
 	MirrorModePool = MirrorMode(C.RBD_MIRROR_MODE_POOL)
 )
 
+// String representation of MirrorMode.
+func (m MirrorMode) String() string {
+	switch m {
+	case MirrorModeDisabled:
+		return "disabled"
+	case MirrorModeImage:
+		return "image"
+	case MirrorModePool:
+		return "pool"
+	default:
+		return "<unknown>"
+	}
+}
+
 // ImageMirrorMode is used to indicate the mirroring approach for an RBD image.
 type ImageMirrorMode int64
 

--- a/rbd/mirror_test.go
+++ b/rbd/mirror_test.go
@@ -8,6 +8,7 @@
 package rbd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -238,4 +239,26 @@ func TestGetMirrorImageInfo(t *testing.T) {
 		assert.Equal(t, mii.State, MirrorImageEnabled)
 		assert.Equal(t, mii.Primary, true)
 	})
+}
+
+func TestMirrorConstantStrings(t *testing.T) {
+	x := []struct {
+		s fmt.Stringer
+		t string
+	}{
+		{MirrorModeDisabled, "disabled"},
+		{MirrorModeImage, "image"},
+		{MirrorModePool, "pool"},
+		{MirrorMode(9999), "<unknown>"},
+		{ImageMirrorModeJournal, "journal"},
+		{ImageMirrorModeSnapshot, "snapshot"},
+		{ImageMirrorMode(9999), "<unknown>"},
+		{MirrorImageDisabling, "disabling"},
+		{MirrorImageEnabled, "enabled"},
+		{MirrorImageDisabled, "disabled"},
+		{MirrorImageState(9999), "<unknown>"},
+	}
+	for _, v := range x {
+		assert.Equal(t, v.s.String(), v.t)
+	}
 }


### PR DESCRIPTION
Make some of the types we added to support constants for the mirroring meet the Stringer interface.
This adds string conversion for MirrorMode, ImageMirrorMode, and MirrorImageState.

Fixes: #470 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
