### PR TITLE
docs: api-update typo

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -174,7 +174,7 @@ In order to better track the status of our deprecated and preview APIs we have
 an [API Status document](./api-status.md). This document is generated from a
 JSON file in our `docs/` directory. When a new API is being added, one or more
 additional patches need to be provided to update the API status doc and JSON
-file. If you have no unusual requirements, you can run `make api-udpate` and
+file. If you have no unusual requirements, you can run `make api-update` and
 commit the changes that have been made to the `docs/` directory.
 
 This command will automatically update the `api-status.*` files, indicating


### PR DESCRIPTION
This PR fixes a typo in development docs:

    s/udpate/update/g

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Is this new API marked PREVIEW?
