### PR TITLE
rados: implement binding for rados_{read,write}_op_assert_version

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -944,6 +944,18 @@
         "comment": "Remove object.\n PREVIEW\n\nImplements:\n void rados_write_op_remove(rados_write_op_t write_op)\n",
         "added_in_version": "v0.14.0",
         "expected_stable_version": "v0.16.0"
+      },
+      {
+        "name": "ReadOp.AssertVersion",
+        "comment": "Ensure that the object exists and that its internal version number is equal\nto \"ver\" before reading. \"ver\" should be a version number previously\nobtained with IOContext.GetLastVersion().\n PREVIEW\n\nImplements:\n void rados_read_op_assert_version(rados_read_op_t read_op,\n                                   uint64_t ver)\n",
+        "added_in_version": "v0.14.0",
+        "expected_stable_version": "v0.16.0"
+      },
+      {
+        "name": "WriteOp.AssertVersion",
+        "comment": "Ensure that the object exists and that its internal version number is equal\nto \"ver\" before writing. \"ver\" should be a version number previously\nobtained with IOContext.GetLastVersion().\n PREVIEW\n\nImplements:\n void rados_read_op_assert_version(rados_read_op_t read_op,\n                                   uint64_t ver)\n",
+        "added_in_version": "v0.14.0",
+        "expected_stable_version": "v0.16.0"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -15,6 +15,8 @@ Name | Added in Version | Expected Stable Version |
 WriteOp.CmpExt | v0.12.0 | v0.14.0 | 
 ReadOp.Read | v0.14.0 | v0.16.0 | 
 WriteOp.Remove | v0.14.0 | v0.16.0 | 
+ReadOp.AssertVersion | v0.14.0 | v0.16.0 | 
+WriteOp.AssertVersion | v0.14.0 | v0.16.0 | 
 
 ## Package: rbd
 

--- a/rados/rados_read_op_assert_version.go
+++ b/rados/rados_read_op_assert_version.go
@@ -1,0 +1,22 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// Ensure that the object exists and that its internal version number is equal
+// to "ver" before reading. "ver" should be a version number previously
+// obtained with IOContext.GetLastVersion().
+//  PREVIEW
+//
+// Implements:
+//  void rados_read_op_assert_version(rados_read_op_t read_op,
+//                                    uint64_t ver)
+func (r *ReadOp) AssertVersion(ver uint64) {
+	C.rados_read_op_assert_version(r.op, C.uint64_t(ver))
+}

--- a/rados/rados_read_op_assert_version_test.go
+++ b/rados/rados_read_op_assert_version_test.go
@@ -1,0 +1,48 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestReadOpAssertVersion() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	var (
+		oid = "TestReadOpAssertVersion"
+		err error
+	)
+
+	// Create an object.
+	op1 := CreateWriteOp()
+	defer op1.Release()
+	op1.Create(CreateIdempotent)
+	err = op1.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	// Retrieve last object version after writing.
+	ver1, err := suite.ioctx.GetLastVersion()
+	ta.NoError(err)
+
+	// Read with version assert. It should succeed.
+	op2 := CreateReadOp()
+	defer op2.Release()
+	op2.AssertVersion(ver1)
+	err = op2.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	// Refresh the version.
+	ver2, err := suite.ioctx.GetLastVersion()
+	ta.NoError(err)
+
+	// Read with version assert, but modify the version first.
+	// It should fail.
+	op3 := CreateReadOp()
+	defer op3.Release()
+	op3.AssertVersion(ver2 + 1)
+	err = op3.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.Error(err)
+}

--- a/rados/rados_write_op_assert_version.go
+++ b/rados/rados_write_op_assert_version.go
@@ -1,0 +1,22 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// Ensure that the object exists and that its internal version number is equal
+// to "ver" before writing. "ver" should be a version number previously
+// obtained with IOContext.GetLastVersion().
+//  PREVIEW
+//
+// Implements:
+//  void rados_read_op_assert_version(rados_read_op_t read_op,
+//                                    uint64_t ver)
+func (w *WriteOp) AssertVersion(ver uint64) {
+	C.rados_write_op_assert_version(w.op, C.uint64_t(ver))
+}

--- a/rados/rados_write_op_assert_version_test.go
+++ b/rados/rados_write_op_assert_version_test.go
@@ -1,0 +1,48 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestWriteOpAssertVersion() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	var (
+		oid = "TestWriteOpAssertVersion"
+		err error
+	)
+
+	// Create an object.
+	op1 := CreateWriteOp()
+	defer op1.Release()
+	op1.Create(CreateIdempotent)
+	err = op1.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	// Retrieve last object version after writing.
+	ver1, err := suite.ioctx.GetLastVersion()
+	ta.NoError(err)
+
+	// Write with version assert. It should succeed.
+	op2 := CreateWriteOp()
+	defer op2.Release()
+	op2.AssertVersion(ver1)
+	err = op2.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	// Refresh the version.
+	ver2, err := suite.ioctx.GetLastVersion()
+	ta.NoError(err)
+
+	// Write with version assert, but modify the version first.
+	// It should fail.
+	op3 := CreateWriteOp()
+	defer op3.Release()
+	op3.AssertVersion(ver2 + 1)
+	err = op3.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.Error(err)
+}


### PR DESCRIPTION
This PR implements bindings for:
* `rados_read_op_assert_version` RADOS Read operation
* `rados_write_op_assert_version` RADOS Write operation.

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Is this new API marked PREVIEW?
