### PR TITLE
cephfs admin: wait for mirroring module

### DIFF
--- a/cephfs/admin/mgrmodule.go
+++ b/cephfs/admin/mgrmodule.go
@@ -52,3 +52,32 @@ func (fsa *FSAdmin) EnableMirroringModule(force bool) error {
 func (fsa *FSAdmin) DisableMirroringModule() error {
 	return fsa.DisableModule(mirroring)
 }
+
+type moduleInfo struct {
+	EnabledModules []string `json:"enabled_modules"`
+	//DisabledModules []string `json:"disabled_modules"`
+	// DisabledModules is documented in ceph as a list of string
+	// but that's not what comes back from the server (on pacific).
+	// Since we don't need this today, we're just going to ignore
+	// it, but if we ever want to support this for external consumers
+	// we'll need to figure out the real structure of this.
+}
+
+func parseModuleInfo(res response) (*moduleInfo, error) {
+	m := &moduleInfo{}
+	if err := res.NoStatus().Unmarshal(m).End(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// listModules returns moduleInfo or error. it is not exported because
+// this is really not a cephfs specific thing but we needed it
+// for cephfs tests. maybe lift it somewhere else someday.
+func (fsa *FSAdmin) listModules() (*moduleInfo, error) {
+	m := map[string]string{
+		"prefix": "mgr module ls",
+		"format": "json",
+	}
+	return parseModuleInfo(commands.MarshalMonCommand(fsa.conn, m))
+}


### PR DESCRIPTION
Add (internal only) support for getting the enabled modules for the manager. Use that to try and make the test case more robust.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Is this new API marked PREVIEW?
