### PR TITLE
cephfs admin: add sleeps after mgr module is enabled (workaround)

### DIFF
--- a/cephfs/admin/mirror_workflow_test.go
+++ b/cephfs/admin/mirror_workflow_test.go
@@ -41,6 +41,7 @@ func TestMirroring(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	require.NoError(t, err)
+	time.Sleep(500 * time.Millisecond) // TODO: improve this
 
 	smadmin1 := fsa1.SnapshotMirror()
 	err = smadmin1.Enable(fsname)
@@ -49,6 +50,7 @@ func TestMirroring(t *testing.T) {
 		err := smadmin1.Disable(fsname)
 		require.NoError(t, err)
 	}()
+	time.Sleep(500 * time.Millisecond) // TODO: improve this
 
 	fsa2 := newFSAdmin(t, mirrorConfig())
 	err = fsa2.EnableMirroringModule(noForce)


### PR DESCRIPTION
Fixes #574

This is a workaround for the common test flake:
```
=== RUN   TestMirroring
    mirror_workflow_test.go:63:
            Error Trace:    mirror_workflow_test.go:63
            Error:          Received unexpected error:
                            rados: ret=-95, Operation not supported:
"Module 'mirroring' is not enabled (required by command 'fs snapshot
mirror enable'): use `ceph mgr module enable mirroring` to enable it"
            Test:           TestMirroring
```
at even though we've certainly requested the mode be enabled the mgr
has apparently not fully processed the request and the module is
not yet available. We add a half-second sleep after each call
to hopefully give the mgr time enough to completely enable the module.

A future improvement would be to poll the mgr until we know it is ready to
use the cephfs mirroring module, but that would take some research and
(probably) new API calls. So this is a temporary workaround just
to try and reduce the number of test flakes sooner rather than later.
