### PR TITLE
entrypoint: show return values of tests

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -128,8 +128,14 @@ if [ -n "${BUILD_TAGS}" ]; then
 fi
 
 show() {
+    local ret
     echo "*** running:" "$@"
     "$@"
+    ret=$?
+    if [ ${ret} -ne 0 ] ; then
+        echo "*** ERROR: returned ${ret}"
+    fi
+    return ${ret}
 }
 
 wait_for_files() {


### PR DESCRIPTION
This might help a bit with flakey tests.

Signed-off-by: Sven Anderson <sven@redhat.com>
