### PR TITLE
rados: Make "operation" code comply to pointer passing rules

### DIFF
--- a/rados/read_op.go
+++ b/rados/read_op.go
@@ -77,8 +77,8 @@ func (r *ReadOp) GetOmapValues(startAfter, filterPrefix string, maxReturn uint64
 		gos.cFilterPrefix,
 		C.uint64_t(gos.maxReturn),
 		&gos.iter,
-		&gos.more,
-		&gos.rval,
+		gos.more,
+		gos.rval,
 	)
 	return gos
 }

--- a/rados/write_step.go
+++ b/rados/write_step.go
@@ -25,7 +25,7 @@ type writeStep struct {
 func newWriteStep(b []byte, writeLen, offset uint64) *writeStep {
 	return &writeStep{
 		b:         b,
-		cBuffer:   (*C.char)(unsafe.Pointer(&b[0])),
+		cBuffer:   (*C.char)(unsafe.Pointer(&b[0])), // TODO: must be pinned
 		cDataLen:  C.size_t(len(b)),
 		cWriteLen: C.size_t(writeLen),
 		cOffset:   C.uint64_t(offset),


### PR DESCRIPTION
In #581 we discovered, that we are actually violating the pointer passing rules in some places. For the write buffer of the `writeStep`s this change uses a `PtrGuard`, while the return parameters of `GetOmapStep`s are allocated in C memory.

Related: #584 
