### PR TITLE
rgw/admin: remove Debug field from API type

### DIFF
--- a/rgw/admin/README.md
+++ b/rgw/admin/README.md
@@ -24,9 +24,6 @@ func main() {
         panic(err)
     }
 
-    // To enable debug requests
-    // co.Debug = true
-
     // Get the "admin" user
     user, err := co.GetUser(context.Background(), "admin")
     if err != nil {

--- a/rgw/admin/bucket_test.go
+++ b/rgw/admin/bucket_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,8 +11,7 @@ import (
 
 func (suite *RadosGWTestSuite) TestBucket() {
 	suite.SetupConnection()
-	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, nil)
-	co.Debug = true
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 	assert.NoError(suite.T(), err)
 
 	s3, err := newS3Agent(suite.accessKey, suite.secretKey, suite.endpoint, true)

--- a/rgw/admin/quota_test.go
+++ b/rgw/admin/quota_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +10,7 @@ import (
 
 func (suite *RadosGWTestSuite) TestQuota() {
 	suite.SetupConnection()
-	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, nil)
-	co.Debug = true
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 	assert.NoError(suite.T(), err)
 
 	suite.T().Run("set quota to user but user ID is empty", func(t *testing.T) {

--- a/rgw/admin/radosgw.go
+++ b/rgw/admin/radosgw.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
-	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"time"
 
@@ -39,7 +37,6 @@ type API struct {
 	SecretKey  string
 	Endpoint   string
 	HTTPClient HTTPClient
-	Debug      bool
 }
 
 // New returns client for Ceph RGW
@@ -69,7 +66,6 @@ func New(endpoint, accessKey, secretKey string, httpClient HTTPClient) (*API, er
 		AccessKey:  accessKey,
 		SecretKey:  secretKey,
 		HTTPClient: httpClient,
-		Debug:      false,
 	}, nil
 }
 
@@ -94,30 +90,12 @@ func (api *API) call(ctx context.Context, httpMethod, path string, args url.Valu
 		return nil, err
 	}
 
-	// Print request if Debug is enabled
-	if api.Debug {
-		dump, err := httputil.DumpRequestOut(request, true)
-		if err != nil {
-			return nil, err
-		}
-		log.Printf("\n%s\n", string(dump))
-	}
-
 	// Send HTTP request
 	resp, err := api.HTTPClient.Do(request)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	// Print response if Debug is enabled
-	if api.Debug {
-		dump, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			return nil, err
-		}
-		log.Printf("\n%s\n", string(dump))
-	}
 
 	// Decode HTTP response
 	decodedResponse, err := ioutil.ReadAll(resp.Body)

--- a/rgw/admin/radosgw_test.go
+++ b/rgw/admin/radosgw_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"reflect"
 	"testing"
@@ -22,6 +23,36 @@ type RadosGWTestSuite struct {
 	accessKey      string
 	secretKey      string
 	bucketTestName string
+}
+
+type debugHTTPClient struct {
+	client HTTPClient
+}
+
+func newDebugHTTPClient(client HTTPClient) *debugHTTPClient {
+	return &debugHTTPClient{client}
+}
+
+func (c *debugHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	dump, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("\n%s\n", string(dump))
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	dump, err = httputil.DumpResponse(resp, true)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("\n%s\n", string(dump))
+
+	return resp, nil
 }
 
 func TestRadosGWTestSuite(t *testing.T) {

--- a/rgw/admin/usage_test.go
+++ b/rgw/admin/usage_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +10,7 @@ import (
 
 func (suite *RadosGWTestSuite) TestUsage() {
 	suite.SetupConnection()
-	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, nil)
-	co.Debug = true
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 	assert.NoError(suite.T(), err)
 
 	suite.T().Run("get usage", func(t *testing.T) {

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -79,8 +79,7 @@ func TestUnmarshal(t *testing.T) {
 
 func (suite *RadosGWTestSuite) TestUser() {
 	suite.SetupConnection()
-	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, nil)
-	co.Debug = true
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 	assert.NoError(suite.T(), err)
 
 	suite.T().Run("fail to create user since no UID provided", func(t *testing.T) {


### PR DESCRIPTION
Instead of implementing our own logging let's the consumer implement
their own potential debug for each HTTP requests.

Closes: https://github.com/ceph/go-ceph/issues/508
Signed-off-by: Sébastien Han <seb@redhat.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
