### PR TITLE
rbd: clean up status iterator (breaking changes)

### DIFF
--- a/rbd/mirror_test.go
+++ b/rbd/mirror_test.go
@@ -824,14 +824,13 @@ func TestMirrorImageGlobalStatusIter(t *testing.T) {
 
 	t.Run("ioctxNil", func(t *testing.T) {
 		iter := NewMirrorImageGlobalStatusIter(nil)
-		defer iter.Close()
 		assert.Panics(t, func() {
 			iter.Next()
 		})
 	})
 
 	t.Run("getStatus", func(t *testing.T) {
-		lst := []*GlobalMirrorImageIDAndStatus{}
+		lst := []*MirrorImageGlobalStatusItem{}
 		iter := NewMirrorImageGlobalStatusIter(ioctx)
 		for {
 			istatus, err := iter.Next()


### PR DESCRIPTION
Probably against some resistance I'm proposing these changes that fix some things that I came across while implementing #523, and that I unfortunately didn't see while reviewing:

- `GlobalMirrorImageIDAndStatus` is an exported identifier but includes details about internal structure, which undermines the purpose of a type definition (which is isolation from the concrete structure). If a field is added, the name becomes inconsistent. Also it doesn't fit to all the other identifiers, which are all `MirrorImageGlobalStatus...`
- `Close()` is basically a no-op in the `defer` use case, and reuse of iterators I would strongly discourage from. The existence of this method gives the wrong impression that there are resources, that need to be freed. Also the error return value is unusual and actually dead code. It seems like the `Close()` method is a leftover from an earlier implementation.
- some small internal simplification in `Next()`.