### PR TITLE
containers: disable a repo to get the ci up and going again

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -13,6 +13,7 @@ ENV GO_CEPH_VERSION=${GO_CEPH_VERSION:-$CEPH_VERSION} \
 RUN true && \
     echo "Check: [ ${CEPH_VERSION} = ${GO_CEPH_VERSION} ]" && \
     [ "${CEPH_VERSION}" = "${GO_CEPH_VERSION}" ] && \
+    (dnf config-manager --disable apache-arrow-centos || true) && \
     yum update -y && \
     cv="$(rpm -q --queryformat '%{version}-%{release}' ceph-common)" && \
     yum install -y \


### PR DESCRIPTION
This issue should have been fixed in ceph-containers already but for
whatever reason we don't seem to be getting the fix.
For now, disable the apache-arrow-centos repo.

Based on: https://github.com/ceph/ceph-csi/pull/2859/commits/8b4c8dc7305ff5ecc99d5805b9f7a31a33068a33
