### PR TITLE
ci: remove the need for rbd-fuse from the test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-multi-container: $(BUILDFILE) $(RESULTS_DIR)
 		-v test_ceph_a_data:/tmp/ceph $(CI_IMAGE_TAG) --test-run=NONE --pause
 	$(CONTAINER_CMD) run $(CONTAINER_OPTS) --rm -d --name test_ceph_b --hostname test_ceph_b --net test_ceph_net \
 		-v test_ceph_b_data:/tmp/ceph $(CI_IMAGE_TAG) --test-run=NONE --pause
-	$(CONTAINER_CMD) run --device /dev/fuse --cap-add SYS_ADMIN $(CONTAINER_OPTS) --rm \
+	$(CONTAINER_CMD) run $(CONTAINER_OPTS) --rm \
 		--net test_ceph_net -v test_ceph_a_data:/ceph_a -v test_ceph_b_data:/ceph_b \
 		-v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) $(RESULTS_VOLUME) \
 		$(CI_IMAGE_TAG) --wait-for=/ceph_a/.ready:/ceph_b/.ready --ceph-conf=/ceph_a/ceph.conf \

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ introduce how some of API calls work together.
 
 ```
 docker run --rm -it --net=host \
-  --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined \
+  --security-opt apparmor:unconfined \
   -v ${PWD}:/go/src/github.com/ceph/go-ceph:z \
   -v /home/nwatkins/src/ceph/build:/home/nwatkins/src/ceph/build:z \
   -e CEPH_CONF=/home/nwatkins/src/ceph/build/ceph.conf \

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -9,7 +9,6 @@ RUN true && \
     yum install -y \
         git wget curl make \
         /usr/bin/cc /usr/bin/c++ \
-        rbd-fuse \
         "libcephfs-devel-${cv}" "librados-devel-${cv}" "librbd-devel-${cv}" && \
     true
 


### PR DESCRIPTION
After examining the rbd command line tool more closely I determined that we could replace the current use of fuse for the rbd mirroring test setup with `rbd import` and `rbd export` commands. Thus we can drop the dependency on fuse (again).

See commit messages for some additional details.

Depends on #476 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
