### PR TITLE
rbd: add EncryptionLoad api to support the rbd_encryption_load librbd…

### DIFF
--- a/rbd/encryption_test.go
+++ b/rbd/encryption_test.go
@@ -45,3 +45,85 @@ func TestEncryptionFormat(t *testing.T) {
 	conn.DeletePool(poolname)
 	conn.Shutdown()
 }
+
+func TestEncryptionLoad(t *testing.T) {
+	conn := radosConnect(t)
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+
+	name := GetUUID()
+	testImageSize := uint64(1 << 23) // format requires more than 4194304 bytes
+	options := NewRbdImageOptions()
+	assert.NoError(t,
+		options.SetUint64(ImageOptionOrder, uint64(testImageOrder)))
+	err = CreateImage(ioctx, name, testImageSize, options)
+	assert.NoError(t, err)
+
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+
+	var opts EncryptionOptionsLUKS1
+	opts.Alg = EncryptionAlgorithmAES256
+	opts.Passphrase = ([]byte)("test-password")
+	err = img.EncryptionFormat(opts)
+	assert.NoError(t, err)
+
+	// close the image so we can reopen it and load the encryption info
+	// then write some encrypted data at the end of the image
+	err = img.Close()
+	assert.NoError(t, err)
+	img, err = OpenImage(ioctx, name, NoSnapshot)
+	err = img.EncryptionLoad(opts)
+	assert.NoError(t, err)
+
+	outData := []byte("Hi rbd! Nice to talk through go-ceph :)")
+
+	stats, err := img.Stat()
+	require.NoError(t, err)
+	offset := int64(stats.Size) - int64(len(outData))
+
+	nOut, err := img.WriteAt(outData, offset)
+	assert.Equal(t, len(outData), nOut)
+	assert.NoError(t, err)
+
+	err = img.Close()
+	assert.NoError(t, err)
+
+	// Re-open the image, load the encryption format, and read the encrypted data
+	img, err = OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+	err = img.EncryptionLoad(opts)
+	assert.NoError(t, err)
+
+	inData := make([]byte, len(outData))
+	nIn, err := img.ReadAt(inData, offset)
+	assert.Equal(t, nIn, len(inData))
+	assert.Equal(t, inData, outData)
+	assert.NoError(t, err)
+
+	err = img.Close()
+	assert.NoError(t, err)
+
+	// Re-open the image and attempt to read the encrypted data without loading the encryption
+	img, err = OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+
+	nIn, err = img.ReadAt(inData, offset)
+	assert.Equal(t, nIn, len(inData))
+	assert.NotEqual(t, inData, outData)
+	assert.NoError(t, err)
+
+	err = img.Close()
+	assert.NoError(t, err)
+	err = img.Remove()
+	assert.NoError(t, err)
+
+	ioctx.Destroy()
+	conn.DeletePool(poolname)
+	conn.Shutdown()
+}


### PR DESCRIPTION
rbd: add EncryptionLoad api to support the rbd_encryption_load librbd api.

EncryptionLoad loads the encryption format information for an image and enables encrypted IO.  This is a new feature in Ceph Pacific.

Signed-off-by: Effi Ofer <effio@il.ibm.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
