### PR TITLE
makefile: use "octopus" as our default ceph version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CONTAINER_CMD ?=
 CONTAINER_OPTS := --security-opt $(shell grep -q selinux /sys/kernel/security/lsm 2>/dev/null && echo "label=disable" || echo "apparmor:unconfined")
 CONTAINER_CONFIG_DIR := testing/containers/ceph
 VOLUME_FLAGS :=
-CEPH_VERSION := nautilus
+CEPH_VERSION := octopus
 RESULTS_DIR :=
 CHECK_GOFMT_FLAGS := -e -s -l
 IMPLEMENTS_OPTS :=

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -1,7 +1,7 @@
 ARG CEPH_VERSION
-FROM ceph/daemon-base:latest-${CEPH_VERSION:-nautilus}
+FROM ceph/daemon-base:latest-${CEPH_VERSION:-octopus}
 
-ENV CEPH_VERSION=${CEPH_VERSION:-nautilus}
+ENV CEPH_VERSION=${CEPH_VERSION:-octopus}
 
 RUN true && \
     yum clean all && \


### PR DESCRIPTION
We're adding a fair amount of octopus (and later) only features now, and
at the time of this writing, pacific is already out. Stop defaulting to
nautilus and default to octopus instead.