### PR TITLE
readme: document v0.10.0 and the ceph versions it supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ go test -tags nautilus ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.10.0         | nautilus, octopus, pacific  |                      |
 | v0.9.0          | nautilus, octopus       |                          |
 | v0.8.0          | nautilus, octopus       |                          |
 | v0.7.0          | nautilus, octopus       |                          |


### PR DESCRIPTION

I forgot to do this last week after the release. Oops. :-)