### PR TITLE
rgw/admin: add support for new /info section

### DIFF
--- a/rgw/admin/info.go
+++ b/rgw/admin/info.go
@@ -1,0 +1,37 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+/* parse a nested json expression like
+ * {"info":{"storage_backends":[{"name":"rados","cluster_id":"75d1938b-2949-4933-8386-fb2d1449ff03"}]}} */
+
+// Info struct
+type Backend struct {
+	Name    string `json:"name"`
+	ClusterID    string `json:"cluster_id"`
+}
+
+type Info struct {
+	Info map[string] []Backend
+}
+
+// GetInfo fetch an array of info elements (e.g., the cluster fsid)
+func (api *API) GetInfo(ctx context.Context) (Info, error) {
+	body, err := api.call(ctx, http.MethodGet, "/info", nil)
+	if err != nil {
+		return Info{}, err
+	}
+	fmt.Println(string(body))
+	u := Info{}
+	err = json.Unmarshal(body, &u)
+	if err != nil {
+		return Info{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+	}
+
+	return u, nil
+}


### PR DESCRIPTION
Implement support for new /info AdminOps interface, which returns
an extensible json record similar to:

{"info":{"storage_backends":[{"name":"rados","cluster_id":"75d1938b-2949-4933-8386-fb2d1449ff03"}]}}

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Is this new API marked PREVIEW?
