### PR TITLE
rgw/admin: add apis for handling UserCap

### DIFF
--- a/rgw/admin/caps.go
+++ b/rgw/admin/caps.go
@@ -1,0 +1,62 @@
+// +build ceph_preview
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// AddUserCap adds the capabilities for a user.
+// On Success, it returns the updated list of UserCaps for the user.
+// PREVIEW
+func (api *API) AddUserCap(ctx context.Context, uid, userCap string) ([]UserCapSpec, error) {
+	if uid == "" {
+		return nil, errMissingUserID
+	}
+	if userCap == "" {
+		return nil, errMissingUserCap
+	}
+
+	user := User{ID: uid, UserCaps: userCap}
+	body, err := api.call(ctx, http.MethodPut, "/user?caps", valueToURLParams(user))
+	if err != nil {
+		return nil, err
+	}
+
+	var ref []UserCapSpec
+	err = json.Unmarshal(body, &ref)
+	if err != nil {
+		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+	}
+
+	return ref, nil
+}
+
+// RemoveUserCap removes the capabilities from a user.
+// On Success, it returns the updated list of UserCaps for the user.
+// PREVIEW
+func (api *API) RemoveUserCap(ctx context.Context, uid, userCap string) ([]UserCapSpec, error) {
+	if uid == "" {
+		return nil, errMissingUserID
+	}
+	if userCap == "" {
+		return nil, errMissingUserCap
+	}
+
+	user := User{ID: uid, UserCaps: userCap}
+	body, err := api.call(ctx, http.MethodDelete, "/user?caps", valueToURLParams(user))
+	if err != nil {
+		return nil, err
+	}
+
+	var ref []UserCapSpec
+	err = json.Unmarshal(body, &ref)
+	if err != nil {
+		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+	}
+
+	return ref, nil
+}

--- a/rgw/admin/caps_test.go
+++ b/rgw/admin/caps_test.go
@@ -1,0 +1,69 @@
+// +build ceph_preview
+
+package admin
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosGWTestSuite) TestCaps() {
+	suite.SetupConnection()
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
+
+	assert.NoError(suite.T(), err)
+	suite.T().Run("create test user", func(t *testing.T) {
+		user, err := co.CreateUser(context.Background(), User{ID: "test", DisplayName: "test-user", Email: "test@example.com"})
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), "test", user.ID)
+		assert.Zero(suite.T(), len(user.Caps))
+	})
+
+	suite.T().Run("add caps to the user but user ID is empty", func(t *testing.T) {
+		_, err := co.AddUserCap(context.Background(), "", "users=read")
+		assert.Error(suite.T(), err)
+		assert.EqualError(suite.T(), err, errMissingUserID.Error())
+	})
+
+	suite.T().Run("add caps to the user but no cap is specified", func(t *testing.T) {
+		_, err := co.AddUserCap(context.Background(), "test", "")
+		assert.Error(suite.T(), err)
+		assert.EqualError(suite.T(), err, errMissingUserCap.Error())
+
+	})
+
+	suite.T().Run("add caps to the user, returns success", func(t *testing.T) {
+		usercap, err := co.AddUserCap(context.Background(), "test", "users=read")
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), "users", usercap[0].Type)
+		assert.Equal(suite.T(), "read", usercap[0].Perm)
+
+	})
+
+	suite.T().Run("remove caps from the user but user ID is empty", func(t *testing.T) {
+		_, err := co.RemoveUserCap(context.Background(), "", "users=read")
+		assert.Error(suite.T(), err)
+		assert.EqualError(suite.T(), err, errMissingUserID.Error())
+	})
+
+	suite.T().Run("remove caps from the user but no cap is specified", func(t *testing.T) {
+		_, err := co.RemoveUserCap(context.Background(), "test", "")
+		assert.Error(suite.T(), err)
+		assert.EqualError(suite.T(), err, errMissingUserCap.Error())
+
+	})
+
+	suite.T().Run("remove caps from the user returns success", func(t *testing.T) {
+		usercap, err := co.RemoveUserCap(context.Background(), "test", "users=read")
+		assert.NoError(suite.T(), err)
+		assert.Zero(suite.T(), len(usercap))
+	})
+
+	suite.T().Run("delete test user", func(t *testing.T) {
+		err := co.RemoveUser(context.Background(), User{ID: "test"})
+		assert.NoError(suite.T(), err)
+	})
+}

--- a/rgw/admin/errors.go
+++ b/rgw/admin/errors.go
@@ -88,6 +88,7 @@ const (
 var (
 	errMissingUserID          = errors.New("missing user ID")
 	errMissingUserDisplayName = errors.New("missing user display name")
+	errMissingUserCap         = errors.New("missing user capabilities")
 )
 
 // errorReason is the reason of the error


### PR DESCRIPTION
Added two apis AddUserCap() and RemoveUserCap() to add/remove the
capabilities from RGW user.
    
 Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>
<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
