### PR TITLE
contrib: add configuration for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+ARG CEPH_VERSION
+FROM go-ceph-ci:${CEPH_VERSION}
+
+RUN cd /tmp && \
+  go get -v \
+    golang.org/x/tools/gopls \
+    honnef.co/go/tools/... \
+    golang.org/x/lint/golint \
+    github.com/mgechev/revive \
+    github.com/uudashr/gopkgs/v2/cmd/gopkgs \
+    github.com/ramya-rao-a/go-outline \
+    github.com/go-delve/delve/cmd/dlv \
+    github.com/golangci/golangci-lint/cmd/golangci-lint

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.166.1/containers/docker-existing-dockerfile
+{
+    "name": "go-ceph",
+    "initializeCommand": "make CEPH_VERSION=octopus ci-image",
+    "build": {
+        // Sets the run context to one level up instead of the .devcontainer folder.
+        //"context": "..",
+        "dockerfile": "Dockerfile",
+        "args": {
+            "CEPH_VERSION": "octopus"
+        }
+    },
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash",
+        "go.toolsManagement.checkForUpdates": "local",
+        "go.toolsManagement.autoUpdate": true,
+        "go.useLanguageServer": true,
+        "go.goroot": "/opt/go",
+        "go.testEnvVars": {
+            "GODEBUG": "cgocheck=2"
+        },
+        "go.lintTool": "golangci-lint",
+        "go.buildTags": "ptrguard",
+        "go.testTags": "ptrguard",
+        "go.testFlags": [
+            "-v",
+            "-count=1"
+        ],
+    },
+    // Add the IDs of extensions you want installed when the container is created.
+    "extensions": [
+        "golang.go",
+    ],
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Uncomment the next line to run commands after the container is created - for example installing curl.
+    // "postCreateCommand": "apt-get update && apt-get install -y curl",
+    // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    // Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+    // "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+    // Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+    // "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 *.swp
 *.out
 *.test
-*.json
+/*.json
 implements


### PR DESCRIPTION
This change adds configurations for running the development environment in a container, as supported by VSCode or GitHub Codespaces.

Signed-off-by: Sven Anderson <sven@redhat.com>