### PR TITLE
rbd: add GetRadosIOContext to return image rados IOContext

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1546,6 +1546,10 @@
         "comment": "GetName returns the image name."
       },
       {
+        "name": "Image.GetRadosIOContext",
+        "comment": "GetRadosIOContext returns the image rados IOContext."
+      },
+      {
         "name": "Image.SetSnapshot",
         "comment": "SetSnapshot updates the rbd image (not the Snapshot) such that the snapshot\nis the source of readable data.\n\nImplements:\n int rbd_snap_set(rbd_image_t image, const char *snapname);\n"
       },

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -960,6 +960,11 @@ func (image *Image) GetName() string {
 	return image.name
 }
 
+// GetRadosIOContext returns the image rados IOContext
+func (image *Image) GetRadosIOContext() *rados.IOContext {
+	return image.ioctx
+}
+
 // SetSnapshot updates the rbd image (not the Snapshot) such that the snapshot
 // is the source of readable data.
 //

--- a/rbd/rbd_test.go
+++ b/rbd/rbd_test.go
@@ -1649,6 +1649,26 @@ func TestGetName(t *testing.T) {
 	assert.Equal(t, image.name, imgName)
 }
 
+func TestGetRadosIOContext(t *testing.T) {
+	conn := radosConnect(t)
+	defer conn.Shutdown()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+	defer conn.DeletePool(poolname)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+	defer ioctx.Destroy()
+
+	image := Image{
+		ioctx: ioctx,
+	}
+	imgIOCtx := image.GetRadosIOContext()
+	assert.Equal(t, imgIOCtx, ioctx)
+}
+
 func TestOpenImageById(t *testing.T) {
 	conn := radosConnect(t)
 


### PR DESCRIPTION
This can help to get the rados IOContext and destroy it without keeping the ioctx variable

Signed-off-by: Seena Fallah <seenafallah@gmail.com>

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Is this new API marked PREVIEW?
