### PR TITLE
rbd: fix various naming convention issues in tests

### DIFF
--- a/rados/command_test.go
+++ b/rados/command_test.go
@@ -49,14 +49,14 @@ func (suite *RadosTestSuite) TestMonCommandWithInputBuffer() {
 	})
 	assert.NoError(suite.T(), err)
 
-	client_key := fmt.Sprintf(clientKeyFormat, entity)
+	clientKey := fmt.Sprintf(clientKeyFormat, entity)
 
-	inbuf := []byte(client_key)
+	inbuf := []byte(clientKey)
 
 	buf, info, err := suite.conn.MonCommandWithInputBuffer(command, inbuf)
 	assert.NoError(suite.T(), err)
-	expected_info := fmt.Sprintf("added key for %s", entity)
-	assert.Equal(suite.T(), expected_info, info)
+	expectedInfo := fmt.Sprintf("added key for %s", entity)
+	assert.Equal(suite.T(), expectedInfo, info)
 	assert.Equal(suite.T(), "", string(buf[:]))
 
 	// get the key and verify that it's what we previously set

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -579,8 +579,8 @@ func (suite *RadosTestSuite) TestGetPoolStats() {
 	suite.SetupConnection()
 
 	// grab current stats
-	prev_stat, err := suite.ioctx.GetPoolStats()
-	fmt.Printf("prev_stat: %+v\n", prev_stat)
+	prevStat, err := suite.ioctx.GetPoolStats()
+	fmt.Printf("prevStat: %+v\n", prevStat)
 	assert.NoError(suite.T(), err)
 
 	// make some changes to the cluster
@@ -597,7 +597,7 @@ func (suite *RadosTestSuite) TestGetPoolStats() {
 		assert.NoError(suite.T(), err)
 
 		// wait for something to change
-		if stat == prev_stat {
+		if stat == prevStat {
 			fmt.Printf("curr_stat: %+v (trying again...)\n", stat)
 			time.Sleep(time.Second)
 		} else {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -289,19 +289,19 @@ func (suite *RadosTestSuite) TestMakeDeletePool() {
 	suite.SetupConnection()
 
 	// check that new pool name is unique
-	new_name := uuid.Must(uuid.NewV4()).String()
-	_, err := suite.conn.GetPoolByName(new_name)
+	newName := uuid.Must(uuid.NewV4()).String()
+	_, err := suite.conn.GetPoolByName(newName)
 	if err == nil {
 		suite.T().Error("Random pool name exists!")
 		return
 	}
 
 	// create pool
-	err = suite.conn.MakePool(new_name)
+	err = suite.conn.MakePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that the new pool name exists
-	pool, err := suite.conn.GetPoolByName(new_name)
+	pool, err := suite.conn.GetPoolByName(newName)
 	assert.NoError(suite.T(), err)
 
 	if pool == 0 {
@@ -309,11 +309,11 @@ func (suite *RadosTestSuite) TestMakeDeletePool() {
 	}
 
 	// delete the pool
-	err = suite.conn.DeletePool(new_name)
+	err = suite.conn.DeletePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that it is gone
-	pool, _ = suite.conn.GetPoolByName(new_name)
+	pool, _ = suite.conn.GetPoolByName(newName)
 	if pool != 0 {
 		suite.T().Error("Deleted pool still exists")
 	}

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -247,8 +247,8 @@ func (suite *RadosTestSuite) TestGetClusterStats() {
 	suite.SetupConnection()
 
 	// grab current stats
-	prev_stat, err := suite.conn.GetClusterStats()
-	fmt.Printf("prev_stat: %+v\n", prev_stat)
+	prevStat, err := suite.conn.GetClusterStats()
+	fmt.Printf("prevStat: %+v\n", prevStat)
 	assert.NoError(suite.T(), err)
 
 	// make some changes to the cluster
@@ -265,7 +265,7 @@ func (suite *RadosTestSuite) TestGetClusterStats() {
 		assert.NoError(suite.T(), err)
 
 		// wait for something to change
-		if stat == prev_stat {
+		if stat == prevStat {
 			fmt.Printf("curr_stat: %+v (trying again...)\n", stat)
 			time.Sleep(time.Second)
 		} else {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -1026,15 +1026,15 @@ func (suite *RadosTestSuite) TestListAcrossNamespaces() {
 
 	// create oid
 	oid := suite.GenObjectName()
-	bytes_in := []byte("input data")
-	err = suite.ioctx.Write(oid, bytes_in, 0)
+	bytesIn := []byte("input data")
+	err = suite.ioctx.Write(oid, bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	// create oid2 in space1 ns
 	suite.ioctx.SetNamespace("space1")
 	oid2 := suite.GenObjectName()
-	bytes_in = []byte("input data")
-	err = suite.ioctx.Write(oid2, bytes_in, 0)
+	bytesIn = []byte("input data")
+	err = suite.ioctx.Write(oid2, bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	// count objects in space1 ns

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -987,12 +987,12 @@ func (suite *RadosTestSuite) TestSetNamespace() {
 
 	// create oid
 	oid := suite.GenObjectName()
-	bytes_in := []byte("input data")
-	err := suite.ioctx.Write(oid, bytes_in, 0)
+	bytesIn := []byte("input data")
+	err := suite.ioctx.Write(oid, bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	stat, err := suite.ioctx.Stat(oid)
-	assert.Equal(suite.T(), uint64(len(bytes_in)), stat.Size)
+	assert.Equal(suite.T(), uint64(len(bytesIn)), stat.Size)
 	assert.NotNil(suite.T(), stat.ModTime)
 
 	// oid isn't seen in space1 ns
@@ -1002,8 +1002,8 @@ func (suite *RadosTestSuite) TestSetNamespace() {
 
 	// create oid2 in space1 ns
 	oid2 := suite.GenObjectName()
-	bytes_in = []byte("input data")
-	err = suite.ioctx.Write(oid2, bytes_in, 0)
+	bytesIn = []byte("input data")
+	err = suite.ioctx.Write(oid2, bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	suite.ioctx.SetNamespace("")
@@ -1011,7 +1011,7 @@ func (suite *RadosTestSuite) TestSetNamespace() {
 	assert.Equal(suite.T(), err, ErrNotFound)
 
 	stat, err = suite.ioctx.Stat(oid)
-	assert.Equal(suite.T(), uint64(len(bytes_in)), stat.Size)
+	assert.Equal(suite.T(), uint64(len(bytesIn)), stat.Size)
 	assert.NotNil(suite.T(), stat.ModTime)
 }
 

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -327,38 +327,38 @@ func (suite *RadosTestSuite) TestGetPoolByName() {
 	assert.NoError(suite.T(), err)
 
 	// check that new pool name is unique
-	new_name := uuid.Must(uuid.NewV4()).String()
+	newName := uuid.Must(uuid.NewV4()).String()
 	require.NotContains(
-		suite.T(), pools, new_name, "Random pool name exists!")
+		suite.T(), pools, newName, "Random pool name exists!")
 
-	pool, _ := suite.conn.GetPoolByName(new_name)
+	pool, _ := suite.conn.GetPoolByName(newName)
 	assert.Equal(suite.T(), int64(0), pool, "Pool does not exist, but was found!")
 
 	// create pool
-	err = suite.conn.MakePool(new_name)
+	err = suite.conn.MakePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that the new pool name exists
 	pools, err = suite.conn.ListPools()
 	assert.NoError(suite.T(), err)
 	assert.Contains(
-		suite.T(), pools, new_name, "Cannot find newly created pool")
+		suite.T(), pools, newName, "Cannot find newly created pool")
 
-	pool, err = suite.conn.GetPoolByName(new_name)
+	pool, err = suite.conn.GetPoolByName(newName)
 	assert.NoError(suite.T(), err)
 	assert.NotEqual(suite.T(), int64(0), pool, "Pool not found!")
 
 	// delete the pool
-	err = suite.conn.DeletePool(new_name)
+	err = suite.conn.DeletePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that it is gone
 	pools, err = suite.conn.ListPools()
 	assert.NoError(suite.T(), err)
 	assert.NotContains(
-		suite.T(), pools, new_name, "Deleted pool still exists")
+		suite.T(), pools, newName, "Deleted pool still exists")
 
-	pool, err = suite.conn.GetPoolByName(new_name)
+	pool, err = suite.conn.GetPoolByName(newName)
 	assert.Error(suite.T(), err)
 	assert.Equal(
 		suite.T(), int64(0), pool, "Pool should have been deleted, but was found!")
@@ -368,19 +368,19 @@ func (suite *RadosTestSuite) TestGetPoolByID() {
 	suite.SetupConnection()
 
 	// check that new pool name is unique
-	new_name := uuid.Must(uuid.NewV4()).String()
-	pool, err := suite.conn.GetPoolByName(new_name)
+	newName := uuid.Must(uuid.NewV4()).String()
+	pool, err := suite.conn.GetPoolByName(newName)
 	if pool != 0 || err == nil {
 		suite.T().Error("Random pool name exists!")
 		return
 	}
 
 	// create pool
-	err = suite.conn.MakePool(new_name)
+	err = suite.conn.MakePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that the new pool name exists
-	id, err := suite.conn.GetPoolByName(new_name)
+	id, err := suite.conn.GetPoolByName(newName)
 	assert.NoError(suite.T(), err)
 
 	if id == 0 {
@@ -396,7 +396,7 @@ func (suite *RadosTestSuite) TestGetPoolByID() {
 	}
 
 	// delete the pool
-	err = suite.conn.DeletePool(new_name)
+	err = suite.conn.DeletePool(newName)
 	assert.NoError(suite.T(), err)
 
 	// verify that it is gone

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -493,25 +493,25 @@ func (suite *RadosTestSuite) TestCreate() {
 func (suite *RadosTestSuite) TestReadWrite() {
 	suite.SetupConnection()
 
-	bytes_in := []byte("input data")
-	err := suite.ioctx.Write("obj", bytes_in, 0)
+	bytesIn := []byte("input data")
+	err := suite.ioctx.Write("obj", bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
-	bytes_out := make([]byte, len(bytes_in))
-	n_out, err := suite.ioctx.Read("obj", bytes_out, 0)
+	bytesOut := make([]byte, len(bytesIn))
+	numOut, err := suite.ioctx.Read("obj", bytesOut, 0)
 
-	assert.Equal(suite.T(), n_out, len(bytes_in))
-	assert.Equal(suite.T(), bytes_in, bytes_out)
+	assert.Equal(suite.T(), numOut, len(bytesIn))
+	assert.Equal(suite.T(), bytesIn, bytesOut)
 
-	bytes_in = []byte("input another data")
-	err = suite.ioctx.WriteFull("obj", bytes_in)
+	bytesIn = []byte("input another data")
+	err = suite.ioctx.WriteFull("obj", bytesIn)
 	assert.NoError(suite.T(), err)
 
-	bytes_out = make([]byte, len(bytes_in))
-	n_out, err = suite.ioctx.Read("obj", bytes_out, 0)
+	bytesOut = make([]byte, len(bytesIn))
+	numOut, err = suite.ioctx.Read("obj", bytesOut, 0)
 
-	assert.Equal(suite.T(), n_out, len(bytes_in))
-	assert.Equal(suite.T(), bytes_in, bytes_out)
+	assert.Equal(suite.T(), numOut, len(bytesIn))
+	assert.Equal(suite.T(), bytesIn, bytesOut)
 }
 
 func (suite *RadosTestSuite) TestAppend() {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -137,21 +137,21 @@ func (suite *RadosTestSuite) TestGetSetConfigOption() {
 	assert.Error(suite.T(), err)
 
 	// verify SetConfigOption changes a values
-	prev_val, err := suite.conn.GetConfigOption("log_file")
+	prevVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
 	err = suite.conn.SetConfigOption("log_file", "/dev/null")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	curr_val, err := suite.conn.GetConfigOption("log_file")
+	currVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	assert.NotEqual(suite.T(), prev_val, "/dev/null")
-	assert.Equal(suite.T(), curr_val, "/dev/null")
+	assert.NotEqual(suite.T(), prevVal, "/dev/null")
+	assert.Equal(suite.T(), currVal, "/dev/null")
 }
 
 func (suite *RadosTestSuite) TestParseDefaultConfigEnv() {
-	prev_val, err := suite.conn.GetConfigOption("log_file")
+	prevVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
 	err = os.Setenv("CEPH_ARGS", "--log-file /dev/null")
@@ -160,26 +160,26 @@ func (suite *RadosTestSuite) TestParseDefaultConfigEnv() {
 	err = suite.conn.ParseDefaultConfigEnv()
 	assert.NoError(suite.T(), err)
 
-	curr_val, err := suite.conn.GetConfigOption("log_file")
+	currVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	assert.NotEqual(suite.T(), prev_val, "/dev/null")
-	assert.Equal(suite.T(), curr_val, "/dev/null")
+	assert.NotEqual(suite.T(), prevVal, "/dev/null")
+	assert.Equal(suite.T(), currVal, "/dev/null")
 }
 
 func (suite *RadosTestSuite) TestParseConfigArgv() {
-	prev_val, err := suite.conn.GetConfigOption("log_file")
+	prevVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
 	argv := []string{"rados.test", "--log_file", "/dev/null"}
 	err = suite.conn.ParseConfigArgv(argv)
 	assert.NoError(suite.T(), err)
 
-	curr_val, err := suite.conn.GetConfigOption("log_file")
+	currVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	assert.NotEqual(suite.T(), prev_val, "/dev/null")
-	assert.Equal(suite.T(), curr_val, "/dev/null")
+	assert.NotEqual(suite.T(), prevVal, "/dev/null")
+	assert.Equal(suite.T(), currVal, "/dev/null")
 
 	// ensure that an empty slice triggers an error (not a crash)
 	err = suite.conn.ParseConfigArgv([]string{})
@@ -193,26 +193,26 @@ func (suite *RadosTestSuite) TestParseConfigArgv() {
 }
 
 func (suite *RadosTestSuite) TestParseCmdLineArgs() {
-	prev_val, err := suite.conn.GetConfigOption("log_file")
+	prevVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
 	args := []string{"--log_file", "/dev/null"}
 	err = suite.conn.ParseCmdLineArgs(args)
 	assert.NoError(suite.T(), err)
 
-	curr_val, err := suite.conn.GetConfigOption("log_file")
+	currVal, err := suite.conn.GetConfigOption("log_file")
 	assert.NoError(suite.T(), err, "Invalid option")
 
-	assert.NotEqual(suite.T(), prev_val, "/dev/null")
-	assert.Equal(suite.T(), curr_val, "/dev/null")
+	assert.NotEqual(suite.T(), prevVal, "/dev/null")
+	assert.Equal(suite.T(), currVal, "/dev/null")
 }
 
 func (suite *RadosTestSuite) TestReadConfigFile() {
 	// check current log_file value
-	prev_str, err := suite.conn.GetConfigOption("log_max_new")
+	prevStr, err := suite.conn.GetConfigOption("log_max_new")
 	assert.NoError(suite.T(), err)
 
-	prev_val, err := strconv.Atoi(prev_str)
+	prevVal, err := strconv.Atoi(prevStr)
 	assert.NoError(suite.T(), err)
 
 	// create conf file that changes log_file conf option
@@ -223,8 +223,8 @@ func (suite *RadosTestSuite) TestReadConfigFile() {
 		assert.NoError(suite.T(), os.Remove(file.Name()))
 	}()
 
-	next_val := prev_val + 1
-	conf := fmt.Sprintf("[global]\nlog_max_new = %d\n", next_val)
+	nextVal := prevVal + 1
+	conf := fmt.Sprintf("[global]\nlog_max_new = %d\n", nextVal)
 	_, err = io.WriteString(file, conf)
 	assert.NoError(suite.T(), err)
 
@@ -233,14 +233,14 @@ func (suite *RadosTestSuite) TestReadConfigFile() {
 	assert.NoError(suite.T(), err)
 
 	// check current log_file value
-	curr_str, err := suite.conn.GetConfigOption("log_max_new")
+	currStr, err := suite.conn.GetConfigOption("log_max_new")
 	assert.NoError(suite.T(), err)
 
-	curr_val, err := strconv.Atoi(curr_str)
+	currVal, err := strconv.Atoi(currStr)
 	assert.NoError(suite.T(), err)
 
-	assert.NotEqual(suite.T(), prev_str, curr_str)
-	assert.Equal(suite.T(), curr_val, prev_val+1)
+	assert.NotEqual(suite.T(), prevStr, currStr)
+	assert.Equal(suite.T(), currVal, prevVal+1)
 }
 
 func (suite *RadosTestSuite) TestGetClusterStats() {

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -683,8 +683,8 @@ func (suite *RadosTestSuite) TestObjectIterator() {
 	// create an object in a different namespace to verify that
 	// iteration within a namespace does not return it
 	suite.ioctx.SetNamespace("ns1")
-	bytes_in := []byte("input data")
-	err = suite.ioctx.Write(suite.GenObjectName(), bytes_in, 0)
+	bytesIn := []byte("input data")
+	err = suite.ioctx.Write(suite.GenObjectName(), bytesIn, 0)
 	assert.NoError(suite.T(), err)
 
 	// create some objects in default namespace
@@ -692,8 +692,8 @@ func (suite *RadosTestSuite) TestObjectIterator() {
 	createdList := []string{}
 	for i := 0; i < 10; i++ {
 		oid := suite.GenObjectName()
-		bytes_in := []byte("input data")
-		err = suite.ioctx.Write(oid, bytes_in, 0)
+		bytesIn := []byte("input data")
+		err = suite.ioctx.Write(oid, bytesIn, 0)
 		assert.NoError(suite.T(), err)
 		createdList = append(createdList, oid)
 	}
@@ -743,8 +743,8 @@ func (suite *RadosTestSuite) TestObjectIteratorAcrossNamespaces() {
 	suite.ioctx.SetNamespace("nsX")
 	for i := 0; i < 10; i++ {
 		oid := suite.GenObjectName()
-		bytes_in := []byte("input data")
-		err = suite.ioctx.Write(oid, bytes_in, 0)
+		bytesIn := []byte("input data")
+		err = suite.ioctx.Write(oid, bytesIn, 0)
 		assert.NoError(suite.T(), err)
 		createdList = append(createdList, oid)
 	}
@@ -754,8 +754,8 @@ func (suite *RadosTestSuite) TestObjectIteratorAcrossNamespaces() {
 	suite.ioctx.SetNamespace("nsY")
 	for i := 0; i < 10; i++ {
 		oid := suite.GenObjectName()
-		bytes_in := []byte("input data")
-		err = suite.ioctx.Write(oid, bytes_in, 0)
+		bytesIn := []byte("input data")
+		err = suite.ioctx.Write(oid, bytesIn, 0)
 		assert.NoError(suite.T(), err)
 		createdList = append(createdList, oid)
 	}

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -763,39 +763,39 @@ func TestReadAt(t *testing.T) {
 	assert.NoError(t, err)
 
 	// write 0 bytes should succeed
-	data_out := make([]byte, 0)
-	n_out, err := img.WriteAt(data_out, 256)
-	assert.Equal(t, 0, n_out)
+	dataOut := make([]byte, 0)
+	numOut, err := img.WriteAt(dataOut, 256)
+	assert.Equal(t, 0, numOut)
 	assert.NoError(t, err)
 
 	// reading 0 bytes should be successful
-	data_in := make([]byte, 0)
-	n_in, err := img.ReadAt(data_in, 256)
-	assert.Equal(t, 0, n_in)
+	dataIn := make([]byte, 0)
+	numIn, err := img.ReadAt(dataIn, 256)
+	assert.Equal(t, 0, numIn)
 	assert.NoError(t, err)
 
 	// write some data at the end of the image
-	data_out = []byte("Hi rbd! Nice to talk through go-ceph :)")
+	dataOut = []byte("Hi rbd! Nice to talk through go-ceph :)")
 
 	stats, err := img.Stat()
 	require.NoError(t, err)
-	offset := int64(stats.Size) - int64(len(data_out))
+	offset := int64(stats.Size) - int64(len(dataOut))
 
-	n_out, err = img.WriteAt(data_out, offset)
-	assert.Equal(t, len(data_out), n_out)
+	numOut, err = img.WriteAt(dataOut, offset)
+	assert.Equal(t, len(dataOut), numOut)
 	assert.NoError(t, err)
 
-	data_in = make([]byte, len(data_out))
-	n_in, err = img.ReadAt(data_in, offset)
-	assert.Equal(t, n_in, len(data_in))
-	assert.Equal(t, data_in, data_out)
+	dataIn = make([]byte, len(dataOut))
+	numIn, err = img.ReadAt(dataIn, offset)
+	assert.Equal(t, numIn, len(dataIn))
+	assert.Equal(t, dataIn, dataOut)
 	assert.NoError(t, err)
 
 	// reading after EOF (needs to be large enough to hit EOF)
-	data_in = make([]byte, len(data_out)+256)
-	n_in, err = img.ReadAt(data_in, offset)
-	assert.Equal(t, n_in, len(data_out))
-	assert.Equal(t, data_in[0:len(data_out)], data_out)
+	dataIn = make([]byte, len(dataOut)+256)
+	numIn, err = img.ReadAt(dataIn, offset)
+	assert.Equal(t, numIn, len(dataOut))
+	assert.Equal(t, dataIn[0:len(dataOut)], dataOut)
 	assert.Equal(t, io.EOF, err)
 
 	err = img.Close()
@@ -805,7 +805,7 @@ func TestReadAt(t *testing.T) {
 	img, err = OpenImageReadOnly(ioctx, name, NoSnapshot)
 	assert.NoError(t, err)
 
-	_, err = img.WriteAt(data_out, 256)
+	_, err = img.WriteAt(dataOut, 256)
 	assert.Error(t, err)
 
 	err = img.Close()

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -682,52 +682,52 @@ func TestIOReaderWriter(t *testing.T) {
 	assert.Equal(t, &stats, &stats2)
 
 	_, err = img.Seek(0, SeekSet)
-	bytes_in := []byte("input data")
-	_, err = img.Write(bytes_in)
+	bytesIn := []byte("input data")
+	_, err = img.Write(bytesIn)
 	assert.NoError(t, err)
 
 	_, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)
 
 	// reading 0 bytes should succeed
-	nil_bytes := make([]byte, 0)
-	n_out, err := img.Read(nil_bytes)
-	assert.Equal(t, n_out, 0)
+	nothing := make([]byte, 0)
+	numOut, err := img.Read(nothing)
+	assert.Equal(t, numOut, 0)
 	assert.NoError(t, err)
 
-	bytes_out := make([]byte, len(bytes_in))
-	n_out, err = img.Read(bytes_out)
+	bytesOut := make([]byte, len(bytesIn))
+	numOut, err = img.Read(bytesOut)
 
-	assert.Equal(t, n_out, len(bytes_in))
-	assert.Equal(t, bytes_in, bytes_out)
+	assert.Equal(t, numOut, len(bytesIn))
+	assert.Equal(t, bytesIn, bytesOut)
 
 	// write some data at the end of the image
-	offset := int64(stats.Size) - int64(len(bytes_in))
+	offset := int64(stats.Size) - int64(len(bytesIn))
 
 	_, err = img.Seek(offset, SeekSet)
 	assert.NoError(t, err)
 
-	n_out, err = img.Write(bytes_in)
-	assert.Equal(t, len(bytes_in), n_out)
+	numOut, err = img.Write(bytesIn)
+	assert.Equal(t, len(bytesIn), numOut)
 	assert.NoError(t, err)
 
 	_, err = img.Seek(offset, SeekSet)
 	assert.NoError(t, err)
 
-	bytes_out = make([]byte, len(bytes_in))
-	n_out, err = img.Read(bytes_out)
-	assert.Equal(t, n_out, len(bytes_in))
-	assert.Equal(t, bytes_in, bytes_out)
+	bytesOut = make([]byte, len(bytesIn))
+	numOut, err = img.Read(bytesOut)
+	assert.Equal(t, numOut, len(bytesIn))
+	assert.Equal(t, bytesIn, bytesOut)
 	assert.NoError(t, err)
 
 	// reading after EOF (needs to be large enough to hit EOF)
 	_, err = img.Seek(offset, SeekSet)
 	assert.NoError(t, err)
 
-	bytes_in = make([]byte, len(bytes_out)+256)
-	n_out, err = img.Read(bytes_in)
-	assert.Equal(t, n_out, len(bytes_out))
-	assert.Equal(t, bytes_in[0:len(bytes_out)], bytes_out)
+	bytesIn = make([]byte, len(bytesOut)+256)
+	numOut, err = img.Read(bytesIn)
+	assert.Equal(t, numOut, len(bytesOut))
+	assert.Equal(t, bytesIn[0:len(bytesOut)], bytesOut)
 	assert.Equal(t, io.EOF, err)
 
 	err = img.Close()

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -275,8 +275,8 @@ func TestDeprecatedImageOpen(t *testing.T) {
 	err = image.Open(true)
 	assert.NoError(t, err)
 
-	bytes_in := []byte("input data")
-	_, err = image.Write(bytes_in)
+	bytesIn := []byte("input data")
+	_, err = image.Write(bytesIn)
 	// writing should fail in read-only mode
 	assert.Error(t, err)
 
@@ -442,28 +442,28 @@ func TestImageSeek(t *testing.T) {
 	_, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)
 
-	bytes_in := []byte("input data")
-	n_in, err := img.Write(bytes_in)
+	bytesIn := []byte("input data")
+	numIn, err := img.Write(bytesIn)
 	assert.NoError(t, err)
-	assert.Equal(t, n_in, len(bytes_in))
+	assert.Equal(t, numIn, len(bytesIn))
 
 	pos, err := img.Seek(0, SeekCur)
 	assert.NoError(t, err)
-	assert.Equal(t, pos, int64(n_in))
+	assert.Equal(t, pos, int64(numIn))
 
 	pos, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)
 	assert.Equal(t, pos, int64(0))
 
-	bytes_out := make([]byte, len(bytes_in))
-	n_out, err := img.Read(bytes_out)
+	bytesOut := make([]byte, len(bytesIn))
+	numOut, err := img.Read(bytesOut)
 	assert.NoError(t, err)
-	assert.Equal(t, n_out, len(bytes_out))
-	assert.Equal(t, bytes_in, bytes_out)
+	assert.Equal(t, numOut, len(bytesOut))
+	assert.Equal(t, bytesIn, bytesOut)
 
 	pos, err = img.Seek(0, SeekCur)
 	assert.NoError(t, err)
-	assert.Equal(t, pos, int64(n_out))
+	assert.Equal(t, pos, int64(numOut))
 
 	pos, err = img.Seek(0, SeekSet)
 	assert.NoError(t, err)

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -562,40 +562,40 @@ func TestWriteSame(t *testing.T) {
 	img, err := OpenImage(ioctx, name, NoSnapshot)
 	assert.NoError(t, err)
 
-	data_out := []byte("this is a string of 28 bytes")
+	dataOut := []byte("this is a string of 28 bytes")
 
 	t.Run("writeAndRead", func(t *testing.T) {
 		// write some bytes at the start of the image
-		n_out, err := img.WriteSame(0, uint64(4*len(data_out)), data_out, rados.OpFlagNone)
-		assert.Equal(t, int64(4*len(data_out)), n_out)
+		numOut, err := img.WriteSame(0, uint64(4*len(dataOut)), dataOut, rados.OpFlagNone)
+		assert.Equal(t, int64(4*len(dataOut)), numOut)
 		assert.NoError(t, err)
 
 		// the same string should be read from byte 0
-		data_in := make([]byte, len(data_out))
-		n_in, err := img.ReadAt(data_in, 0)
-		assert.Equal(t, len(data_out), n_in)
-		assert.Equal(t, data_out, data_in)
+		dataIn := make([]byte, len(dataOut))
+		numIn, err := img.ReadAt(dataIn, 0)
+		assert.Equal(t, len(dataOut), numIn)
+		assert.Equal(t, dataOut, dataIn)
 		assert.NoError(t, err)
 
 		// the same string should be read from byte 28
-		data_in = make([]byte, len(data_out))
-		n_in, err = img.ReadAt(data_in, 28)
-		assert.Equal(t, len(data_out), n_in)
-		assert.Equal(t, data_out, data_in)
+		dataIn = make([]byte, len(dataOut))
+		numIn, err = img.ReadAt(dataIn, 28)
+		assert.Equal(t, len(dataOut), numIn)
+		assert.Equal(t, dataOut, dataIn)
 		assert.NoError(t, err)
 	})
 
 	t.Run("writePartialData", func(t *testing.T) {
-		// writing a non-multiple of data_out len will fail
-		_, err = img.WriteSame(0, 64, data_out, rados.OpFlagNone)
+		// writing a non-multiple of dataOut len will fail
+		_, err = img.WriteSame(0, 64, dataOut, rados.OpFlagNone)
 		assert.Error(t, err)
 	})
 
 	t.Run("writeNoData", func(t *testing.T) {
 		// writing empty data should succeed
-		n_in, err := img.WriteSame(0, 64, []byte(""), rados.OpFlagNone)
+		numIn, err := img.WriteSame(0, 64, []byte(""), rados.OpFlagNone)
 		assert.NoError(t, err)
-		assert.Equal(t, int64(0), n_in)
+		assert.Equal(t, int64(0), numIn)
 	})
 
 	t.Run("zerofill", func(t *testing.T) {
@@ -613,9 +613,9 @@ func TestWriteSame(t *testing.T) {
 		// by the stripe-count
 		order := uint(st.Order) // signed shifting requires newer golang?!
 		zeroBlock := make([]byte, sc*(1<<order))
-		n_in, err := img.WriteSame(0, size, zeroBlock, rados.OpFlagNone)
+		numIn, err := img.WriteSame(0, size, zeroBlock, rados.OpFlagNone)
 		assert.NoError(t, err)
-		assert.Equal(t, size, uint64(n_in))
+		assert.Equal(t, size, uint64(numIn))
 
 		cmd := exec.Command("rbd", "diff", "--pool", poolname, name)
 		out, err := cmd.Output()
@@ -631,7 +631,7 @@ func TestWriteSame(t *testing.T) {
 		img, err = OpenImageReadOnly(ioctx, name, NoSnapshot)
 		assert.NoError(t, err)
 
-		_, err = img.WriteSame(96, 32, data_out, rados.OpFlagNone)
+		_, err = img.WriteSame(96, 32, dataOut, rados.OpFlagNone)
 		assert.Error(t, err)
 
 		err = img.Close()

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -1422,8 +1422,8 @@ func TestOpenImage(t *testing.T) {
 	oImage, err = OpenImageReadOnly(ioctx, name, NoSnapshot)
 	assert.NoError(t, err)
 
-	bytes_in := []byte("input data")
-	_, err = oImage.Write(bytes_in)
+	bytesIn := []byte("input data")
+	_, err = oImage.Write(bytesIn)
 	// writing should fail in read-only mode
 	assert.Error(t, err)
 


### PR DESCRIPTION

More naming cleanups.  This time mostly in the rbd test functions.

I think these changes should have fewer exceptions then the previous patches did but as these are coming out of a backlog I can't 100% guarantee it. :-)