### PR TITLE
entrypoint.sh: add a vim modeline to help set formatting parameters

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -266,3 +266,5 @@ pause_if_needed() {
 
 test_go_ceph
 pause_if_needed
+
+# vim: set ts=4 sw=4 sts=4 et:

--- a/micro-osd.sh
+++ b/micro-osd.sh
@@ -113,3 +113,5 @@ ceph osd pool delete ${test_pool} ${test_pool} --yes-i-really-really-mean-it
 rm ${temp_file}
 
 touch ${DIR}/.ready
+
+# vim: set ts=4 sw=4 sts=4 et:


### PR DESCRIPTION
For better or worse, unlike Go, shell does not have a standard formatting style.
Add a vim modeline that should match the basic current formatting style of the
scripts. This ought to help fellow vim users when editing the scripts.

Signed-off-by: John Mulligan <jmulligan@redhat.com>
