### PR TITLE
github: require Pacific and dpulls to pass before merging

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,10 +15,12 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - status-success=check
+      - status-success=dpulls
       # each test should be listed separately, do not use regular expressions:
       # https://docs.mergify.io/conditions.html#validating-all-status-check
       - status-success=test-suite (nautilus)
       - status-success=test-suite (octopus)
+      - status-success=test-suite (pacific)
     actions:
       merge:
         method: rebase


### PR DESCRIPTION
Tests are running against Ceph Pacific and passing, so this can be
marked as a required CI status.

dpulls handles dependencies between PRs, once the status is marked with
success, the requirements have all been merged. Prevent merging when
dpulls is in a failed state.
