### PR TITLE
makefile: add a flag to run go commands via a container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ ifdef RESULTS_DIR
 	RESULTS_VOLUME := -v $(RESULTS_DIR):/results$(VOLUME_FLAGS)
 endif
 
+ifneq ($(USE_GOCO),)
+	GO_CMD:=$(CONTAINER_CMD) run $(CONTAINER_OPTS) --rm $(GOCACHE_VOLUME) -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) --entrypoint $(GO_CMD) $(CI_IMAGE_TAG)
+	GOFMT_CMD:=$(CONTAINER_CMD) run $(CONTAINER_OPTS) --rm $(GOCACHE_VOLUME) -v $(CURDIR):/go/src/github.com/ceph/go-ceph$(VOLUME_FLAGS) --entrypoint $(GOFMT_CMD) $(CI_IMAGE_TAG)
+endif
+
 build:
 	$(GO_CMD) build -v -tags $(BUILD_TAGS) $(shell $(GO_CMD) list ./... | grep -v /contrib)
 fmt:


### PR DESCRIPTION
These changes convert instances of the `go` and `gofmt` commands in the makefile to variables.

Then we add a new variable "flag" `USE_GOCO=1` to enable running go commands through a container image. This is inspired by recent work     to enable development containers for VSCode, but is more aimed at     vim/cli users like myself who want to compile the code via makefile     rules and make use of vim's quickfix feature without having to have ceph     libs or, more importantly, the right version of the ceph libs, locally.

Full example: `make build test-bins USE_CACHE=1 USE_GOCO=1`
    
