### PR TITLE
rgw/admin: add quota support

### DIFF
--- a/rgw/admin/bucket.go
+++ b/rgw/admin/bucket.go
@@ -96,34 +96,34 @@ func (api *API) ListBuckets(ctx context.Context) ([]string, error) {
 }
 
 // GetBucketInfo will return various information about a specific token
-func (api *API) GetBucketInfo(ctx context.Context, bucket Bucket) (*Bucket, error) {
+func (api *API) GetBucketInfo(ctx context.Context, bucket Bucket) (Bucket, error) {
 	body, err := api.call(ctx, get, "/bucket", valueToURLParams(bucket))
 	if err != nil {
-		return nil, err
+		return Bucket{}, err
 	}
 
-	ref := &Bucket{}
-	err = json.Unmarshal(body, ref)
+	ref := Bucket{}
+	err = json.Unmarshal(body, &ref)
 	if err != nil {
-		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+		return Bucket{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
 	}
 
 	return ref, nil
 }
 
 // GetBucketPolicy - http://docs.ceph.com/docs/mimic/radosgw/adminops/#get-bucket-or-object-policy
-func (api *API) GetBucketPolicy(ctx context.Context, bucket Bucket) (*Policy, error) {
+func (api *API) GetBucketPolicy(ctx context.Context, bucket Bucket) (Policy, error) {
 	policy := true
 	bucket.Policy = &policy
 	body, err := api.call(ctx, get, "/bucket", valueToURLParams(bucket))
 	if err != nil {
-		return nil, err
+		return Policy{}, err
 	}
 
-	ref := &Policy{}
-	err = json.Unmarshal(body, ref)
+	ref := Policy{}
+	err = json.Unmarshal(body, &ref)
 	if err != nil {
-		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+		return Policy{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
 	}
 
 	return ref, nil

--- a/rgw/admin/bucket.go
+++ b/rgw/admin/bucket.go
@@ -44,15 +44,9 @@ type Bucket struct {
 			NumObjects     *uint64 `json:"num_objects"`
 		} `json:"rgw.multimeta"`
 	} `json:"usage"`
-	BucketQuota struct {
-		Enabled    *bool   `json:"enabled"`
-		CheckOnRaw *bool   `json:"check_on_raw"`
-		MaxSize    *uint64 `json:"max_size"`
-		MaxSizeKb  *uint64 `json:"max_size_kb"`
-		MaxObjects *uint64 `json:"max_objects"`
-	} `json:"bucket_quota"`
-	Policy      *bool `url:"policy"`
-	PurgeObject *bool `url:"purge-objects"`
+	BucketQuota QuotaSpec `json:"bucket_quota"`
+	Policy      *bool     `url:"policy"`
+	PurgeObject *bool     `url:"purge-objects"`
 }
 
 // Policy describes a bucket policy

--- a/rgw/admin/bucket_test.go
+++ b/rgw/admin/bucket_test.go
@@ -14,16 +14,38 @@ func (suite *RadosGWTestSuite) TestBucket() {
 	co.Debug = true
 	assert.NoError(suite.T(), err)
 
+	s3, err := newS3Agent(suite.accessKey, suite.secretKey, suite.endpoint, true)
+	assert.NoError(suite.T(), err)
+
+	err = s3.createBucket(suite.bucketTestName)
+	assert.NoError(suite.T(), err)
+
 	suite.T().Run("list buckets", func(t *testing.T) {
 		buckets, err := co.ListBuckets(context.Background())
 		assert.NoError(suite.T(), err)
-		assert.Equal(suite.T(), 0, len(buckets))
+		assert.Equal(suite.T(), 1, len(buckets))
 	})
 
 	suite.T().Run("info non-existing bucket", func(t *testing.T) {
 		_, err := co.GetBucketInfo(context.Background(), Bucket{Bucket: "foo"})
 		assert.Error(suite.T(), err)
 		assert.True(suite.T(), errors.Is(err, ErrNoSuchBucket), err)
+	})
+
+	suite.T().Run("info existing bucket", func(t *testing.T) {
+		_, err := co.GetBucketInfo(context.Background(), Bucket{Bucket: suite.bucketTestName})
+		assert.NoError(suite.T(), err)
+	})
+
+	suite.T().Run("remove bucket", func(t *testing.T) {
+		err := co.RemoveBucket(context.Background(), Bucket{Bucket: suite.bucketTestName})
+		assert.NoError(suite.T(), err)
+	})
+
+	suite.T().Run("list bucket is now zero", func(t *testing.T) {
+		buckets, err := co.ListBuckets(context.Background())
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), 0, len(buckets))
 	})
 
 	suite.T().Run("remove non-existing bucket", func(t *testing.T) {

--- a/rgw/admin/errors.go
+++ b/rgw/admin/errors.go
@@ -79,6 +79,9 @@ const (
 	// ErrUnknown - reports an unknown error
 	ErrUnknown errorReason = "Unknown"
 
+	// ErrSignatureDoesNotMatch - the query to the API has invalid parameters
+	ErrSignatureDoesNotMatch errorReason = "SignatureDoesNotMatch"
+
 	unmarshalError = "failed to unmarshal radosgw http response"
 )
 

--- a/rgw/admin/quota.go
+++ b/rgw/admin/quota.go
@@ -1,0 +1,61 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// QuotaSpec describes an object store quota for a user or a bucket
+// Only user's quota are supported
+type QuotaSpec struct {
+	UID        string `json:"user_id" url:"uid"`
+	QuotaType  string `url:"quota-type"`
+	Enabled    *bool  `json:"enabled" url:"enabled"`
+	CheckOnRaw bool   `json:"check_on_raw"`
+	MaxSize    *int64 `json:"max_size" url:"max-size"`
+	MaxSizeKb  *int   `json:"max_size_kb" url:"max-size-kb"`
+	MaxObjects *int64 `json:"max_objects" url:"max-objects"`
+}
+
+// GetUserQuota will return the quota for a user
+func (api *API) GetUserQuota(ctx context.Context, quota QuotaSpec) (QuotaSpec, error) {
+	// Always for quota type to user
+	quota.QuotaType = "user"
+
+	if quota.UID == "" {
+		return QuotaSpec{}, errMissingUserID
+	}
+
+	body, err := api.call(ctx, get, "/user?quota", valueToURLParams(quota))
+	if err != nil {
+		return QuotaSpec{}, err
+	}
+
+	ref := QuotaSpec{}
+	err = json.Unmarshal(body, &ref)
+	if err != nil {
+		return QuotaSpec{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+	}
+
+	return ref, nil
+}
+
+// SetUserQuota sets quota to a user
+// Global quotas (https://docs.ceph.com/en/latest/radosgw/admin/#reading-writing-global-quotas) are not surfaced in the Admin Ops API
+// So this library cannot expose it yet
+func (api *API) SetUserQuota(ctx context.Context, quota QuotaSpec) error {
+	// Always for quota type to user
+	quota.QuotaType = "user"
+
+	if quota.UID == "" {
+		return errMissingUserID
+	}
+
+	_, err := api.call(ctx, put, "/user?quota", valueToURLParams(quota))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/rgw/admin/quota_test.go
+++ b/rgw/admin/quota_test.go
@@ -1,0 +1,28 @@
+package admin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosGWTestSuite) TestQuota() {
+	suite.SetupConnection()
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, nil)
+	co.Debug = true
+	assert.NoError(suite.T(), err)
+
+	suite.T().Run("set quota to user but user ID is empty", func(t *testing.T) {
+		err := co.SetUserQuota(context.Background(), QuotaSpec{})
+		assert.Error(suite.T(), err)
+		assert.EqualError(suite.T(), err, errMissingUserID.Error())
+	})
+
+	suite.T().Run("get user quota but no user is specified", func(t *testing.T) {
+		_, err := co.GetUserQuota(context.Background(), QuotaSpec{})
+		assert.Error(suite.T(), err)
+		assert.EqualError(suite.T(), err, errMissingUserID.Error())
+
+	})
+}

--- a/rgw/admin/radosgw.go
+++ b/rgw/admin/radosgw.go
@@ -76,14 +76,8 @@ func New(endpoint, accessKey, secretKey string, httpClient *http.Client) (*API, 
 
 // call makes request to the RGW Admin Ops API
 func (api *API) call(ctx context.Context, verb verbHTTP, path string, args url.Values) (body []byte, err error) {
-	// Verify the endpoint URL is correct
-	url, err := url.Parse(buildQueryPath(api.Endpoint, path, args.Encode()))
-	if err != nil {
-		return nil, err
-	}
-
 	// Build request
-	request, err := http.NewRequestWithContext(ctx, string(verb), url.String(), nil)
+	request, err := http.NewRequestWithContext(ctx, string(verb), buildQueryPath(api.Endpoint, path, args.Encode()), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/rgw/admin/radosgw_test.go
+++ b/rgw/admin/radosgw_test.go
@@ -1,22 +1,85 @@
 package admin
 
 import (
+	"fmt"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/suite"
 )
 
 type RadosGWTestSuite struct {
 	suite.Suite
-	endpoint  string
-	accessKey string
-	secretKey string
+	endpoint       string
+	accessKey      string
+	secretKey      string
+	bucketTestName string
 }
 
 func TestRadosGWTestSuite(t *testing.T) {
 	suite.Run(t, new(RadosGWTestSuite))
+}
+
+// S3Agent wraps the s3.S3 structure to allow for wrapper methods
+type S3Agent struct {
+	Client *s3.S3
+}
+
+func newS3Agent(accessKey, secretKey, endpoint string, debug bool) (*S3Agent, error) {
+	const cephRegion = "us-east-1"
+
+	logLevel := aws.LogOff
+	if debug {
+		logLevel = aws.LogDebug
+	}
+	client := http.Client{
+		Timeout: time.Second * 15,
+	}
+	sess, err := session.NewSession(
+		aws.NewConfig().
+			WithRegion(cephRegion).
+			WithCredentials(credentials.NewStaticCredentials(accessKey, secretKey, "")).
+			WithEndpoint(endpoint).
+			WithS3ForcePathStyle(true).
+			WithMaxRetries(5).
+			WithDisableSSL(true).
+			WithHTTPClient(&client).
+			WithLogLevel(logLevel),
+	)
+	if err != nil {
+		return nil, err
+	}
+	svc := s3.New(sess)
+	return &S3Agent{
+		Client: svc,
+	}, nil
+}
+
+func (s *S3Agent) createBucket(name string) error {
+	bucketInput := &s3.CreateBucketInput{
+		Bucket: &name,
+	}
+	_, err := s.Client.CreateBucket(bucketInput)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeBucketAlreadyExists:
+				return nil
+			case s3.ErrCodeBucketAlreadyOwnedByYou:
+				return nil
+			}
+		}
+		return fmt.Errorf("failed to create bucket %q. %w", name, err)
+	}
+	return nil
 }
 
 func (suite *RadosGWTestSuite) SetupConnection() {
@@ -28,6 +91,7 @@ func (suite *RadosGWTestSuite) SetupConnection() {
 		endpoint = "test_ceph_a"
 	}
 	suite.endpoint = "http://" + endpoint
+	suite.bucketTestName = "test"
 }
 
 func TestNew(t *testing.T) {

--- a/rgw/admin/usage.go
+++ b/rgw/admin/usage.go
@@ -48,15 +48,15 @@ type Usage struct {
 }
 
 // GetUsage request bandwidth usage information on the object store
-func (api *API) GetUsage(ctx context.Context, usage Usage) (*Usage, error) {
+func (api *API) GetUsage(ctx context.Context, usage Usage) (Usage, error) {
 	body, err := api.call(ctx, get, "/usage", valueToURLParams(usage))
 	if err != nil {
-		return nil, err
+		return Usage{}, err
 	}
-	u := &Usage{}
-	err = json.Unmarshal(body, u)
+	u := Usage{}
+	err = json.Unmarshal(body, &u)
 	if err != nil {
-		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+		return Usage{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
 	}
 
 	return u, nil

--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -8,47 +8,41 @@ import (
 
 // User is GO representation of the json output of a user creation
 type User struct {
-	ID          string        `json:"user_id" url:"uid"`
-	DisplayName string        `json:"display_name" url:"display-name"`
-	Email       string        `json:"email" url:"email"`
-	Suspended   *int          `json:"suspended" url:"suspended"`
-	MaxBuckets  *int          `json:"max_buckets" url:"max-buckets"`
-	Subusers    []interface{} `json:"subusers"`
-	Keys        []struct {
-		User      string `json:"user"`
-		AccessKey string `json:"access_key" url:"access-key"`
-		SecretKey string `json:"secret_key" url:"secret-key"`
-	} `json:"keys"`
-	SwiftKeys []interface{} `json:"swift_keys"`
-	Caps      []struct {
-		Type string `json:"type"`
-		Perm string `json:"perm"`
-	} `json:"caps"`
+	ID                  string        `json:"user_id" url:"uid"`
+	DisplayName         string        `json:"display_name" url:"display-name"`
+	Email               string        `json:"email" url:"email"`
+	Suspended           *int          `json:"suspended" url:"suspended"`
+	MaxBuckets          *int          `json:"max_buckets" url:"max-buckets"`
+	Subusers            []interface{} `json:"subusers"`
+	Keys                []UserKeySpec `json:"keys"`
+	SwiftKeys           []interface{} `json:"swift_keys"`
+	Caps                []UserCapSpec `json:"caps"`
 	OpMask              string        `json:"op_mask"`
 	DefaultPlacement    string        `json:"default_placement"`
 	DefaultStorageClass string        `json:"default_storage_class"`
 	PlacementTags       []interface{} `json:"placement_tags"`
-	BucketQuota         struct {
-		Enabled    *bool `json:"enabled"`
-		CheckOnRaw *bool `json:"check_on_raw"`
-		MaxSize    *int  `json:"max_size"`
-		MaxSizeKb  *int  `json:"max_size_kb"`
-		MaxObjects *int  `json:"max_objects"`
-	} `json:"bucket_quota"`
-	UserQuota struct {
-		Enabled    *bool `json:"enabled"`
-		CheckOnRaw *bool `json:"check_on_raw"`
-		MaxSize    *int  `json:"max_size"`
-		MaxSizeKb  *int  `json:"max_size_kb"`
-		MaxObjects *int  `json:"max_objects"`
-	} `json:"user_quota"`
-	TempURLKeys []interface{} `json:"temp_url_keys"`
-	Type        string        `json:"type"`
-	MfaIds      []interface{} `json:"mfa_ids"`
-	KeyType     string        `url:"key-type"`
-	Tenant      string        `url:"tenant"`
-	GenerateKey *bool         `url:"generate-key"`
-	PurgeData   *int          `url:"purge-data"`
+	BucketQuota         QuotaSpec     `json:"bucket_quota"`
+	UserQuota           QuotaSpec     `json:"user_quota"`
+	TempURLKeys         []interface{} `json:"temp_url_keys"`
+	Type                string        `json:"type"`
+	MfaIds              []interface{} `json:"mfa_ids"`
+	KeyType             string        `url:"key-type"`
+	Tenant              string        `url:"tenant"`
+	GenerateKey         *bool         `url:"generate-key"`
+	PurgeData           *int          `url:"purge-data"`
+}
+
+// UserCapSpec represents a user capability which gives access to certain ressources
+type UserCapSpec struct {
+	Type string `json:"type"`
+	Perm string `json:"perm"`
+}
+
+// UserKeySpec is the user credential configuration
+type UserKeySpec struct {
+	User      string `json:"user"`
+	AccessKey string `json:"access_key" url:"access-key"`
+	SecretKey string `json:"secret_key" url:"secret-key"`
 }
 
 // GetUser retrieves a given object store user

--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -46,20 +46,20 @@ type UserKeySpec struct {
 }
 
 // GetUser retrieves a given object store user
-func (api *API) GetUser(ctx context.Context, user User) (*User, error) {
+func (api *API) GetUser(ctx context.Context, user User) (User, error) {
 	if user.ID == "" {
-		return nil, errMissingUserID
+		return User{}, errMissingUserID
 	}
 
 	body, err := api.call(ctx, get, "/user", valueToURLParams(user))
 	if err != nil {
-		return nil, err
+		return User{}, err
 	}
 
-	u := &User{}
-	err = json.Unmarshal(body, u)
+	u := User{}
+	err = json.Unmarshal(body, &u)
 	if err != nil {
-		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+		return User{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
 	}
 
 	return u, nil
@@ -81,25 +81,25 @@ func (api *API) GetUsers(ctx context.Context) (*[]string, error) {
 }
 
 // CreateUser creates a user in the object store
-func (api *API) CreateUser(ctx context.Context, user User) (*User, error) {
+func (api *API) CreateUser(ctx context.Context, user User) (User, error) {
 	if user.ID == "" {
-		return nil, errMissingUserID
+		return User{}, errMissingUserID
 	}
 	if user.DisplayName == "" {
-		return nil, errMissingUserDisplayName
+		return User{}, errMissingUserDisplayName
 	}
 
 	// Send request
 	body, err := api.call(ctx, put, "/user", valueToURLParams(user))
 	if err != nil {
-		return nil, err
+		return User{}, err
 	}
 
 	// Unmarshal response into Go type
-	u := &User{}
-	err = json.Unmarshal(body, u)
+	u := User{}
+	err = json.Unmarshal(body, &u)
 	if err != nil {
-		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+		return User{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
 	}
 
 	return u, nil
@@ -120,20 +120,20 @@ func (api *API) RemoveUser(ctx context.Context, user User) error {
 }
 
 // ModifyUser - http://docs.ceph.com/docs/latest/radosgw/adminops/#modify-user
-func (api *API) ModifyUser(ctx context.Context, user User) (*User, error) {
+func (api *API) ModifyUser(ctx context.Context, user User) (User, error) {
 	if user.ID == "" {
-		return nil, errMissingUserID
+		return User{}, errMissingUserID
 	}
 
 	body, err := api.call(ctx, post, "/user", valueToURLParams(user))
 	if err != nil {
-		return nil, err
+		return User{}, err
 	}
 
-	u := &User{}
-	err = json.Unmarshal(body, u)
+	u := User{}
+	err = json.Unmarshal(body, &u)
 	if err != nil {
-		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+		return User{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
 	}
 
 	return u, nil

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -97,6 +97,14 @@ func (suite *RadosGWTestSuite) TestUser() {
 		assert.Equal(suite.T(), "leseb@leseb.com", user.Email)
 	})
 
+	suite.T().Run("modify user max bucket", func(t *testing.T) {
+		maxBuckets := -1
+		user, err := co.ModifyUser(context.Background(), User{ID: "leseb", MaxBuckets: &maxBuckets})
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), "leseb@leseb.com", user.Email)
+		assert.Equal(suite.T(), -1, *user.MaxBuckets)
+	})
+
 	suite.T().Run("user already exists", func(t *testing.T) {
 		_, err := co.CreateUser(context.Background(), User{ID: "admin", DisplayName: "Admin user"})
 		assert.Error(suite.T(), err)
@@ -107,6 +115,19 @@ func (suite *RadosGWTestSuite) TestUser() {
 		users, err := co.GetUsers(context.Background())
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 2, len(*users))
+	})
+
+	suite.T().Run("set user quota", func(t *testing.T) {
+		quotaEnable := true
+		maxObjects := int64(100)
+		err := co.SetUserQuota(context.Background(), QuotaSpec{QuotaType: "user", UID: "leseb", MaxObjects: &maxObjects, Enabled: &quotaEnable})
+		assert.NoError(suite.T(), err)
+	})
+
+	suite.T().Run("get user quota", func(t *testing.T) {
+		q, err := co.GetUserQuota(context.Background(), QuotaSpec{QuotaType: "user", UID: "leseb"})
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), int64(100), *q.MaxObjects)
 	})
 
 	suite.T().Run("remove user", func(t *testing.T) {

--- a/rgw/admin/utils.go
+++ b/rgw/admin/utils.go
@@ -12,6 +12,17 @@ const (
 )
 
 func buildQueryPath(endpoint, path, args string) string {
+	// Sometimes the API requires single URL key with no values
+	// For instance, the Quota code uses the admin API path to "/user?quota"
+	// This is done this way since url.Values does not support adding keys without values.
+	//
+	// So Quota code passes the begining of the query (indicated with a marker "?") in its path already, so we need to escape it
+	// and add a separator key instead
+	// So we can get something like "/admin/user?quota&" instead of passing two beginning query markers ("?")
+	if strings.Contains(path, "?") {
+		return fmt.Sprintf("%s%s%s&%s", endpoint, queryAdminPath, path, args)
+	}
+
 	return fmt.Sprintf("%s%s%s?%s", endpoint, queryAdminPath, path, args)
 }
 


### PR DESCRIPTION
This commit introduces support for user and bucket quota on the rgw
admin ops API.

Co-authored-by: Irek Fasikhov malmyzh@gmail.com
Co-authored-by: Quentin Perez qperez42@gmail.com
Signed-off-by: Sébastien Han <seb@redhat.com>

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
