### PR TITLE
worfklows: update CI rules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,12 +39,12 @@ jobs:
         - "pacific"
     steps:
     - uses: actions/checkout@v2
-    - name: Run test container
-      run: make test-container "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
-    - name: Run ptrguard test container
-      run: make test-container "USE_PTRGUARD=true" "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
-    - name: Run multi-container test
-      run: make test-multi-container "USE_PTRGUARD=true" "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
+    - name: Run tests
+      run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
+    - name: Run tests with ptrguard
+      run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "USE_PTRGUARD=true" "RESULTS_DIR=$PWD/_results"
+    - name: Clean up test containers
+      run: make test-containers-clean "CEPH_VERSION=${{ matrix.ceph_version }}"
     - name: Archive coverage results
       uses: actions/upload-artifact@v2
       with:

--- a/cephfs/path_test.go
+++ b/cephfs/path_test.go
@@ -254,6 +254,9 @@ func TestSymlink(t *testing.T) {
 
 		err = mount.Symlink("/", "someDir")
 		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, mount.Unlink("someDir"))
+		}()
 
 		err = mount.Symlink("someFile", "/")
 		// Error, permission denied.

--- a/cephfs/statx_test.go
+++ b/cephfs/statx_test.go
@@ -18,7 +18,10 @@ func TestStatxFieldsRootDir(t *testing.T) {
 	assert.NotNil(t, st)
 
 	assert.Equal(t, StatxBasicStats, st.Mask&StatxBasicStats)
-	assert.Equal(t, uint32(2), st.Nlink)
+	// allow Nlink to be >= 2 in the case that some test(s) don't entirely
+	// clean up after themselves or the environment is being used outside
+	// of the go-ceph suite only.
+	assert.GreaterOrEqual(t, st.Nlink, uint32(2))
 	assert.Equal(t, uint32(0), st.Uid)
 	assert.Equal(t, uint32(0), st.Gid)
 	assert.NotEqual(t, uint16(0), st.Mode)


### PR DESCRIPTION
Depends on: #560 

These changes fix minor issues repeating the tests run on an existing cluster in cephfs.

Then we update the CI rules to allow us to share (mirror-enabled) ceph container     instances. Use this to test both non-ptrguard and prtguard test runs     while dropping the (now redundant) non-mirror-enabled ceph + tests    container run.
