### PR TITLE
tests: add USE_CACHE variable to enable go packages cache

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -25,6 +25,7 @@ ENV GOROOT=/opt/go
 ENV GO111MODULE=on
 ENV GOPATH /go
 ENV GODEBUG=cgocheck=2
+ENV GOCACHE=/go/cache
 WORKDIR /go/src/github.com/ceph/go-ceph
 VOLUME /go/src/github.com/ceph/go-ceph
 


### PR DESCRIPTION
If the make variable USE_CACHE is set, the test container will mount
the /go directory from a named volume that is reused in following
test runs, so that go dependencies don't have to be installed again.

Signed-off-by: Sven Anderson <sven@redhat.com>
