### PR TITLE
rbd: implement bindings for rbd_mirror_image_info_list

### DIFF
--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -655,8 +655,8 @@ func mirrorImageGlobalStatusList(
 		cephIoctx(ioctx),
 		cStart,
 		max,
-		(**C.char)(unsafe.Pointer(&ids[0])),
-		(*C.rbd_mirror_image_global_status_t)(unsafe.Pointer(&images[0])),
+		&ids[0],
+		&images[0],
 		&length)
 
 	for i := 0; i < int(length); i++ {
@@ -664,8 +664,8 @@ func mirrorImageGlobalStatusList(
 		results[i].Status = newGlobalMirrorImageStatus(&images[0])
 	}
 	C.rbd_mirror_image_global_status_list_cleanup(
-		(**C.char)(unsafe.Pointer(&ids[0])),
-		(*C.rbd_mirror_image_global_status_t)(unsafe.Pointer(&images[0])),
+		&ids[0],
+		&images[0],
 		length)
 	return int(length), getError(ret)
 }

--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -71,12 +71,12 @@ func (imm ImageMirrorMode) String() string {
 	}
 }
 
-//  GetMirrorUUID returns a string naming the mirroring uuid for the pool
-//  associated with the ioctx.
+// GetMirrorUUID returns a string naming the mirroring uuid for the pool
+// associated with the ioctx.
 //
-//  Implements:
-//  int rbd_mirror_uuid_get(rados_ioctx_t io_ctx,
-//	                       char *uuid, size_t *max_len);
+// Implements:
+//  int rbd_mirror_uuid_get(rados_ioctx_t io_ctx, char *uuid, size_t
+//                          *max_len);
 func GetMirrorUUID(ioctx *rados.IOContext) (string, error) {
 	var (
 		err   error

--- a/rbd/mirror_test.go
+++ b/rbd/mirror_test.go
@@ -782,11 +782,11 @@ func TestMirrorBootstrapToken(t *testing.T) {
 
 func TestMirrorImageGlobalStatusIter(t *testing.T) {
 	defer func(x int) {
-		statusIterBufSize = x
-	}(statusIterBufSize)
+		iterBufSize = x
+	}(iterBufSize)
 	// shrink the buffer size in order to trigger more of the
 	// retry logic in the iter type
-	statusIterBufSize = 4
+	iterBufSize = 4
 
 	conn := radosConnect(t)
 	poolName := GetUUID()


### PR DESCRIPTION
This change adds an iterator type to fetch infos for all images in a pool with `rbd_mirror_image_info_list()`. It uses the same interface as `MirrorImageGlobalStatusIter`.

Resolves: #482

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
