### PR TITLE
Makefile: improve working with multi containers for devs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .build-docker
 .build.*
+.run.*
 *.swp
 *.out
 *.test


### PR DESCRIPTION
The first change adds a state file for mirroring setup to the entrypoint. It helps avoid doing extra work.

The second change adds a whole family of test-containers-* rules. The role
meant to be used directly "test-containers-test" brings up the
required dependencies once, and will reuse them on subsequent runs.
The targets "test-containers-kill" and "test-containers-clean" will
remove just the ceph containers and all dependencies respectively.

The change may look big, and I did shorten some lines, thus lengthening
the makefile vertically, but the logic is basically the same as before.
One can continue using "test-multi-container" and it should behave
pretty much as before, but outside the CI when working on code or
testing things out using the more granular rules can help speed things
up.

Example (with trimmed output):
```
$ time make   test-containers-test   USE_CACHE=1 CEPH_VERSION=pacific CONTAINER_OPTS='-e GO_CEPH_TEST_DEBUG_TRACE=true --security-opt label=disable'  RESULTS_DIR="$PWD/_results" ENTRYPOINT_ARG
S='--test-pkg=cephfs/admin --test-run=TestFoobar'
# ...
real    1m17.033s
user    0m0.676s
sys     0m0.408s


$ time make   test-containers-test   USE_CACHE=1 CEPH_VERSION=pacific CONTAINER_OPTS='-e GO_CEPH_TEST_DEBUG_TRACE=true --security-opt label=disable'  RESULTS_DIR="$PWD/_results" ENTRYPOINT_ARGS='--test-pkg=cephfs/admin --test-run=TestFoobar'
# ...
real    0m2.213s
user    0m0.242s
sys     0m0.155s
```

In this off the cuff test I went from having to wait over a minute to get my test results to 2 seconds. This is a great improvment for those like me who often develop through experimentation and only run small subsets of the tests when developing.