### PR TITLE
Use the ceph_preview tag by default in our CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,12 @@ ifneq ($(USE_PTRGUARD),)
 	BUILD_TAGS := $(BUILD_TAGS),ptrguard
 endif
 
+ifneq ($(NO_PREVIEW),)
+	CONTAINER_OPTS += -e NO_PREVIEW=true
+else
+	BUILD_TAGS := $(BUILD_TAGS),ceph_preview
+endif
+
 ifneq ($(USE_CACHE),)
 	GOCACHE_VOLUME := -v test_ceph_go_cache:/go
 endif

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,21 +115,14 @@ while true ; do
     esac
 done
 
-if [ -n "${CEPH_VERSION}" ]; then
-    BUILD_TAGS="${CEPH_VERSION}"
-fi
-
-if [ -n "${USE_PTRGUARD}" ]; then
-    BUILD_TAGS+=",ptrguard"
-fi
-
-if [ -z "${NO_PREVIEW}" ]; then
-    BUILD_TAGS+=",ceph_preview"
-fi
-
-if [ -n "${BUILD_TAGS}" ]; then
-    BUILD_TAGS="-tags ${BUILD_TAGS}"
-fi
+add_build_tag() {
+    local val="$1"
+    if [ -n "$BUILD_TAGS" ]; then
+        BUILD_TAGS+=",${val}"
+    else
+        BUILD_TAGS="${val}"
+    fi
+}
 
 show() {
     local ret
@@ -296,6 +289,23 @@ pause_if_needed() {
         sleep infinity
     fi
 }
+
+
+if [ -n "${CEPH_VERSION}" ]; then
+    add_build_tag "${CEPH_VERSION}"
+fi
+
+if [ -n "${USE_PTRGUARD}" ]; then
+    add_build_tag "ptrguard"
+fi
+
+if [ -z "${NO_PREVIEW}" ]; then
+    add_build_tag "ceph_preview"
+fi
+
+if [ -n "${BUILD_TAGS}" ]; then
+    BUILD_TAGS="-tags ${BUILD_TAGS}"
+fi
 
 test_go_ceph
 pause_if_needed

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -123,6 +123,10 @@ if [ -n "${USE_PTRGUARD}" ]; then
     BUILD_TAGS+=",ptrguard"
 fi
 
+if [ -z "${NO_PREVIEW}" ]; then
+    BUILD_TAGS+=",ceph_preview"
+fi
+
 if [ -n "${BUILD_TAGS}" ]; then
     BUILD_TAGS="-tags ${BUILD_TAGS}"
 fi


### PR DESCRIPTION
By default we want our ci to run with the `ceph_preview` tag (see the recent [api-stability policy](https://github.com/ceph/go-ceph/tree/master//docs/api-stability.md)).
In the Makefile and entrypoint.sh we support setting NO_PREVIEW in order to skip the ceph_preview tag and test only non-preview api calls.

This pr currently contains a patch with a "canary" test that intentionally fails when build with the preview tag. This is make sure things are being plumbed through correctly. It should be dropped from the PR prior to merge.