### PR TITLE
rbd admin: add a String method to LevelSpec type

### DIFF
--- a/rbd/admin/admin.go
+++ b/rbd/admin/admin.go
@@ -49,3 +49,8 @@ func NewLevelSpec(pool, namespace, image string) LevelSpec {
 func NewRawLevelSpec(spec string) LevelSpec {
 	return LevelSpec{spec}
 }
+
+// String representation of a level spec.
+func (ls LevelSpec) String() string {
+	return ls.spec
+}

--- a/rbd/admin/admin_test.go
+++ b/rbd/admin/admin_test.go
@@ -30,3 +30,11 @@ func TestRawLevelSpec(t *testing.T) {
 	rls = NewRawLevelSpec("totally! invalid! haha. ha...")
 	assert.Equal(t, "totally! invalid! haha. ha...", rls.spec)
 }
+
+func TestLevelSpecString(t *testing.T) {
+	ls := NewLevelSpec("bob", "", "")
+	assert.Equal(t, "bob/", ls.String())
+
+	ls = NewRawLevelSpec("bob/alice")
+	assert.Equal(t, "bob/alice", ls.String())
+}


### PR DESCRIPTION
Fixes: #522 

This adds a String method to LevelSpec. I opted not to implement an Equals method as I felt that x.String() == y.String() is as expressive as x.Equals(y) in this case and I feel that Equals is starting to tread into territory that may interact with generics and so I'd rather leave that aside for now until Go has generics and the community has had time to experiment with them.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
