### PR TITLE
ptrguard: simplify pointer size assert

### DIFF
--- a/internal/cutil/ptrguard.go
+++ b/internal/cutil/ptrguard.go
@@ -60,10 +60,10 @@ func (v *PtrGuard) Release() {
 // The uintptrPtr() helper function below assumes that uintptr has the same size
 // as a pointer, although in theory it could be larger.  Therefore we use this
 // constant expression to assert size equality as a safeguard at compile time.
-// How it works: the difference of both sizes is converted into an 8 bit value
-// and left-bit-shifted by 8.  This always creates an overflow error at compile
-// time, if the difference of the sizes is not 0.
-const _ = uint8(unsafe.Sizeof(uintptr(0))-PtrSize) << 8 // size assert
+// How it works: if sizes are different, either the inner or outer expression is
+// negative, which always fails with "constant ... overflows uintptr", because
+// unsafe.Sizeof() is a uintptr typed constant.
+const _ = -(unsafe.Sizeof(uintptr(0)) - PtrSize) // size assert
 func uintptrPtr(p *CPtr) *uintptr {
 	return (*uintptr)(unsafe.Pointer(p))
 }


### PR DESCRIPTION
Some linters complain about the old expression. Although purely cosmetic, I came up with a simpler expression, that does not create warnings.

Signed-off-by: Sven Anderson <sven@redhat.com>
