### PR TITLE
docs: update comments of preview and deprecated APIs to new style 

### DIFF
--- a/cephfs/admin/bytecount.go
+++ b/cephfs/admin/bytecount.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/clone.go
+++ b/cephfs/admin/clone.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/clone_test.go
+++ b/cephfs/admin/clone_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/flags.go
+++ b/cephfs/admin/flags.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/fsadmin_test.go
+++ b/cephfs/admin/fsadmin_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/mirror_workflow_test.go
+++ b/cephfs/admin/mirror_workflow_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus && !octopus
 // +build !nautilus,!octopus
 
 package admin

--- a/cephfs/admin/response.go
+++ b/cephfs/admin/response.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/subvolume.go
+++ b/cephfs/admin/subvolume.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/subvolume_test.go
+++ b/cephfs/admin/subvolume_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/subvolumegroup.go
+++ b/cephfs/admin/subvolumegroup.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/subvolumegroup_test.go
+++ b/cephfs/admin/subvolumegroup_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/timestamp.go
+++ b/cephfs/admin/timestamp.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/timestamp_test.go
+++ b/cephfs/admin/timestamp_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/volume.go
+++ b/cephfs/admin/volume.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/volume_test.go
+++ b/cephfs/admin/volume_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/admin/workflow_test.go
+++ b/cephfs/admin/workflow_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package admin

--- a/cephfs/conn_nautilus.go
+++ b/cephfs/conn_nautilus.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package cephfs

--- a/cephfs/conn_nautilus_test.go
+++ b/cephfs/conn_nautilus_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package cephfs

--- a/cephfs/mount_perms_mimic.go
+++ b/cephfs/mount_perms_mimic.go
@@ -1,4 +1,6 @@
+//go:build !luminous
 // +build !luminous
+
 //
 // ceph_mount_perms_set available in mimic & later
 

--- a/cephfs/mount_perms_mimic_test.go
+++ b/cephfs/mount_perms_mimic_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous
 // +build !luminous
 
 package cephfs

--- a/contrib/implements/internal/implements/gosrc.go
+++ b/contrib/implements/internal/implements/gosrc.go
@@ -85,11 +85,11 @@ func readDocComment(fdec *ast.FuncDecl, gfunc *goFunction) {
 	gfunc.comment = fdec.Doc.Text()
 	lines := strings.Split(gfunc.comment, "\n")
 	for i := range lines {
-		if strings.Contains(lines[i], "DEPRECATED") {
+		if strings.HasPrefix(lines[i], "Deprecated: ") {
 			gfunc.isDeprecated = true
 			logger.Printf("marked deprecated: %s\n", fdec.Name.Name)
 		}
-		if strings.Contains(lines[i], "PREVIEW") {
+		if strings.HasPrefix(lines[i], " PREVIEW") {
 			gfunc.isPreview = true
 			logger.Printf("marked preview: %s\n", fdec.Name.Name)
 		}

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -17,12 +17,13 @@ convention in the Go community.
 ## Deprecated
 
 This is a level for APIs that should not be used for new code. These are marked
-with _DEPRECATED_ in the documentation. During 0.x releases these APIs might get
-removed in a future release, especially the 1.0 release, so we recommend
-refactoring the code at the earliest convenience. After the 1.0 release,
-deprecated APIs will not be removed, however they are still deprecated and only
-in maintanence mode. We usually don't make improvements for these APIs and we
-can't guarantee optimal performance.
+as deprecated according to Go conventions in the documentation (that is, a
+paragraph beginning with _Deprecated:_). During 0.x releases these APIs
+might get removed in a future release, especially the 1.0 release, so we
+recommend refactoring the code at the earliest convenience. After the 1.0
+release, deprecated APIs will not be removed, however they are still deprecated
+and only in maintanence mode. We usually don't make improvements for these APIs
+and we can't guarantee optimal performance.
 
 ## Preview
 

--- a/internal/cutil/sync_buffer.go
+++ b/internal/cutil/sync_buffer.go
@@ -1,3 +1,4 @@
+//go:build ptrguard
 // +build ptrguard
 
 package cutil

--- a/internal/cutil/sync_buffer_memcpy.go
+++ b/internal/cutil/sync_buffer_memcpy.go
@@ -1,3 +1,4 @@
+//go:build !ptrguard
 // +build !ptrguard
 
 package cutil

--- a/rados/command_mimic_test.go
+++ b/rados/command_mimic_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous
 // +build !luminous
 
 package rados

--- a/rados/ioctx_nautilus.go
+++ b/rados/ioctx_nautilus.go
@@ -1,3 +1,4 @@
+//go:build nautilus
 // +build nautilus
 
 package rados

--- a/rados/ioctx_nautilus_test.go
+++ b/rados/ioctx_nautilus_test.go
@@ -1,3 +1,4 @@
+//go:build nautilus
 // +build nautilus
 
 package rados

--- a/rados/ioctx_octopus.go
+++ b/rados/ioctx_octopus.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package rados

--- a/rados/ioctx_octopus_test.go
+++ b/rados/ioctx_octopus_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package rados

--- a/rados/rados_nautilus.go
+++ b/rados/rados_nautilus.go
@@ -1,3 +1,4 @@
+//go:build !mimic
 // +build !mimic
 
 package rados

--- a/rbd/admin/admin.go
+++ b/rbd/admin/admin.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package admin

--- a/rbd/admin/admin_test.go
+++ b/rbd/admin/admin_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package admin

--- a/rbd/admin/common_test.go
+++ b/rbd/admin/common_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package admin

--- a/rbd/admin/imagespec.go
+++ b/rbd/admin/imagespec.go
@@ -1,3 +1,4 @@
+//go:build !nautilus && ceph_preview
 // +build !nautilus,ceph_preview
 
 package admin

--- a/rbd/admin/imagespec.go
+++ b/rbd/admin/imagespec.go
@@ -9,18 +9,19 @@ import (
 // ImageSpec values are used to identify an RBD image wherever Ceph APIs
 // require an image_spec/image_id_spec using image name/id and optional
 // pool and namespace.
-// PREVIEW
+//  PREVIEW
 type ImageSpec struct {
 	spec string
 }
 
 // NewImageSpec is used to construct an ImageSpec given an image name/id
 // and optional namespace and pool names.
+//  PREVIEW
+//
 // NewImageSpec constructs an ImageSpec to identify an RBD image and thus
 // requires image name/id, whereas NewLevelSpec constructs LevelSpec to
 // identify entire pool, pool namespace or single RBD image, all of which
 // requires pool name.
-// PREVIEW
 func NewImageSpec(pool, namespace, image string) ImageSpec {
 	var s string
 	if pool != "" && namespace != "" {
@@ -34,10 +35,11 @@ func NewImageSpec(pool, namespace, image string) ImageSpec {
 }
 
 // NewRawImageSpec returns a ImageSpec directly based on the spec string
-// argument without constructing it from component values. This should only be
-// used if NewImageSpec can not create the imagespec value you want to pass to
-// ceph.
-// PREVIEW
+// argument without constructing it from component values.
+//  PREVIEW
+//
+// This should only be used if NewImageSpec can not create the imagespec value
+// you want to pass to ceph.
 func NewRawImageSpec(spec string) ImageSpec {
 	return ImageSpec{spec}
 }

--- a/rbd/admin/imagespec_test.go
+++ b/rbd/admin/imagespec_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus && ceph_preview
 // +build !nautilus,ceph_preview
 
 package admin

--- a/rbd/admin/msschedule.go
+++ b/rbd/admin/msschedule.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package admin

--- a/rbd/admin/msschedule_complex_test.go
+++ b/rbd/admin/msschedule_complex_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package admin

--- a/rbd/admin/msschedule_test.go
+++ b/rbd/admin/msschedule_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package admin

--- a/rbd/admin/task.go
+++ b/rbd/admin/task.go
@@ -7,22 +7,20 @@ import (
 	"github.com/ceph/go-ceph/internal/commands"
 )
 
-// TaskAdmin encapsulates management functions for
-// ceph rbd task operations.
-// PREVIEW
+// TaskAdmin encapsulates management functions for ceph rbd task operations.
+//  PREVIEW
 type TaskAdmin struct {
 	conn ccom.MgrCommander
 }
 
-// Task returns a TaskAdmin type for
-// managing ceph rbd task operations.
-// PREVIEW
+// Task returns a TaskAdmin type for managing ceph rbd task operations.
+//  PREVIEW
 func (ra *RBDAdmin) Task() *TaskAdmin {
 	return &TaskAdmin{conn: ra.conn}
 }
 
 // TaskRefs contains the action name and information about the image.
-// PREVIEW
+//  PREVIEW
 type TaskRefs struct {
 	Action        string `json:"action"`
 	PoolName      string `json:"pool_name"`
@@ -32,7 +30,7 @@ type TaskRefs struct {
 }
 
 // TaskResponse contains the information about the task added on an image.
-// PREVIEW
+//  PREVIEW
 type TaskResponse struct {
 	Sequence      int      `json:"sequence"`
 	ID            string   `json:"id"`
@@ -57,11 +55,12 @@ func parseTaskResponseList(res commands.Response) ([]TaskResponse, error) {
 	return taskResponseList, err
 }
 
-// AddFlatten adds a background task to flatten a cloned image based on the supplied image spec.
+// AddFlatten adds a background task to flatten a cloned image based on the
+// supplied image spec.
+//  PREVIEW
 //
 // Similar To:
 //  rbd task add flatten <image_spec>
-// PREVIEW
 func (ta *TaskAdmin) AddFlatten(img ImageSpec) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":     "rbd task add flatten",
@@ -71,11 +70,12 @@ func (ta *TaskAdmin) AddFlatten(img ImageSpec) (TaskResponse, error) {
 	return parseTaskResponse(commands.MarshalMgrCommand(ta.conn, m))
 }
 
-// AddRemove adds a background task to remove an image based on the supplied image spec.
+// AddRemove adds a background task to remove an image based on the supplied
+// image spec.
+//  PREVIEW
 //
 // Similar To:
 //  rbd task add remove <image_spec>
-// PREVIEW
 func (ta *TaskAdmin) AddRemove(img ImageSpec) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":     "rbd task add remove",
@@ -85,12 +85,12 @@ func (ta *TaskAdmin) AddRemove(img ImageSpec) (TaskResponse, error) {
 	return parseTaskResponse(commands.MarshalMgrCommand(ta.conn, m))
 }
 
-// AddTrashRemove adds a background task to remove an image from the trash based on the
-// supplied image id spec.
+// AddTrashRemove adds a background task to remove an image from the trash based
+// on the supplied image id spec.
+//  PREVIEW
 //
 // Similar To:
 //  rbd task add trash remove <image_id_spec>
-// PREVIEW
 func (ta *TaskAdmin) AddTrashRemove(img ImageSpec) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":        "rbd task add trash remove",
@@ -101,10 +101,10 @@ func (ta *TaskAdmin) AddTrashRemove(img ImageSpec) (TaskResponse, error) {
 }
 
 // List pending or running asynchronous tasks.
+//  PREVIEW
 //
 // Similar To:
 //  rbd task list
-// PREVIEW
 func (ta *TaskAdmin) List() ([]TaskResponse, error) {
 	m := map[string]string{
 		"prefix": "rbd task list",
@@ -114,10 +114,10 @@ func (ta *TaskAdmin) List() ([]TaskResponse, error) {
 }
 
 // GetTaskByID returns pending or running asynchronous task using id.
+//  PREVIEW
 //
 // Similar To:
 //  rbd task list <task_id>
-// PREVIEW
 func (ta *TaskAdmin) GetTaskByID(taskID string) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":  "rbd task list",
@@ -128,10 +128,10 @@ func (ta *TaskAdmin) GetTaskByID(taskID string) (TaskResponse, error) {
 }
 
 // Cancel a pending or running asynchronous task.
+//  PREVIEW
 //
 // Similar To:
 //  rbd task cancel <task_id>
-// PREVIEW
 func (ta *TaskAdmin) Cancel(taskID string) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":  "rbd task cancel",

--- a/rbd/admin/task.go
+++ b/rbd/admin/task.go
@@ -1,3 +1,4 @@
+//go:build !nautilus && ceph_preview
 // +build !nautilus,ceph_preview
 
 package admin

--- a/rbd/admin/task_test.go
+++ b/rbd/admin/task_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus && ceph_preview
 // +build !nautilus,ceph_preview
 
 package admin

--- a/rbd/encryption.go
+++ b/rbd/encryption.go
@@ -1,3 +1,4 @@
+//go:build !octopus && !nautilus
 // +build !octopus,!nautilus
 
 package rbd

--- a/rbd/encryption_test.go
+++ b/rbd/encryption_test.go
@@ -1,3 +1,4 @@
+//go:build !octopus && !nautilus
 // +build !octopus,!nautilus
 
 package rbd

--- a/rbd/features_nautilus.go
+++ b/rbd/features_nautilus.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package rbd

--- a/rbd/features_nautilus_test.go
+++ b/rbd/features_nautilus_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package rbd

--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 // Initially, we're only providing mirroring related functions for octopus as

--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -746,7 +746,9 @@ func (iter *MirrorImageGlobalStatusIter) Next() (*GlobalMirrorImageIDAndStatus, 
 }
 
 // Close terminates iteration regardless if iteration was completed and
-// frees any associated resources. (DEPRECATED)
+// frees any associated resources.
+//
+// Deprecated: not required
 func (*MirrorImageGlobalStatusIter) Close() error {
 	return nil
 }

--- a/rbd/mirror_test.go
+++ b/rbd/mirror_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 // Initially, we're only providing mirroring related functions for octopus as

--- a/rbd/namespace_nautilus.go
+++ b/rbd/namespace_nautilus.go
@@ -1,4 +1,6 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
+
 //
 // Ceph Nautilus is the first release that includes rbd_namespace_create(),
 // rbd_namespace_remove(), rbd_namespace_exists() and rbd_namespace_list().

--- a/rbd/namespace_nautilus_test.go
+++ b/rbd/namespace_nautilus_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package rbd

--- a/rbd/options_octopus.go
+++ b/rbd/options_octopus.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package rbd

--- a/rbd/pool_nautilus.go
+++ b/rbd/pool_nautilus.go
@@ -1,4 +1,6 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
+
 //
 // Ceph Nautilus is the first release that includes rbd_pool_metadata_get(),
 // rbd_pool_metadata_set() and rbd_pool_metadata_remove().

--- a/rbd/pool_nautilus_test.go
+++ b/rbd/pool_nautilus_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package rbd

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -327,11 +327,9 @@ func (image *Image) Rename(destname string) error {
 	return err
 }
 
-// Open the rbd image (DEPRECATED).
+// Open the rbd image.
 //
-// Deprecated: The Open function was provided in earlier versions of the API
-// and now exists to support older code. The use of OpenImage and
-// OpenImageReadOnly is preferred.
+// Deprecated: use OpenImage and OpenImageReadOnly instead
 func (image *Image) Open(args ...interface{}) error {
 	if err := image.validate(imageNeedsIOContext | imageNeedsName); err != nil {
 		return err

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -1,4 +1,6 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
+
 //
 // Ceph Nautilus is the first release that includes rbd_list2() and
 // rbd_get_create_timestamp().

--- a/rbd/rbd_nautilus_test.go
+++ b/rbd/rbd_nautilus_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
 
 package rbd

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -147,9 +147,10 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 	return cIsProtected != 0, nil
 }
 
-// Set updates the rbd image (not the Snapshot) such that the snapshot
-// is the source of readable data (DEPRECATED).
-// Refer the SetSnapshot method of the Image type instead.
+// Set updates the rbd image (not the Snapshot) such that the snapshot is the
+// source of readable data.
+//
+// Deprecated: use the SetSnapshot method of the Image type instead
 //
 // Implements:
 //  int rbd_snap_set(rbd_image_t image, const char *snapname);

--- a/rbd/snapshot_namespace.go
+++ b/rbd/snapshot_namespace.go
@@ -1,4 +1,6 @@
+//go:build !luminous
 // +build !luminous
+
 //
 // Ceph Mimic introduced rbd_snap_get_namespace_type().
 

--- a/rbd/snapshot_namespace_test.go
+++ b/rbd/snapshot_namespace_test.go
@@ -1,3 +1,4 @@
+//go:build !luminous
 // +build !luminous
 
 package rbd

--- a/rbd/snapshot_nautilus.go
+++ b/rbd/snapshot_nautilus.go
@@ -1,4 +1,6 @@
+//go:build !luminous && !mimic
 // +build !luminous,!mimic
+
 //
 // Ceph Nautilus introduced rbd_get_parent() and deprecated rbd_get_parent_info().
 // Ceph Nautilus introduced rbd_list_children3() and deprecated rbd_list_children().

--- a/rbd/snapshot_octopus.go
+++ b/rbd/snapshot_octopus.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package rbd

--- a/rbd/snapshot_octopus_test.go
+++ b/rbd/snapshot_octopus_test.go
@@ -1,3 +1,4 @@
+//go:build !nautilus
 // +build !nautilus
 
 package rbd

--- a/rgw/admin/caps.go
+++ b/rgw/admin/caps.go
@@ -10,8 +10,9 @@ import (
 )
 
 // AddUserCap adds the capabilities for a user.
+//  PREVIEW
+//
 // On Success, it returns the updated list of UserCaps for the user.
-// PREVIEW
 func (api *API) AddUserCap(ctx context.Context, uid, userCap string) ([]UserCapSpec, error) {
 	if uid == "" {
 		return nil, errMissingUserID
@@ -36,8 +37,9 @@ func (api *API) AddUserCap(ctx context.Context, uid, userCap string) ([]UserCapS
 }
 
 // RemoveUserCap removes the capabilities from a user.
+//  PREVIEW
+//
 // On Success, it returns the updated list of UserCaps for the user.
-// PREVIEW
 func (api *API) RemoveUserCap(ctx context.Context, uid, userCap string) ([]UserCapSpec, error) {
 	if uid == "" {
 		return nil, errMissingUserID

--- a/rgw/admin/caps.go
+++ b/rgw/admin/caps.go
@@ -1,3 +1,4 @@
+//go:build ceph_preview
 // +build ceph_preview
 
 package admin

--- a/rgw/admin/caps_test.go
+++ b/rgw/admin/caps_test.go
@@ -1,3 +1,4 @@
+//go:build ceph_preview
 // +build ceph_preview
 
 package admin


### PR DESCRIPTION
In order to make comment style more consistent and improve the generated HTML docs, this change

- updates the API stability document to use standard Go convention for deprecated APIs
- updates the implements tool accordingly
- refactors all comments of preview and deprecated APIs into consistent style
  - `Deprecated:` paragraph always follows the first sentence.
  - `PREVIEW` keyword always follows the first sentence in a separate line and indented with one additional space, so that it is rendered as pre-formatted text, which is more prominent.
