### PR TITLE
cephfs: add ReadConfigFile implementing ceph_conf_read_file 

### DIFF
--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -64,7 +64,10 @@ func CreateFromRados(conn *rados.Conn) (*MountInfo, error) {
 	return mount, nil
 }
 
-// ReadDefaultConfigFile loads the ceph configuration from the specified config file.
+// ReadDefaultConfigFile loads the ceph configuration from the default config file.
+//
+// Implements:
+//  int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
 func (mount *MountInfo) ReadDefaultConfigFile() error {
 	ret := C.ceph_conf_read_file(mount.mount, nil)
 	return getError(ret)

--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -73,6 +73,17 @@ func (mount *MountInfo) ReadDefaultConfigFile() error {
 	return getError(ret)
 }
 
+// ReadConfigFile loads the ceph configuration from the specified config file.
+//
+// Implements:
+//  int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
+func (mount *MountInfo) ReadConfigFile(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	ret := C.ceph_conf_read_file(mount.mount, cPath)
+	return getError(ret)
+}
+
 // ParseConfigArgv configures the mount using a unix style command line
 // argument vector.
 //


### PR DESCRIPTION
Add a ReadConfigFile function that accepts a path to a config file. This will be especially handy when we need to connect to multiple ceph clusters from one (go-ceph test) function.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
