### PR TITLE
cephfs: re-enabled the skipped test for cephfs

### DIFF
--- a/cephfs/file_test.go
+++ b/cephfs/file_test.go
@@ -934,7 +934,6 @@ func TestFileTruncate(t *testing.T) {
 	})
 
 	t.Run("closedFile", func(t *testing.T) {
-		t.Skip("test fails because of a bug(?) in ceph")
 		// "touch" the file
 		f1, err := mount.Open(fname, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		assert.NoError(t, err)


### PR DESCRIPTION
cephfs test was disabled because there was bug in ceph related to ftruncate
the ceph bug is resolved, so re-enabling the cephfs test

Closes: https://github.com/ceph/go-ceph/issues/439
Signed-off-by: parth-gr <paarora@redhat.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
