### PR TITLE
rados: implement binding for rados_write_op_remove

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -938,6 +938,12 @@
         "comment": "Read bytes from offset into buffer.\nlen(buffer) is the maximum number of bytes read from the object.\nbuffer[:ReadOpReadStep.BytesRead] then contains object data.\n PREVIEW\n\nImplements:\n void rados_read_op_read(rados_read_op_t read_op,\n                         uint64_t offset,\n                         size_t len,\n                         char * buffer,\n                         size_t * bytes_read,\n                         int * prval)\n",
         "added_in_version": "v0.14.0",
         "expected_stable_version": "v0.16.0"
+      },
+      {
+        "name": "WriteOp.Remove",
+        "comment": "Remove object.\n PREVIEW\n\nImplements:\n void rados_write_op_remove(rados_write_op_t write_op)\n",
+        "added_in_version": "v0.14.0",
+        "expected_stable_version": "v0.16.0"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -14,6 +14,7 @@ Name | Added in Version | Expected Stable Version |
 ---- | ---------------- | ----------------------- | 
 WriteOp.CmpExt | v0.12.0 | v0.14.0 | 
 ReadOp.Read | v0.14.0 | v0.16.0 | 
+WriteOp.Remove | v0.14.0 | v0.16.0 | 
 
 ## Package: rbd
 

--- a/rados/rados_write_op_remove.go
+++ b/rados/rados_write_op_remove.go
@@ -1,0 +1,19 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// Remove object.
+//  PREVIEW
+//
+// Implements:
+//  void rados_write_op_remove(rados_write_op_t write_op)
+func (w *WriteOp) Remove() {
+	C.rados_write_op_remove(w.op)
+}

--- a/rados/rados_write_op_remove_test.go
+++ b/rados/rados_write_op_remove_test.go
@@ -1,0 +1,41 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestWriteOpRemove() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	var (
+		oid = "TestWriteOpRemove"
+		err error
+	)
+
+	// Create an object.
+	op1 := CreateWriteOp()
+	defer op1.Release()
+	op1.Create(CreateIdempotent)
+	err = op1.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	// Try to stat() it before removal. It should succeed.
+	_, err = suite.ioctx.Stat(oid)
+	ta.NoError(err)
+
+	// Try to remove it. It should succeed.
+	op2 := CreateWriteOp()
+	defer op2.Release()
+	op2.Remove()
+	err = op2.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	// Try to stat() it. It should fail with ENOENT.
+	_, err = suite.ioctx.Stat(oid)
+	ta.Error(err)
+	ta.Equal(ErrNotFound, err)
+}


### PR DESCRIPTION
This PR implements binding for `rados_write_op_remove` RADOS Write operation.

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Is this new API marked PREVIEW?
