### PR TITLE
rbd: fix various naming convention issues

### DIFF
--- a/rbd/metadata.go
+++ b/rbd/metadata.go
@@ -21,8 +21,8 @@ func (image *Image) GetMetadata(key string) (string, error) {
 		return "", err
 	}
 
-	c_key := C.CString(key)
-	defer C.free(unsafe.Pointer(c_key))
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
 
 	var (
 		buf []byte
@@ -34,7 +34,7 @@ func (image *Image) GetMetadata(key string) (string, error) {
 		// rbd_metadata_get is a bit quirky and *does not* update the size
 		// value if the size passed in >= the needed size.
 		ret := C.rbd_metadata_get(
-			image.image, c_key, (*C.char)(unsafe.Pointer(&buf[0])), &csize)
+			image.image, cKey, (*C.char)(unsafe.Pointer(&buf[0])), &csize)
 		err = getError(ret)
 		return retry.Size(int(csize)).If(err == errRange)
 	})
@@ -53,12 +53,12 @@ func (image *Image) SetMetadata(key string, value string) error {
 		return err
 	}
 
-	c_key := C.CString(key)
-	c_value := C.CString(value)
-	defer C.free(unsafe.Pointer(c_key))
-	defer C.free(unsafe.Pointer(c_value))
+	cKey := C.CString(key)
+	cValue := C.CString(value)
+	defer C.free(unsafe.Pointer(cKey))
+	defer C.free(unsafe.Pointer(cValue))
 
-	ret := C.rbd_metadata_set(image.image, c_key, c_value)
+	ret := C.rbd_metadata_set(image.image, cKey, cValue)
 	if ret < 0 {
 		return rbdError(ret)
 	}
@@ -75,10 +75,10 @@ func (image *Image) RemoveMetadata(key string) error {
 		return err
 	}
 
-	c_key := C.CString(key)
-	defer C.free(unsafe.Pointer(c_key))
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
 
-	ret := C.rbd_metadata_remove(image.image, c_key)
+	ret := C.rbd_metadata_remove(image.image, cKey)
 	if ret < 0 {
 		return rbdError(ret)
 	}

--- a/rbd/options.go
+++ b/rbd/options.go
@@ -120,10 +120,10 @@ func (rio *ImageOptions) Destroy() {
 //  int rbd_image_options_set_string(rbd_image_options_t opts, int optname,
 //          const char* optval);
 func (rio *ImageOptions) SetString(option ImageOption, value string) error {
-	c_value := C.CString(value)
-	defer C.free(unsafe.Pointer(c_value))
+	cValue := C.CString(value)
+	defer C.free(unsafe.Pointer(cValue))
 
-	ret := C.rbd_image_options_set_string(rio.options, C.int(option), c_value)
+	ret := C.rbd_image_options_set_string(rio.options, C.int(option), cValue)
 	if ret != 0 {
 		return fmt.Errorf("%v, could not set option %v to \"%v\"",
 			getError(ret), option, value)
@@ -156,9 +156,9 @@ func (rio *ImageOptions) GetString(option ImageOption) (string, error) {
 //  int rbd_image_options_set_uint64(rbd_image_options_t opts, int optname,
 //          const uint64_t optval);
 func (rio *ImageOptions) SetUint64(option ImageOption, value uint64) error {
-	c_value := C.uint64_t(value)
+	cValue := C.uint64_t(value)
 
-	ret := C.rbd_image_options_set_uint64(rio.options, C.int(option), c_value)
+	ret := C.rbd_image_options_set_uint64(rio.options, C.int(option), cValue)
 	if ret != 0 {
 		return fmt.Errorf("%v, could not set option %v to \"%v\"",
 			getError(ret), option, value)
@@ -173,14 +173,14 @@ func (rio *ImageOptions) SetUint64(option ImageOption, value uint64) error {
 //  int rbd_image_options_get_uint64(rbd_image_options_t opts, int optname,
 //          uint64_t* optval);
 func (rio *ImageOptions) GetUint64(option ImageOption) (uint64, error) {
-	var c_value C.uint64_t
+	var cValue C.uint64_t
 
-	ret := C.rbd_image_options_get_uint64(rio.options, C.int(option), &c_value)
+	ret := C.rbd_image_options_get_uint64(rio.options, C.int(option), &cValue)
 	if ret != 0 {
 		return 0, fmt.Errorf("%v, could not get option %v", getError(ret), option)
 	}
 
-	return uint64(c_value), nil
+	return uint64(cValue), nil
 }
 
 // IsSet returns a true if the RbdImageOption is set, false otherwise.

--- a/rbd/options.go
+++ b/rbd/options.go
@@ -189,14 +189,14 @@ func (rio *ImageOptions) GetUint64(option ImageOption) (uint64, error) {
 //  int rbd_image_options_is_set(rbd_image_options_t opts, int optname,
 //          bool* is_set);
 func (rio *ImageOptions) IsSet(option ImageOption) (bool, error) {
-	var c_set C.bool
+	var cSet C.bool
 
-	ret := C.rbd_image_options_is_set(rio.options, C.int(option), &c_set)
+	ret := C.rbd_image_options_is_set(rio.options, C.int(option), &cSet)
 	if ret != 0 {
 		return false, fmt.Errorf("%v, could not check option %v", getError(ret), option)
 	}
 
-	return bool(c_set), nil
+	return bool(cSet), nil
 }
 
 // Unset a given RbdImageOption.

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -649,10 +649,10 @@ func (image *Image) LockExclusive(cookie string) error {
 		return err
 	}
 
-	c_cookie := C.CString(cookie)
-	defer C.free(unsafe.Pointer(c_cookie))
+	cCookie := C.CString(cookie)
+	defer C.free(unsafe.Pointer(cCookie))
 
-	return getError(C.rbd_lock_exclusive(image.image, c_cookie))
+	return getError(C.rbd_lock_exclusive(image.image, cCookie))
 }
 
 // LockShared acquires a shared lock on the rbd image.
@@ -664,12 +664,12 @@ func (image *Image) LockShared(cookie string, tag string) error {
 		return err
 	}
 
-	c_cookie := C.CString(cookie)
-	c_tag := C.CString(tag)
-	defer C.free(unsafe.Pointer(c_cookie))
-	defer C.free(unsafe.Pointer(c_tag))
+	cCookie := C.CString(cookie)
+	cTag := C.CString(tag)
+	defer C.free(unsafe.Pointer(cCookie))
+	defer C.free(unsafe.Pointer(cTag))
 
-	return getError(C.rbd_lock_shared(image.image, c_cookie, c_tag))
+	return getError(C.rbd_lock_shared(image.image, cCookie, cTag))
 }
 
 // Unlock releases a lock on the image.

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -681,10 +681,10 @@ func (image *Image) Unlock(cookie string) error {
 		return err
 	}
 
-	c_cookie := C.CString(cookie)
-	defer C.free(unsafe.Pointer(c_cookie))
+	cCookie := C.CString(cookie)
+	defer C.free(unsafe.Pointer(cCookie))
 
-	return getError(C.rbd_unlock(image.image, c_cookie))
+	return getError(C.rbd_unlock(image.image, cCookie))
 }
 
 // BreakLock forces the release of a lock held by another client.

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1000,21 +1000,21 @@ func GetTrashList(ioctx *rados.IOContext) ([]TrashInfo, error) {
 
 // TrashRemove permanently deletes the trashed RBD with the specified id.
 func TrashRemove(ioctx *rados.IOContext, id string, force bool) error {
-	c_id := C.CString(id)
-	defer C.free(unsafe.Pointer(c_id))
+	cid := C.CString(id)
+	defer C.free(unsafe.Pointer(cid))
 
-	return getError(C.rbd_trash_remove(cephIoctx(ioctx), c_id, C.bool(force)))
+	return getError(C.rbd_trash_remove(cephIoctx(ioctx), cid, C.bool(force)))
 }
 
 // TrashRestore restores the trashed RBD with the specified id back to the pool from whence it
 // came, with the specified new name.
 func TrashRestore(ioctx *rados.IOContext, id, name string) error {
-	c_id := C.CString(id)
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_id))
-	defer C.free(unsafe.Pointer(c_name))
+	cid := C.CString(id)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cid))
+	defer C.free(unsafe.Pointer(cName))
 
-	return getError(C.rbd_trash_restore(cephIoctx(ioctx), c_id, c_name))
+	return getError(C.rbd_trash_restore(cephIoctx(ioctx), cid, cName))
 }
 
 // OpenImage will open an existing rbd image by name and snapshot name,

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -292,10 +292,10 @@ func (image *Image) Trash(delay time.Duration) error {
 		return err
 	}
 
-	c_name := C.CString(image.name)
-	defer C.free(unsafe.Pointer(c_name))
+	cName := C.CString(image.name)
+	defer C.free(unsafe.Pointer(cName))
 
-	return getError(C.rbd_trash_move(cephIoctx(image.ioctx), c_name,
+	return getError(C.rbd_trash_move(cephIoctx(image.ioctx), cName,
 		C.uint64_t(delay.Seconds())))
 }
 

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -160,13 +160,13 @@ func Create(ioctx *rados.IOContext, name string, size uint64, order int,
 	case 1:
 		return Create2(ioctx, name, size, args[0], order)
 	case 0:
-		c_order := C.int(order)
-		c_name := C.CString(name)
+		cOrder := C.int(order)
+		cName := C.CString(name)
 
-		defer C.free(unsafe.Pointer(c_name))
+		defer C.free(unsafe.Pointer(cName))
 
 		ret = C.rbd_create(cephIoctx(ioctx),
-			c_name, C.uint64_t(size), &c_order)
+			cName, C.uint64_t(size), &cOrder)
 	default:
 		return nil, errors.New("Wrong number of argument")
 	}
@@ -190,13 +190,13 @@ func Create2(ioctx *rados.IOContext, name string, size uint64, features uint64,
 	order int) (image *Image, err error) {
 	var ret C.int
 
-	c_order := C.int(order)
-	c_name := C.CString(name)
+	cOrder := C.int(order)
+	cName := C.CString(name)
 
-	defer C.free(unsafe.Pointer(c_name))
+	defer C.free(unsafe.Pointer(cName))
 
-	ret = C.rbd_create2(cephIoctx(ioctx), c_name,
-		C.uint64_t(size), C.uint64_t(features), &c_order)
+	ret = C.rbd_create2(cephIoctx(ioctx), cName,
+		C.uint64_t(size), C.uint64_t(features), &cOrder)
 	if ret < 0 {
 		return nil, rbdError(ret)
 	}
@@ -215,17 +215,17 @@ func Create2(ioctx *rados.IOContext, name string, size uint64, features uint64,
 //        uint64_t features, int *order,
 //        uint64_t stripe_unit, uint64_t stripe_count);
 func Create3(ioctx *rados.IOContext, name string, size uint64, features uint64,
-	order int, stripe_unit uint64, stripe_count uint64) (image *Image, err error) {
+	order int, stripeUnit uint64, stripeCount uint64) (image *Image, err error) {
 	var ret C.int
 
-	c_order := C.int(order)
-	c_name := C.CString(name)
+	cOrder := C.int(order)
+	cName := C.CString(name)
 
-	defer C.free(unsafe.Pointer(c_name))
+	defer C.free(unsafe.Pointer(cName))
 
-	ret = C.rbd_create3(cephIoctx(ioctx), c_name,
-		C.uint64_t(size), C.uint64_t(features), &c_order,
-		C.uint64_t(stripe_unit), C.uint64_t(stripe_count))
+	ret = C.rbd_create3(cephIoctx(ioctx), cName,
+		C.uint64_t(size), C.uint64_t(features), &cOrder,
+		C.uint64_t(stripeUnit), C.uint64_t(stripeCount))
 	if ret < 0 {
 		return nil, rbdError(ret)
 	}

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -125,9 +125,9 @@ func (image *Image) validate(req uint32) error {
 
 // Version returns the major, minor, and patch level of the librbd library.
 func Version() (int, int, int) {
-	var c_major, c_minor, c_patch C.int
-	C.rbd_version(&c_major, &c_minor, &c_patch)
-	return int(c_major), int(c_minor), int(c_patch)
+	var cMajor, cMinor, cPatch C.int
+	C.rbd_version(&cMajor, &cMinor, &cPatch)
+	return int(cMajor), int(cMinor), int(cPatch)
 }
 
 // GetImage gets a reference to a previously created rbd image.

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -308,14 +308,14 @@ func (image *Image) Rename(destname string) error {
 		return err
 	}
 
-	c_srcname := C.CString(image.name)
-	c_destname := C.CString(destname)
+	cSrcName := C.CString(image.name)
+	cDestName := C.CString(destname)
 
-	defer C.free(unsafe.Pointer(c_srcname))
-	defer C.free(unsafe.Pointer(c_destname))
+	defer C.free(unsafe.Pointer(cSrcName))
+	defer C.free(unsafe.Pointer(cDestName))
 
 	err := rbdError(C.rbd_rename(cephIoctx(image.ioctx),
-		c_srcname, c_destname))
+		cSrcName, cDestName))
 	if err == 0 {
 		image.name = destname
 		return nil

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1205,10 +1205,10 @@ func CreateImage(ioctx *rados.IOContext, name string, size uint64, rio *ImageOpt
 		return rbdError(C.EINVAL)
 	}
 
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
 
-	ret := C.rbd_create4(cephIoctx(ioctx), c_name,
+	ret := C.rbd_create4(cephIoctx(ioctx), cName,
 		C.uint64_t(size), C.rbd_image_options_t(rio.options))
 	return getError(ret)
 }

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -516,11 +516,11 @@ func (image *Image) Copy(ioctx *rados.IOContext, destname string) error {
 		return ErrNoName
 	}
 
-	c_destname := C.CString(destname)
-	defer C.free(unsafe.Pointer(c_destname))
+	cDestName := C.CString(destname)
+	defer C.free(unsafe.Pointer(cDestName))
 
 	return getError(C.rbd_copy(image.image,
-		cephIoctx(ioctx), c_destname))
+		cephIoctx(ioctx), cDestName))
 }
 
 // Copy2 copies one rbd image to another, using an image handle.

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -959,10 +959,10 @@ func (image *Image) SetSnapshot(snapname string) error {
 		return err
 	}
 
-	c_snapname := C.CString(snapname)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapName := C.CString(snapname)
+	defer C.free(unsafe.Pointer(cSnapName))
 
-	return getError(C.rbd_snap_set(image.image, c_snapname))
+	return getError(C.rbd_snap_set(image.image, cSnapName))
 }
 
 // GetTrashList returns a slice of TrashInfo structs, containing information about all RBD images

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -403,18 +403,18 @@ func (image *Image) Stat() (info *ImageInfo, err error) {
 		return nil, err
 	}
 
-	var c_stat C.rbd_image_info_t
+	var cStat C.rbd_image_info_t
 
-	if ret := C.rbd_stat(image.image, &c_stat, C.size_t(unsafe.Sizeof(info))); ret < 0 {
+	if ret := C.rbd_stat(image.image, &cStat, C.size_t(unsafe.Sizeof(info))); ret < 0 {
 		return info, rbdError(ret)
 	}
 
 	return &ImageInfo{
-		Size:              uint64(c_stat.size),
-		Obj_size:          uint64(c_stat.obj_size),
-		Num_objs:          uint64(c_stat.num_objs),
-		Order:             int(c_stat.order),
-		Block_name_prefix: C.GoString((*C.char)(&c_stat.block_name_prefix[0]))}, nil
+		Size:              uint64(cStat.size),
+		Obj_size:          uint64(cStat.obj_size),
+		Num_objs:          uint64(cStat.num_objs),
+		Order:             int(cStat.order),
+		Block_name_prefix: C.GoString((*C.char)(&cStat.block_name_prefix[0]))}, nil
 }
 
 // IsOldFormat returns true if the rbd image uses the old format.

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1225,9 +1225,9 @@ func RemoveImage(ioctx *rados.IOContext, name string) error {
 		return ErrNoName
 	}
 
-	c_name := C.CString(name)
-	defer C.free(unsafe.Pointer(c_name))
-	return getError(C.rbd_remove(cephIoctx(ioctx), c_name))
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	return getError(C.rbd_remove(cephIoctx(ioctx), cName))
 }
 
 // CloneImage creates a clone of the image from the named snapshot in the

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -242,31 +242,35 @@ func Create3(ioctx *rados.IOContext, name string, size uint64, features uint64,
 //  int rbd_clone(rados_ioctx_t p_ioctx, const char *p_name,
 //           const char *p_snapname, rados_ioctx_t c_ioctx,
 //           const char *c_name, uint64_t features, int *c_order);
-func (image *Image) Clone(snapname string, c_ioctx *rados.IOContext, c_name string, features uint64, order int) (*Image, error) {
+func (image *Image) Clone(snapname string, cIoctx *rados.IOContext, cName string, features uint64, order int) (*Image, error) {
 	if err := image.validate(imageNeedsIOContext); err != nil {
 		return nil, err
 	}
 
-	c_order := C.int(order)
-	c_p_name := C.CString(image.name)
-	c_p_snapname := C.CString(snapname)
-	c_c_name := C.CString(c_name)
+	cOrder := C.int(order)
+	cParentName := C.CString(image.name)
+	cParentSnapName := C.CString(snapname)
+	cCloneName := C.CString(cName)
 
-	defer C.free(unsafe.Pointer(c_p_name))
-	defer C.free(unsafe.Pointer(c_p_snapname))
-	defer C.free(unsafe.Pointer(c_c_name))
+	defer C.free(unsafe.Pointer(cParentName))
+	defer C.free(unsafe.Pointer(cParentSnapName))
+	defer C.free(unsafe.Pointer(cCloneName))
 
-	ret := C.rbd_clone(cephIoctx(image.ioctx),
-		c_p_name, c_p_snapname,
-		cephIoctx(c_ioctx),
-		c_c_name, C.uint64_t(features), &c_order)
+	ret := C.rbd_clone(
+		cephIoctx(image.ioctx),
+		cParentName,
+		cParentSnapName,
+		cephIoctx(cIoctx),
+		cCloneName,
+		C.uint64_t(features),
+		&cOrder)
 	if ret < 0 {
 		return nil, rbdError(ret)
 	}
 
 	return &Image{
-		ioctx: c_ioctx,
-		name:  c_name,
+		ioctx: cIoctx,
+		name:  cName,
 	}, nil
 }
 

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -49,6 +49,8 @@ const (
 // Timespec is a public type for the internal C 'struct timespec'
 type Timespec ts.Timespec
 
+// revive:disable:var-naming old-yet-exported public api
+
 // ImageInfo represents the status information for an image.
 type ImageInfo struct {
 	Size              uint64
@@ -57,6 +59,8 @@ type ImageInfo struct {
 	Order             int
 	Block_name_prefix string
 }
+
+// revive:enable:var-naming
 
 // SnapInfo represents the status information for a snapshot.
 type SnapInfo struct {

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -421,19 +421,19 @@ func (image *Image) Stat() (info *ImageInfo, err error) {
 //
 // Implements:
 //  int rbd_get_old_format(rbd_image_t image, uint8_t *old);
-func (image *Image) IsOldFormat() (old_format bool, err error) {
+func (image *Image) IsOldFormat() (bool, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return false, err
 	}
 
-	var c_old_format C.uint8_t
+	var cOldFormat C.uint8_t
 	ret := C.rbd_get_old_format(image.image,
-		&c_old_format)
+		&cOldFormat)
 	if ret < 0 {
 		return false, rbdError(ret)
 	}
 
-	return c_old_format != 0, nil
+	return cOldFormat != 0, nil
 }
 
 // GetSize returns the size of the rbd image.

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -696,12 +696,12 @@ func (image *Image) BreakLock(client string, cookie string) error {
 		return err
 	}
 
-	c_client := C.CString(client)
-	c_cookie := C.CString(cookie)
-	defer C.free(unsafe.Pointer(c_client))
-	defer C.free(unsafe.Pointer(c_cookie))
+	cClient := C.CString(client)
+	cCookie := C.CString(cookie)
+	defer C.free(unsafe.Pointer(cClient))
+	defer C.free(unsafe.Pointer(cCookie))
 
-	return getError(C.rbd_break_lock(image.image, c_client, c_cookie))
+	return getError(C.rbd_break_lock(image.image, cClient, cCookie))
 }
 
 // ssize_t rbd_read(rbd_image_t image, uint64_t ofs, size_t len, char *buf);

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -897,26 +897,26 @@ func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 		return nil, err
 	}
 
-	var c_max_snaps C.int
+	var cMaxSnaps C.int
 
-	ret := C.rbd_snap_list(image.image, nil, &c_max_snaps)
+	ret := C.rbd_snap_list(image.image, nil, &cMaxSnaps)
 
-	c_snaps := make([]C.rbd_snap_info_t, c_max_snaps)
-	snaps = make([]SnapInfo, c_max_snaps)
+	cSnaps := make([]C.rbd_snap_info_t, cMaxSnaps)
+	snaps = make([]SnapInfo, cMaxSnaps)
 
 	ret = C.rbd_snap_list(image.image,
-		&c_snaps[0], &c_max_snaps)
+		&cSnaps[0], &cMaxSnaps)
 	if ret < 0 {
 		return nil, rbdError(ret)
 	}
 
-	for i, s := range c_snaps {
+	for i, s := range cSnaps {
 		snaps[i] = SnapInfo{Id: uint64(s.id),
 			Size: uint64(s.size),
 			Name: C.GoString(s.name)}
 	}
 
-	C.rbd_snap_list_end(&c_snaps[0])
+	C.rbd_snap_list_end(&cSnaps[0])
 	return snaps[:len(snaps)-1], nil
 }
 

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -456,32 +456,34 @@ func (image *Image) GetSize() (size uint64, err error) {
 //
 // Implements:
 //  int rbd_get_stripe_unit(rbd_image_t image, uint64_t *stripe_unit);
-func (image *Image) GetStripeUnit() (stripe_unit uint64, err error) {
+func (image *Image) GetStripeUnit() (uint64, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
 	}
 
-	if ret := C.rbd_get_stripe_unit(image.image, (*C.uint64_t)(&stripe_unit)); ret < 0 {
+	var stripeUnit uint64
+	if ret := C.rbd_get_stripe_unit(image.image, (*C.uint64_t)(&stripeUnit)); ret < 0 {
 		return 0, rbdError(ret)
 	}
 
-	return stripe_unit, nil
+	return stripeUnit, nil
 }
 
 // GetStripeCount returns the stripe-count value for the rbd image.
 //
 // Implements:
 //  int rbd_get_stripe_count(rbd_image_t image, uint64_t *stripe_count);
-func (image *Image) GetStripeCount() (stripe_count uint64, err error) {
+func (image *Image) GetStripeCount() (uint64, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
 	}
 
-	if ret := C.rbd_get_stripe_count(image.image, (*C.uint64_t)(&stripe_count)); ret < 0 {
+	var stripeCount uint64
+	if ret := C.rbd_get_stripe_count(image.image, (*C.uint64_t)(&stripeCount)); ret < 0 {
 		return 0, rbdError(ret)
 	}
 
-	return stripe_count, nil
+	return stripeCount, nil
 }
 
 // GetOverlap returns the overlapping bytes between the rbd image and its

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -133,18 +133,18 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 		return false, err
 	}
 
-	var c_is_protected C.int
+	var cIsProtected C.int
 
 	cSnapName := C.CString(snapshot.name)
 	defer C.free(unsafe.Pointer(cSnapName))
 
 	ret := C.rbd_snap_is_protected(snapshot.image.image, cSnapName,
-		&c_is_protected)
+		&cIsProtected)
 	if ret < 0 {
 		return false, rbdError(ret)
 	}
 
-	return c_is_protected != 0, nil
+	return cIsProtected != 0, nil
 }
 
 // Set updates the rbd image (not the Snapshot) such that the snapshot

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -27,10 +27,10 @@ func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
 		return nil, err
 	}
 
-	c_snapname := C.CString(snapname)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapName := C.CString(snapname)
+	defer C.free(unsafe.Pointer(cSnapName))
 
-	ret := C.rbd_snap_create(image.image, c_snapname)
+	ret := C.rbd_snap_create(image.image, cSnapName)
 	if ret < 0 {
 		return nil, rbdError(ret)
 	}
@@ -72,10 +72,10 @@ func (snapshot *Snapshot) Remove() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapName := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapName))
 
-	return getError(C.rbd_snap_remove(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_remove(snapshot.image.image, cSnapName))
 }
 
 // Rollback the image to the snapshot.
@@ -87,10 +87,10 @@ func (snapshot *Snapshot) Rollback() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapName := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapName))
 
-	return getError(C.rbd_snap_rollback(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_rollback(snapshot.image.image, cSnapName))
 }
 
 // Protect a snapshot from unwanted deletion.
@@ -102,10 +102,10 @@ func (snapshot *Snapshot) Protect() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapName := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapName))
 
-	return getError(C.rbd_snap_protect(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_protect(snapshot.image.image, cSnapName))
 }
 
 // Unprotect stops protecting the snapshot.
@@ -117,10 +117,10 @@ func (snapshot *Snapshot) Unprotect() error {
 		return err
 	}
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapName := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapName))
 
-	return getError(C.rbd_snap_unprotect(snapshot.image.image, c_snapname))
+	return getError(C.rbd_snap_unprotect(snapshot.image.image, cSnapName))
 }
 
 // IsProtected returns true if the snapshot is currently protected.
@@ -135,10 +135,10 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 
 	var c_is_protected C.int
 
-	c_snapname := C.CString(snapshot.name)
-	defer C.free(unsafe.Pointer(c_snapname))
+	cSnapName := C.CString(snapshot.name)
+	defer C.free(unsafe.Pointer(cSnapName))
 
-	ret := C.rbd_snap_is_protected(snapshot.image.image, c_snapname,
+	ret := C.rbd_snap_is_protected(snapshot.image.image, cSnapName,
 		&c_is_protected)
 	if ret < 0 {
 		return false, rbdError(ret)


### PR DESCRIPTION
Depends on PR #535 

More naming cleanups. One cleanup needed to be skipped as the public fields of a public struct have underscores.

A few cases were in the vars in a function. I think these can be safely modified as the _names_ of the function arguments and return values are not part of the public API. (They do show up in the docs though)

Yell at me if you think I'm wrong.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
