### PR TITLE
rgw/admin: include stat information to User Struct

### DIFF
--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -31,6 +31,8 @@ type User struct {
 	Tenant              string        `url:"tenant"`
 	GenerateKey         *bool         `url:"generate-key"`
 	PurgeData           *int          `url:"purge-data"`
+	GenerateStat        *bool         `url:"stats"`
+	Stat                UserStat      `json:"stats"`
 }
 
 // UserCapSpec represents a user capability which gives access to certain ressources
@@ -44,6 +46,13 @@ type UserKeySpec struct {
 	User      string `json:"user"`
 	AccessKey string `json:"access_key" url:"access-key"`
 	SecretKey string `json:"secret_key" url:"secret-key"`
+}
+
+// UserStat contains information about storage consumption by the ceph user
+type UserStat struct {
+	Size        *uint64 `json:"size"`
+	SizeRounded *uint64 `json:"size_rounded"`
+	NumObjects  *uint64 `json:"num_objects"`
 }
 
 // GetUser retrieves a given object store user

--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -33,6 +33,7 @@ type User struct {
 	PurgeData           *int          `url:"purge-data"`
 	GenerateStat        *bool         `url:"stats"`
 	Stat                UserStat      `json:"stats"`
+	UserCaps            string        `url:"user-caps"`
 }
 
 // UserCapSpec represents a user capability which gives access to certain ressources

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -145,6 +145,13 @@ func (suite *RadosGWTestSuite) TestUser() {
 		assert.Equal(suite.T(), int64(100), *q.MaxObjects)
 	})
 
+	suite.T().Run("get user stat", func(t *testing.T) {
+		statEnable := true
+		user, err := co.GetUser(context.Background(), User{ID: "leseb", GenerateStat: &statEnable})
+		assert.NoError(suite.T(), err)
+		assert.NotNil(suite.T(), user.Stat.Size)
+	})
+
 	suite.T().Run("remove user", func(t *testing.T) {
 		err = co.RemoveUser(context.Background(), User{ID: "leseb"})
 		assert.NoError(suite.T(), err)

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -95,7 +95,8 @@ func (suite *RadosGWTestSuite) TestUser() {
 	})
 
 	suite.T().Run("user creation success", func(t *testing.T) {
-		user, err := co.CreateUser(context.Background(), User{ID: "leseb", DisplayName: "This is leseb", Email: "leseb@example.com"})
+		usercaps := "users=read"
+		user, err := co.CreateUser(context.Background(), User{ID: "leseb", DisplayName: "This is leseb", Email: "leseb@example.com", UserCaps: usercaps})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@example.com", user.Email)
 	})
@@ -104,6 +105,8 @@ func (suite *RadosGWTestSuite) TestUser() {
 		user, err := co.GetUser(context.Background(), User{ID: "leseb"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@example.com", user.Email)
+		assert.Equal(suite.T(), "users", user.Caps[0].Type)
+		assert.Equal(suite.T(), "read", user.Caps[0].Perm)
 	})
 
 	suite.T().Run("modify user email", func(t *testing.T) {


### PR DESCRIPTION
The stat information gives idea about current storage consumption.
Include that info to the user struct

[Updated} also added url for `user cap` in the api request

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
