### PR TITLE
contrib: encode a simple version of the api stability policy into apiage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,3 +22,4 @@ Thank you for opening a pull request. Please provide:
 - [ ] Added tests for features and functional changes
 - [ ] Public functions and types are documented
 - [ ] Standard formatting is applied to Go code
+- [ ] Is this a new API? Is this new API marked PREVIEW?

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,18 @@ implements:
 check-implements: implements
 	./implements $(IMPLEMENTS_OPTS) ./cephfs ./rados ./rbd
 
+
+api-check:
+	./contrib/apiage.py
+
+api-update:
+	./contrib/apiage.py --mode=update \
+		--current-tag="$$(git describe --tags --abbrev=0)"
+
+api-doc:
+	./contrib/apiage.py --mode=write-doc
+
+
 # force_go_build is phony and builds nothing, can be used for forcing
 # go toolchain commands to always run
-.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements
+.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements api-check api-update api-doc

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,9 @@ implements:
 check-implements: implements
 	./implements $(IMPLEMENTS_OPTS) ./cephfs ./rados ./rbd
 
+clean-implements:
+	$(RM) ./implements
+
 
 api-check: implements-json
 	./contrib/apiage.py
@@ -234,4 +237,4 @@ $(IMPLEMENTS_DIR)/implements.json: $(BUILDFILE)
 
 # force_go_build is phony and builds nothing, can be used for forcing
 # go toolchain commands to always run
-.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements api-check api-update api-doc implements-json
+.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements clean-implements api-check api-update api-doc implements-json

--- a/Makefile
+++ b/Makefile
@@ -211,17 +211,27 @@ check-implements: implements
 	./implements $(IMPLEMENTS_OPTS) ./cephfs ./rados ./rbd
 
 
-api-check:
+api-check: implements-json
 	./contrib/apiage.py
 
-api-update:
+api-update: implements-json
 	./contrib/apiage.py --mode=update \
 		--current-tag="$$(git describe --tags --abbrev=0)"
 
 api-doc:
 	./contrib/apiage.py --mode=write-doc
 
+ifeq ($(RESULTS_DIR),)
+IMPLEMENTS_DIR:=$(PWD)/_results
+else
+IMPLEMENTS_DIR:=$(RESULTS_DIR)
+endif
+
+implements-json: $(IMPLEMENTS_DIR)/implements.json
+
+$(IMPLEMENTS_DIR)/implements.json: $(BUILDFILE)
+	$(MAKE) RESULTS_DIR="$(IMPLEMENTS_DIR)" ENTRYPOINT_ARGS="--test-run=IMPLEMENTS --micro-osd=/bin/true $(ENTRYPOINT_ARGS)" test-container
 
 # force_go_build is phony and builds nothing, can be used for forcing
 # go toolchain commands to always run
-.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements api-check api-update api-doc
+.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements api-check api-update api-doc implements-json

--- a/contrib/apiage.py
+++ b/contrib/apiage.py
@@ -278,6 +278,12 @@ def main():
     api_src = read_json(cli.source) if cli.source else {}
     api_tracked = read_json(cli.current) if cli.current else {}
 
+    if not api_src:
+        print(
+            f"error: no source data found (path: {cli.source})", file=sys.stderr
+        )
+        sys.exit(1)
+
     if cli.current_tag:
         tag_to_versions(cli, cli.current_tag)
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -33,7 +33,7 @@ only available, if the build tag `ceph_preview` is set. There might be breaking
 changes in future releases regarding preview APIs. Usually new exported APIs are
 introduced with this level first and become stable when there were no major
 changes to the API for two releases. The schedule for preview APIs becoming
-stable is tracked in a separate document (link TBD).
+stable is tracked in a [separate document](./api-status.md).
 
 Please note that while these APIs are still considered "unstable", this is not
 true for the quality of their implementations, which we regard as stable and

--- a/docs/development.md
+++ b/docs/development.md
@@ -139,6 +139,51 @@ record a simplified version of the command it most closely matches. Example:
 //  ceph fs subvolume ls <volume> --group-name=<group>
 ```
 
+Recently, go-ceph has adopted an [API Stability Policy](./api-stability.md) to
+help users of our library know what APIs are deprecated and what APIs are
+available for preview.  In short, APIs that are deprecated must contain a line
+starting with "Deprecated:" and APIs that are preview must contain a line
+starting with " PREVIEW".
+
+Deprecated function Example:
+
+```
+// AllocateBlocks pre-allocates the specified number of memory blocks
+// for caching.
+//
+// Deprecated: this API is no longer supported.
+//
+// Implements.
+//  int allocate_blocks(...)
+```
+
+Preview function example:
+
+```
+// Energize the particle buffers with anti-nutrinos. This can be used to
+// warm up the Heisenberg compensator.
+//  PREVIEW
+//
+// Implements:
+//  int energize(...)
+```
+
+### API Status
+
+In order to better track the status of our deprecated and preview APIs we have
+an [API Status document](./api-status.md). This document is generated from a
+JSON file in our `docs/` directory. When a new API is being added, one or more
+additional patches need to be provided to update the API status doc and JSON
+file. If you have no unusual requirements, you can run `make api-udpate` and
+commit the changes that have been made to the `docs/` directory.
+
+This command will automatically update the `api-status.*` files, indicating
+that the API is added in the next expected release and will become stable
+two release after that. If you need to, you can customize this behavior
+by editing the JSON file by hand, or running `./contib/apiage.py` with
+different options, followed by running `make api-doc` to update the generated
+markdown file.
+
 
 ## Testing
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -234,7 +234,7 @@ pre_all_tests() {
     # Prepare Go code
     go get -t -v ${BUILD_TAGS} ./...
     diff -u <(echo -n) <(gofmt -d -s .)
-    make implements
+    make clean-implements implements
 
     # Reset whole-module coverage file
     echo "mode: count" > "cover.out"


### PR DESCRIPTION
Fixes #590 
Fixes #593

Adds defaults to apiage to derive a simple version of the policy in code, deriving from the current git tag.
Adds makefile rules for contributors to use.