### PR TITLE
add build.octopus to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .build-docker
+.build.*
 *.swp
 *.out
 *.test


### PR DESCRIPTION
a file name .build.octopus gets created everytime the repoository is opened into the dev cointainer, adding it in gitignore will solve this issue.

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
