### PR TITLE
cephfs: remove linux dependency from Fallocate()

### DIFF
--- a/cephfs/file.go
+++ b/cephfs/file.go
@@ -7,6 +7,13 @@ package cephfs
 #include <stdlib.h>
 #include <fcntl.h>
 #include <cephfs/libcephfs.h>
+// Fallback definitions
+#ifndef FALLOC_FL_KEEP_SIZE
+#define FALLOC_FL_KEEP_SIZE 0x01
+#endif
+#ifndef FALLOC_FL_PUNCH_HOLE
+#define FALLOC_FL_PUNCH_HOLE 0x02
+#endif
 */
 import "C"
 


### PR DESCRIPTION
Using the linux specific macros FALLOC_FL_KEEP_SIZE and
FALLOC_FL_PUNCH_HOLE inhibits go-ceph to be compiled on BSD or MacOS.
As a fallback this change defines the macros if they are not defined.

Signed-off-by: Sven Anderson <sven@redhat.com>
