### PR TITLE
CI: use golangci-lint as linter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.47.3
+        version: latest
 
         # Optional: working directory, useful for monorepos
         # working-directory: somedir

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,48 +17,79 @@ on:
 jobs:
   # Run static/code-quality checks
   check:
+    name: lint
     runs-on: ubuntu-latest
+    # strategy:
+    #   fail-fast: false
+    #   matrix:
+    #     ceph_version:
+    #     # - "nautilus"
+    #     # - "octopus"
+    #     - "pacific"
+    #     # - "quincy"
     steps:
     - uses: actions/setup-go@v3
       with:
         go-version: 1.18
     - uses: actions/checkout@v3
-    - name: Install revive
-      run: go install github.com/mgechev/revive@latest
-    - name: Run checks
-      run: make check
+    - run: go mod download # workaround for bug in golangci-lint
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+        version: v1.47.3
+
+        # Optional: working directory, useful for monorepos
+        # working-directory: somedir
+
+        # Optional: golangci-lint command line arguments.
+        # args: --issues-exit-code=0
+        args: --max-same-issues=0 --max-issues-per-linter=0
+
+        # Optional: show only new issues if it's a pull request. The default value is `false`.
+        only-new-issues: false
+
+        # Optional: if set to true then the all caching functionality will be complete disabled,
+        #           takes precedence over all other caching options.
+        skip-cache: true
+
+        # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+        # skip-pkg-cache: true
+
+        # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+        # skip-build-cache: true
 
   # Run the test suite in a container per-ceph-codename
-  test-suite:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ceph_version:
-        - "nautilus"
-        - "octopus"
-        - "pacific"
-        - "quincy"
-        - "pre-pacific"
-        - "pre-quincy"
-        - "main"
-    steps:
-    - uses: actions/checkout@v3
-    - name: Run tests
-      run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
-    - name: Clean up test containers
-      run: make test-containers-clean "CEPH_VERSION=${{ matrix.ceph_version }}"
-    - name: Archive test results
-      uses: actions/upload-artifact@v3
-      with:
-        name: "go-ceph-results-${{ matrix.ceph_version }}"
-        path: |
-          _results/
-        retention-days: 30
-    - name: Check API Versions and Aging
-      run: |
-        if [ -f _results/implements.json ]; then
-          ./contrib/apiage.py
-        else
-          echo "Skipping apiage check"
-        fi
+  # test-suite:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       ceph_version:
+  #       - "nautilus"
+  #       - "octopus"
+  #       - "pacific"
+  #       - "quincy"
+  #       - "pre-pacific"
+  #       - "pre-quincy"
+  #       - "main"
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Run tests
+  #     run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
+  #   - name: Clean up test containers
+  #     run: make test-containers-clean "CEPH_VERSION=${{ matrix.ceph_version }}"
+  #   - name: Archive test results
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: "go-ceph-results-${{ matrix.ceph_version }}"
+  #       path: |
+  #         _results/
+  #       retention-days: 30
+  #   - name: Check API Versions and Aging
+  #     run: |
+  #       if [ -f _results/implements.json ]; then
+  #         ./contrib/apiage.py
+  #       else
+  #         echo "Skipping apiage check"
+  #       fi

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,215 @@
+run:
+  build-tags:
+    - ceph_preview
+    - ceph_ci_untested
+
+linters:
+  # disable-all: true
+  # enable-all: true
+  enable:
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
+
+    # Enabled by default linters:
+    # - deadcode # Finds unused code [fast: false, auto-fix: false]
+    # - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
+    # - gosimple #(megacheck): Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]
+    # - govet #(vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
+    # - ineffassign # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
+    # - staticcheck #(megacheck): It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
+    # - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
+    # - unused #(megacheck): Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
+    # - varcheck # Finds unused global variables and constants [fast: false, auto-fix: false]
+
+    # Disabled by default linters:
+    # - asasalint # check for pass []any as any in variadic func(...any) [fast: false, auto-fix: false]
+    # - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers [fast: true, auto-fix: false]
+    # - bidichk # Checks for dangerous unicode character sequences [fast: true, auto-fix: false]
+    # - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
+    # - containedctx # containedctx is a linter that detects struct contained context.Context field [fast: true, auto-fix: false]
+    # - contextcheck # check the function whether use a non-inherited context [fast: false, auto-fix: false]
+    # - cyclop # checks function and package cyclomatic complexity [fast: false, auto-fix: false]
+    # - decorder # check declaration order and count of types, constants, variables and functions [fast: true, auto-fix: false]
+    # - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
+    # - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
+    # - dupl # Tool for code clone detection [fast: true, auto-fix: false]
+    # - durationcheck # check for two durations multiplied together [fast: false, auto-fix: false]
+    # - errchkjson # Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted. [fast: false, auto-fix: false]
+    # - errname # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`. [fast: false, auto-fix: false]
+    # - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. [fast: false, auto-fix: false]
+    # - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds [fast: false, auto-fix: false]
+    # - exhaustive # check exhaustiveness of enum switch statements [fast: false, auto-fix: false]
+    # - exhaustivestruct #[deprecated]: Checks if all struct's fields are initialized [fast: false, auto-fix: false]
+    # - exhaustruct # Checks if all structure fields are initialized [fast: false, auto-fix: false]
+    # - exportloopref # checks for pointers to enclosing loop variables [fast: false, auto-fix: false]
+    # - forbidigo # Forbids identifiers [fast: true, auto-fix: false]
+    # - forcetypeassert # finds forced type assertions [fast: true, auto-fix: false]
+    # - funlen # Tool for detection of long functions [fast: true, auto-fix: false]
+    # - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
+    # - gochecknoglobals # check that no global variables exist [fast: true, auto-fix: false]
+    # - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
+    # - gocognit # Computes and checks the cognitive complexity of functions [fast: true, auto-fix: false]
+    # - goconst # Finds repeated strings that could be replaced by a constant [fast: true, auto-fix: false]
+    # - gocritic # Provides diagnostics that check for bugs, performance and style issues. [fast: false, auto-fix: false]
+    # - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
+    # - godot # Check if comments end in a period [fast: true, auto-fix: true]
+    # - godox # Tool for detection of FIXME, TODO and other comment keywords [fast: true, auto-fix: false]
+    # - goerr113 # Golang linter to check the errors handling expressions [fast: false, auto-fix: false]
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
+    # - gofumpt # Gofumpt checks whether code was gofumpt-ed. [fast: true, auto-fix: true]
+    # - goheader # Checks is file header matches to pattern [fast: true, auto-fix: false]
+    # - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt. [fast: true, auto-fix: true]
+    # - golint #[deprecated]: Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: false, auto-fix: false]
+    # - gomnd # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
+    # - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod. [fast: true, auto-fix: false]
+    # - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. [fast: true, auto-fix: false]
+    # - goprintffuncname # Checks that printf-like functions are named with `f` at the end [fast: true, auto-fix: false]
+    # - gosec #(gas): Inspects source code for security problems [fast: false, auto-fix: false]
+    # - grouper # An analyzer to analyze expression groups. [fast: true, auto-fix: false]
+    # - ifshort # Checks that your code uses short syntax for if-statements whenever possible [fast: true, auto-fix: false]
+    # - importas # Enforces consistent import aliases [fast: false, auto-fix: false]
+    # - interfacer #[deprecated]: Linter that suggests narrower interface types [fast: false, auto-fix: false]
+    # - ireturn # Accept Interfaces, Return Concrete Types [fast: false, auto-fix: false]
+    # - lll # Reports long lines [fast: true, auto-fix: false]
+    # - maintidx # maintidx measures the maintainability index of each function. [fast: true, auto-fix: false]
+    # - makezero # Finds slice declarations with non-zero initial length [fast: false, auto-fix: false]
+    # - maligned #[deprecated]: Tool to detect Go structs that would take less memory if their fields were sorted [fast: false, auto-fix: false]
+    # - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
+    # - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
+    # - nestif # Reports deeply nested if statements [fast: true, auto-fix: false]
+    # - nilerr # Finds the code that returns nil even if it checks that the error is not nil. [fast: false, auto-fix: false]
+    # - nilnil # Checks that there is no simultaneous return of `nil` error and an invalid value. [fast: false, auto-fix: false]
+    # - nlreturn # nlreturn checks for a new line before return and branch statements to increase code clarity [fast: true, auto-fix: false]
+    # - noctx # noctx finds sending http request without context.Context [fast: false, auto-fix: false]
+    # - nolintlint # Reports ill-formed or insufficient nolint directives [fast: true, auto-fix: false]
+    # - nonamedreturns # Reports all named returns [fast: false, auto-fix: false]
+    # - nosnakecase # nosnakecase is a linter that detects snake case of variable naming and function name. [fast: true, auto-fix: false]
+    # - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL. [fast: true, auto-fix: false]
+    # - paralleltest # paralleltest detects missing usage of t.Parallel() method in your Go test [fast: false, auto-fix: false]
+    # - prealloc # Finds slice declarations that could potentially be pre-allocated [fast: true, auto-fix: false]
+    # - predeclared # find code that shadows one of Go's predeclared identifiers [fast: true, auto-fix: false]
+    # - promlinter # Check Prometheus metrics naming via promlint [fast: true, auto-fix: false]
+    # - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
+    # - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
+    # - scopelint #[deprecated]: Scopelint checks for unpinned variables in go programs [fast: true, auto-fix: false]
+    # - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed. [fast: false, auto-fix: false]
+    # - structcheck # Finds unused struct fields [fast: false, auto-fix: false]
+    - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
+    # - tagliatelle # Checks the struct tags. [fast: true, auto-fix: false]
+    # - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17 [fast: false, auto-fix: false]
+    # - testpackage # linter that makes you use a separate _test package [fast: true, auto-fix: false]
+    # - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
+    # - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
+    # - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
+    # - unparam # Reports unused function parameters [fast: false, auto-fix: false]
+    # - varnamelen # checks that the length of a variable's name matches its scope [fast: false, auto-fix: false]
+    # - wastedassign # wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
+    # - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
+    # - wrapcheck # Checks that errors returned from external packages are wrapped [fast: false, auto-fix: false]
+    # - wsl # Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
+  # presets:
+    # Linters presets:
+    # - bugs # asasalint, asciicheck, bidichk, bodyclose, contextcheck, durationcheck, errcheck, errchkjson, errorlint, exhaustive, exportloopref, gosec, govet, makezero, nilerr, noctx, rowserrcheck, scopelint, sqlclosecheck, staticcheck, typecheck
+    # - comment # godot, godox, misspell
+    # - complexity # cyclop, funlen, gocognit, gocyclo, maintidx, nestif
+    # - error # errcheck, errorlint, goerr113, wrapcheck
+    # - format # decorder, gci, gofmt, gofumpt, goimports
+    # - import # depguard, gci, goimports, gomodguard
+    # - metalinter # gocritic, govet, revive, staticcheck
+    # - module # depguard, gomoddirectives, gomodguard
+    # - performance # bodyclose, maligned, noctx, prealloc
+    # - sql # execinquery, rowserrcheck, sqlclosecheck
+    # - style # asciicheck, containedctx, decorder, depguard, dogsled, dupl, errname, exhaustivestruct, exhaustruct, forbidigo, forcetypeassert, gochecknoglobals, gochecknoinits, goconst, gocritic, godot, godox, goerr113, goheader, golint, gomnd, gomoddirectives, gomodguard, goprintffuncname, gosimple, grouper, ifshort, importas, interfacer, ireturn, lll, makezero, misspell, nakedret, nilnil, nlreturn, nolintlint, nonamedreturns, nosnakecase, nosprintfhostport, paralleltest, predeclared, promlinter, revive, stylecheck, tagliatelle, tenv, testpackage, thelper, tparallel, unconvert, varnamelen, wastedassign, whitespace, wrapcheck, wsl
+    # - test # exhaustivestruct, exhaustruct, paralleltest, testpackage, tparallel
+    # - unused # deadcode, ineffassign, structcheck, unparam, unused, varcheck
+
+linters-settings:
+  # staticcheck:
+  #   checks: [ "all" ]
+  # stylecheck:
+  #   checks: [ "all" ]
+  revive:
+    ignore-generated-header: false
+    severity: "error"
+    confidence: 0.8
+    error-code: 1
+    warning-code: 0
+    #enable-all-rules: true
+    directives:
+      - name: "specify-disable-reason"
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+        # arguments:
+        #   - ["ID", "UID"] # whitelist
+        #   - [] # blacklist
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
+      - name: atomic
+      - name: bool-literal-in-expr
+      - name: constant-logical-expr
+      - name: unnecessary-stmt
+      - name: unused-receiver
+      - name: modifies-parameter
+      - name: modifies-value-receiver
+      - name: range-val-in-closure
+      - name: waitgroup-by-value
+      - name: duplicated-imports
+      - name: struct-tag
+      - name: import-shadowing
+
+      - name: argument-limit
+        arguments: [4]
+      - name: function-result-limit
+        arguments: [3]
+      - name: unhandled-error
+        # functions to ignore unhandled errors on
+        # arguments:
+        #   - "fmt.Printf"
+        #   - "fmt.Println"
+
+      # - name: cyclomatic
+      #   arguments: [3]
+      #   severity: "warning"
+      # - name: cognitive-complexity
+      #   arguments: [7]
+      #   severity: "warning"
+
+severity:
+  default-severity: warning # for now CI is only failing on revive issues
+  rules:
+    - linters:
+      - revive
+      severity: error
+
+issues:
+  exclude-use-default: False
+  exclude:
+    - "^G103:" # don't complain about unsafe package
+  include:
+    - EXC0005 # staticcheck: ineffective break statement
+    - EXC0011 # revive: comments
+    - EXC0012 # revive: comments
+    - EXC0013 # revive: comments
+    - EXC0014 # revive: comments
+    - EXC0015 # revive: comments

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,11 +4,10 @@ run:
     - ceph_ci_untested
 
 linters:
-  # disable-all: true
+  disable-all: true
   # enable-all: true
   enable:
     - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. [fast: false, auto-fix: false]
-
     # Enabled by default linters:
     # - deadcode # Finds unused code [fast: false, auto-fix: false]
     # - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -65,7 +65,9 @@ var (
 	// name and it is not provided.
 	ErrNoNamespaceName = errors.New("Namespace value is missing")
 
-	// revive:disable:exported for compatibility with old versions
+	ErrUndocumented = errors.New("Undocumented error")
+
+	// revive:disable
 	RbdErrorImageNotOpen = ErrImageNotOpen
 	RbdErrorNotFound     = ErrNotFound
 	// revive:enable:exported

--- a/rbd/golangci-lint.go
+++ b/rbd/golangci-lint.go
@@ -1,0 +1,11 @@
+package rbd
+
+import "fmt"
+
+// import "C"
+
+var NewVariable = 10
+
+func NewFunction() {
+	fmt.Println("foobar")
+}

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -89,7 +89,6 @@ type Image struct {
 	image  C.rbd_image_t
 }
 
-// TrashInfo contains information about trashed RBDs.
 type TrashInfo struct {
 	Id               string    // Id string, required to remove / restore trashed RBDs.
 	Name             string    // Original name of trashed RBD.
@@ -154,7 +153,8 @@ func GetImage(ioctx *rados.IOContext, name string) *Image {
 //        uint64_t features, int *order,
 //        uint64_t stripe_unit, uint64_t stripe_count);
 func Create(ioctx *rados.IOContext, name string, size uint64, order int,
-	args ...uint64) (image *Image, err error) {
+	args ...uint64,
+) (image *Image, err error) {
 	var ret C.int
 
 	switch len(args) {
@@ -191,7 +191,8 @@ func Create(ioctx *rados.IOContext, name string, size uint64, order int,
 //  int rbd_create2(rados_ioctx_t io, const char *name, uint64_t size,
 //          uint64_t features, int *order);
 func Create2(ioctx *rados.IOContext, name string, size uint64, features uint64,
-	order int) (image *Image, err error) {
+	order int,
+) (image *Image, err error) {
 	var ret C.int
 
 	cOrder := C.int(order)
@@ -219,7 +220,8 @@ func Create2(ioctx *rados.IOContext, name string, size uint64, features uint64,
 //        uint64_t features, int *order,
 //        uint64_t stripe_unit, uint64_t stripe_count);
 func Create3(ioctx *rados.IOContext, name string, size uint64, features uint64,
-	order int, stripeUnit uint64, stripeCount uint64) (image *Image, err error) {
+	order int, stripeUnit uint64, stripeCount uint64,
+) (image *Image, err error) {
 	var ret C.int
 
 	cOrder := C.int(order)
@@ -416,7 +418,8 @@ func (image *Image) Stat() (info *ImageInfo, err error) {
 		Obj_size:          uint64(cStat.obj_size),
 		Num_objs:          uint64(cStat.num_objs),
 		Order:             int(cStat.order),
-		Block_name_prefix: C.GoString((*C.char)(&cStat.block_name_prefix[0]))}, nil
+		Block_name_prefix: C.GoString((*C.char)(&cStat.block_name_prefix[0])),
+	}, nil
 }
 
 // IsOldFormat returns true if the rbd image uses the old format.
@@ -634,9 +637,11 @@ func (image *Image) ListLockers() (tag string, lockers []Locker, err error) {
 
 	lockers = make([]Locker, cLockerCount)
 	for i := 0; i < int(cLockerCount); i++ {
-		lockers[i] = Locker{Client: clients[i],
+		lockers[i] = Locker{
+			Client: clients[i],
 			Cookie: cookies[i],
-			Addr:   addrs[i]}
+			Addr:   addrs[i],
+		}
 	}
 
 	return string(tagBuf), lockers, nil
@@ -917,9 +922,11 @@ func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 	}
 
 	for i, s := range cSnaps {
-		snaps[i] = SnapInfo{Id: uint64(s.id),
+		snaps[i] = SnapInfo{
+			Id:   uint64(s.id),
 			Size: uint64(s.size),
-			Name: C.GoString(s.name)}
+			Name: C.GoString(s.name),
+		}
 	}
 
 	C.rbd_snap_list_end(&cSnaps[0])
@@ -952,7 +959,6 @@ func (image *Image) GetId() (string, error) {
 	}
 	id := C.GoString((*C.char)(unsafe.Pointer(&buf[0])))
 	return id, nil
-
 }
 
 // GetName returns the image name.
@@ -1249,8 +1255,8 @@ func RemoveImage(ioctx *rados.IOContext, name string) error {
 //                  const char *p_snapname, rados_ioctx_t c_ioctx,
 //                  const char *c_name, rbd_image_options_t c_opts);
 func CloneImage(ioctx *rados.IOContext, parentName, snapName string,
-	destctx *rados.IOContext, name string, rio *ImageOptions) error {
-
+	destctx *rados.IOContext, name string, rio *ImageOptions,
+) error {
 	if rio == nil {
 		return rbdError(C.EINVAL)
 	}
@@ -1277,8 +1283,8 @@ func CloneImage(ioctx *rados.IOContext, parentName, snapName string,
 // This function is a convenience wrapper around CloneImage to support cloning
 // from an existing Image.
 func CloneFromImage(parent *Image, snapName string,
-	destctx *rados.IOContext, name string, rio *ImageOptions) error {
-
+	destctx *rados.IOContext, name string, rio *ImageOptions,
+) error {
 	if err := parent.validate(imageNeedsIOContext); err != nil {
 		return err
 	}

--- a/rbd/snapshot_rename.go
+++ b/rbd/snapshot_rename.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 )
 
-// Rename a snapshot.
+// bla a snapshot.
 //
 // Implements:
 // 	int rbd_snap_rename(rbd_image_t image, const char *snapname,


### PR DESCRIPTION
Let's play around with golangci-lint, which also can start revive and has a "new" mode.
