### PR TITLE
readme: document v0.9.0 and the ceph versions it supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ go test -tags nautilus ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.9.0          | nautilus, octopus       |                          |
 | v0.8.0          | nautilus, octopus       |                          |
 | v0.7.0          | nautilus, octopus       |                          |
 | v0.6.0          | nautilus, octopus       | mimic                    |


### PR DESCRIPTION
Update readme post - v0.9.0