### PR TITLE
make: always rebuild implements.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,9 +230,7 @@ else
 IMPLEMENTS_DIR:=$(RESULTS_DIR)
 endif
 
-implements-json: $(IMPLEMENTS_DIR)/implements.json
-
-$(IMPLEMENTS_DIR)/implements.json: $(BUILDFILE)
+implements-json: $(BUILDFILE)
 	$(MAKE) RESULTS_DIR="$(IMPLEMENTS_DIR)" ENTRYPOINT_ARGS="--test-run=IMPLEMENTS --micro-osd=/bin/true $(ENTRYPOINT_ARGS)" test-container
 
 # force_go_build is phony and builds nothing, can be used for forcing


### PR DESCRIPTION
Since it is usually necessary to rebuild the `implements.json` file when doing a `api-check` or `api-update`, this change always rebuilds it, so that it is not necessary anymore to manually delete the result directory. 

Signed-off-by: Sven Anderson <sven@redhat.com>
