### PR TITLE
rados: fix some naming convention violations

### DIFF
--- a/rados/conn.go
+++ b/rados/conn.go
@@ -261,9 +261,9 @@ func (c *Conn) GetInstanceID() uint64 {
 
 // MakePool creates a new pool with default settings.
 func (c *Conn) MakePool(name string) error {
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
-	ret := C.rados_pool_create(c.cluster, c_name)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	ret := C.rados_pool_create(c.cluster, cName)
 	return getError(ret)
 }
 
@@ -272,9 +272,9 @@ func (c *Conn) DeletePool(name string) error {
 	if err := c.ensure_connected(); err != nil {
 		return err
 	}
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
-	ret := C.rados_pool_delete(c.cluster, c_name)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	ret := C.rados_pool_delete(c.cluster, cName)
 	return getError(ret)
 }
 
@@ -283,9 +283,9 @@ func (c *Conn) GetPoolByName(name string) (int64, error) {
 	if err := c.ensure_connected(); err != nil {
 		return 0, err
 	}
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
-	ret := int64(C.rados_pool_lookup(c.cluster, c_name))
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	ret := int64(C.rados_pool_lookup(c.cluster, cName))
 	if ret < 0 {
 		return 0, radosError(ret)
 	}

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -38,13 +38,13 @@ func (c *Conn) Cluster() ClusterRef {
 
 // PingMonitor sends a ping to a monitor and returns the reply.
 func (c *Conn) PingMonitor(id string) (string, error) {
-	c_id := C.CString(id)
-	defer C.free(unsafe.Pointer(c_id))
+	cid := C.CString(id)
+	defer C.free(unsafe.Pointer(cid))
 
 	var strlen C.size_t
 	var strout *C.char
 
-	ret := C.rados_ping_monitor(c.cluster, c_id, &strout, &strlen)
+	ret := C.rados_ping_monitor(c.cluster, cid, &strout, &strlen)
 	defer C.rados_buffer_free(strout)
 
 	if ret == 0 {
@@ -298,8 +298,8 @@ func (c *Conn) GetPoolByID(id int64) (string, error) {
 	if err := c.ensure_connected(); err != nil {
 		return "", err
 	}
-	c_id := C.int64_t(id)
-	ret := int(C.rados_pool_reverse_lookup(c.cluster, c_id, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf))))
+	cid := C.int64_t(id)
+	ret := int(C.rados_pool_reverse_lookup(c.cluster, cid, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf))))
 	if ret < 0 {
 		return "", radosError(ret)
 	}

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -179,16 +179,16 @@ func (c *Conn) GetClusterStats() (stat ClusterStat, err error) {
 	if err := c.ensure_connected(); err != nil {
 		return ClusterStat{}, err
 	}
-	c_stat := C.struct_rados_cluster_stat_t{}
-	ret := C.rados_cluster_stat(c.cluster, &c_stat)
+	cStat := C.struct_rados_cluster_stat_t{}
+	ret := C.rados_cluster_stat(c.cluster, &cStat)
 	if ret < 0 {
 		return ClusterStat{}, getError(ret)
 	}
 	return ClusterStat{
-		Kb:          uint64(c_stat.kb),
-		Kb_used:     uint64(c_stat.kb_used),
-		Kb_avail:    uint64(c_stat.kb_avail),
-		Num_objects: uint64(c_stat.num_objects),
+		Kb:          uint64(cStat.kb),
+		Kb_used:     uint64(cStat.kb_used),
+		Kb_avail:    uint64(cStat.kb_avail),
+		Num_objects: uint64(cStat.num_objects),
 	}, nil
 }
 

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -75,9 +75,9 @@ func (c *Conn) Shutdown() {
 
 // ReadConfigFile configures the connection using a Ceph configuration file.
 func (c *Conn) ReadConfigFile(path string) error {
-	c_path := C.CString(path)
-	defer C.free(unsafe.Pointer(c_path))
-	ret := C.rados_conf_read_file(c.cluster, c_path)
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	ret := C.rados_conf_read_file(c.cluster, cPath)
 	return getError(ret)
 }
 

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -127,10 +127,10 @@ func (c *Conn) ListPools() (names []string, err error) {
 // SetConfigOption sets the value of the configuration option identified by
 // the given name.
 func (c *Conn) SetConfigOption(option, value string) error {
-	c_opt, c_val := C.CString(option), C.CString(value)
-	defer C.free(unsafe.Pointer(c_opt))
-	defer C.free(unsafe.Pointer(c_val))
-	ret := C.rados_conf_set(c.cluster, c_opt, c_val)
+	cOpt, cVal := C.CString(option), C.CString(value)
+	defer C.free(unsafe.Pointer(cOpt))
+	defer C.free(unsafe.Pointer(cVal))
+	ret := C.rados_conf_set(c.cluster, cOpt, cVal)
 	return getError(ret)
 }
 

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -94,10 +94,10 @@ func (c *Conn) ReadDefaultConfigFile() error {
 //  int rados_ioctx_create(rados_t cluster, const char *pool_name,
 //                         rados_ioctx_t *ioctx);
 func (c *Conn) OpenIOContext(pool string) (*IOContext, error) {
-	c_pool := C.CString(pool)
-	defer C.free(unsafe.Pointer(c_pool))
+	cPool := C.CString(pool)
+	defer C.free(unsafe.Pointer(cPool))
 	ioctx := &IOContext{}
-	ret := C.rados_ioctx_create(c.cluster, c_pool, &ioctx.ioctx)
+	ret := C.rados_ioctx_create(c.cluster, cPool, &ioctx.ioctx)
 	if ret == 0 {
 		return ioctx, nil
 	}

--- a/rados/object_iter.go
+++ b/rados/object_iter.go
@@ -50,14 +50,14 @@ func (iter *Iter) Seek(token IterToken) {
 //	return iter.Err()
 //
 func (iter *Iter) Next() bool {
-	var c_entry *C.char
-	var c_namespace *C.char
-	if cerr := C.rados_nobjects_list_next(iter.ctx, &c_entry, nil, &c_namespace); cerr < 0 {
+	var cEntry *C.char
+	var cNamespace *C.char
+	if cerr := C.rados_nobjects_list_next(iter.ctx, &cEntry, nil, &cNamespace); cerr < 0 {
 		iter.err = getError(cerr)
 		return false
 	}
-	iter.entry = C.GoString(c_entry)
-	iter.namespace = C.GoString(c_namespace)
+	iter.entry = C.GoString(cEntry)
+	iter.namespace = C.GoString(cNamespace)
 	return true
 }
 

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -85,9 +85,9 @@ func NewConn() (*Conn, error) {
 // NewConnWithUser creates a new connection object with a custom username.
 // It returns the connection and an error, if any.
 func NewConnWithUser(user string) (*Conn, error) {
-	c_user := C.CString(user)
-	defer C.free(unsafe.Pointer(c_user))
-	return newConn(c_user)
+	cUser := C.CString(user)
+	defer C.free(unsafe.Pointer(cUser))
+	return newConn(cUser)
 }
 
 // NewConnWithClusterAndUser creates a new connection object for a specific cluster and username.

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -55,9 +55,9 @@ const (
 // Version returns the major, minor, and patch components of the version of
 // the RADOS library linked against.
 func Version() (int, int, int) {
-	var c_major, c_minor, c_patch C.int
-	C.rados_version(&c_major, &c_minor, &c_patch)
-	return int(c_major), int(c_minor), int(c_patch)
+	var cMajor, cMinor, cPatch C.int
+	C.rados_version(&cMajor, &cMinor, &cPatch)
+	return int(cMajor), int(cMinor), int(cPatch)
 }
 
 func makeConn() *Conn {

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -93,14 +93,14 @@ func NewConnWithUser(user string) (*Conn, error) {
 // NewConnWithClusterAndUser creates a new connection object for a specific cluster and username.
 // It returns the connection and an error, if any.
 func NewConnWithClusterAndUser(clusterName string, userName string) (*Conn, error) {
-	c_cluster_name := C.CString(clusterName)
-	defer C.free(unsafe.Pointer(c_cluster_name))
+	cClusterName := C.CString(clusterName)
+	defer C.free(unsafe.Pointer(cClusterName))
 
-	c_name := C.CString(userName)
-	defer C.free(unsafe.Pointer(c_name))
+	cName := C.CString(userName)
+	defer C.free(unsafe.Pointer(cName))
 
 	conn := makeConn()
-	ret := C.rados_create2(&conn.cluster, c_cluster_name, c_name, 0)
+	ret := C.rados_create2(&conn.cluster, cClusterName, cName, 0)
 	if ret != 0 {
 		return nil, getError(ret)
 	}


### PR DESCRIPTION
In an urge to revisit and enable more checking rules in revive I've started converting some of the "old" c_* names to variable names that don't voliate Go conventions.

This PR fixes up all files in rados _except_ for rados/ioctx.go. These changes are fairly mechanical [1] and mind-numbing so to make the reviews simpler I'm splitting up the work over time. ioctx.go has a lot of convention violations so I'm saving that for a different PR.

[1] - It was done 90% by script.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
