### PR TITLE
rbd: deprecate Close() method of MirrorImageGlobalStatusIter

### DIFF
--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -710,10 +710,8 @@ func (iter *MirrorImageGlobalStatusIter) Next() (*GlobalMirrorImageIDAndStatus, 
 }
 
 // Close terminates iteration regardless if iteration was completed and
-// frees any associated resources.
-func (iter *MirrorImageGlobalStatusIter) Close() error {
-	iter.buf = nil
-	iter.lastID = ""
+// frees any associated resources. (DEPRECATED)
+func (*MirrorImageGlobalStatusIter) Close() error {
 	return nil
 }
 


### PR DESCRIPTION
`Close()` is basically a no-op in the `defer` use case, and reuse of iterators I would strongly discourage from. The existence of this method gives the wrong impression that there are resources, that need to be freed. Also the error return value is unusual and actually dead code. It seems like the `Close()` method is a leftover from an earlier implementation.

Signed-off-by: Sven Anderson <sven@redhat.com>
