### PR TITLE
 Method snapshot.Set has side-effects on Image state

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -916,6 +916,22 @@ func (image *Image) GetId() (string, error) {
 
 }
 
+// SetSnapshot updates the rbd image (not the Snapshot) such that the snapshot
+// is the source of readable data.
+//
+// Implements:
+//  int rbd_snap_set(rbd_image_t image, const char *snapname);
+func (image *Image) SetSnapshot(snapname string) error {
+	if err := image.validate(imageIsOpen); err != nil {
+		return err
+	}
+
+	c_snapname := C.CString(snapname)
+	defer C.free(unsafe.Pointer(c_snapname))
+
+	return getError(C.rbd_snap_set(image.image, c_snapname))
+}
+
 // GetTrashList returns a slice of TrashInfo structs, containing information about all RBD images
 // currently residing in the trash.
 func GetTrashList(ioctx *rados.IOContext) ([]TrashInfo, error) {

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -149,6 +149,7 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 
 // Set updates the rbd image (not the Snapshot) such that the snapshot
 // is the source of readable data.
+// This method is deprecated. Refer the SetSnapshot method of the Image type instead.
 //
 // Implements:
 //  int rbd_snap_set(rbd_image_t image, const char *snapname);
@@ -157,10 +158,7 @@ func (snapshot *Snapshot) Set() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
-
-	return getError(C.rbd_snap_set(snapshot.image.image, c_snapname))
+	return snapshot.image.SetSnapshot(snapshot.name)
 }
 
 // GetSnapTimestamp returns the timestamp of a snapshot for an image.

--- a/rbd/snapshot_test.go
+++ b/rbd/snapshot_test.go
@@ -94,6 +94,9 @@ func TestErrorSnapshotNoName(t *testing.T) {
 	_, err = snapshot.IsProtected()
 	assert.Equal(t, err, ErrSnapshotNoName)
 
+	err = img.SetSnapshot(snapshot.name)
+	assert.Equal(t, err, ErrImageNotOpen)
+
 	err = snapshot.Set()
 	assert.Equal(t, err, ErrSnapshotNoName)
 


### PR DESCRIPTION
This is a change to what is described in #176.

Transfer of the Set function in the Snapshot.go file to the SetSnapshot() function in rbd.go
 - rbd: add SetSnapshot re-implementing rbd_snap_set on image type
 - rbd: add deprecation comment to snapshot.Set method

## Checklist
- [X] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
