### PR TITLE
rgw/admin: add an interface around the HTTP Client and mocking

### DIFF
--- a/rgw/admin/mock.go
+++ b/rgw/admin/mock.go
@@ -1,0 +1,18 @@
+package admin
+
+import (
+	"net/http"
+)
+
+// MockClient is the mock of the HTTP Client
+// It can be used to mock HTTP request/response from the rgw admin ops API
+type MockClient struct {
+	// MockDo is a type that mock the Do method from the HTTP package
+	MockDo MockDoType
+}
+
+// MockDoType is a custom type that allows setting the function that our Mock Do func will run instead
+type MockDoType func(req *http.Request) (*http.Response, error)
+
+// Do is the mock client's `Do` func
+func (m *MockClient) Do(req *http.Request) (*http.Response, error) { return m.MockDo(req) }

--- a/rgw/admin/radosgw.go
+++ b/rgw/admin/radosgw.go
@@ -33,8 +33,6 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-type verbHTTP string
-
 // API struct for New Client
 type API struct {
 	AccessKey  string
@@ -76,9 +74,9 @@ func New(endpoint, accessKey, secretKey string, httpClient HTTPClient) (*API, er
 }
 
 // call makes request to the RGW Admin Ops API
-func (api *API) call(ctx context.Context, verb verbHTTP, path string, args url.Values) (body []byte, err error) {
+func (api *API) call(ctx context.Context, httpMethod, path string, args url.Values) (body []byte, err error) {
 	// Build request
-	request, err := http.NewRequestWithContext(ctx, string(verb), buildQueryPath(api.Endpoint, path, args.Encode()), nil)
+	request, err := http.NewRequestWithContext(ctx, httpMethod, buildQueryPath(api.Endpoint, path, args.Encode()), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/rgw/admin/radosgw.go
+++ b/rgw/admin/radosgw.go
@@ -28,6 +28,11 @@ var (
 	errNoSecretKey = errors.New("secret key not set")
 )
 
+// HTTPClient interface that conforms to that of the http package's Client.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 type verbHTTP string
 
 // API struct for New Client
@@ -35,12 +40,12 @@ type API struct {
 	AccessKey  string
 	SecretKey  string
 	Endpoint   string
-	HTTPClient *http.Client
+	HTTPClient HTTPClient
 	Debug      bool
 }
 
 // New returns client for Ceph RGW
-func New(endpoint, accessKey, secretKey string, httpClient *http.Client) (*API, error) {
+func New(endpoint, accessKey, secretKey string, httpClient HTTPClient) (*API, error) {
 	// validate endpoint
 	if endpoint == "" {
 		return nil, errNoEndpoint
@@ -56,7 +61,7 @@ func New(endpoint, accessKey, secretKey string, httpClient *http.Client) (*API, 
 		return nil, errNoSecretKey
 	}
 
-	// set http client, if TLS is desired it will have to be passed with an http client
+	// If no client is passed initialize it
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: connectionTimeout}
 	}


### PR DESCRIPTION
Partially solve https://github.com/ceph/go-ceph/issues/508.
I'm saying "partially" since @phlogistonjohn we need to see if we keep `Debug` or not.


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
