### PR TITLE
rgw/admin: ability to retrieve user by access key

### DIFF
--- a/rgw/admin/errors.go
+++ b/rgw/admin/errors.go
@@ -87,6 +87,7 @@ const (
 
 var (
 	errMissingUserID          = errors.New("missing user ID")
+	errMissingUserAccessKey   = errors.New("missing user access key")
 	errMissingUserDisplayName = errors.New("missing user display name")
 	errMissingUserCap         = errors.New("missing user capabilities")
 )

--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -58,8 +58,15 @@ type UserStat struct {
 
 // GetUser retrieves a given object store user
 func (api *API) GetUser(ctx context.Context, user User) (User, error) {
-	if user.ID == "" {
+	if user.ID == "" && len(user.Keys) == 0 {
 		return User{}, errMissingUserID
+	}
+	if len(user.Keys) > 0 {
+		for _, key := range user.Keys {
+			if key.AccessKey == "" {
+				return User{}, errMissingUserAccessKey
+			}
+		}
 	}
 
 	body, err := api.call(ctx, http.MethodGet, "/user", valueToURLParams(user))


### PR DESCRIPTION
We can now get an s3 user from the rgw admin ops API with its access
key. No validation on the key is performed other than not being empty.

Closes: https://github.com/ceph/go-ceph/issues/600
Signed-off-by: Sébastien Han <seb@redhat.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
