### PR TITLE
rados: add GetConn to return connection used for IOContext

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -685,6 +685,10 @@
         "comment": "Destroy informs librados that the I/O context is no longer in use.\nResources associated with the context may not be freed immediately, and the\ncontext should not be used again after calling this method.\n"
       },
       {
+        "name": "IOContext.GetConn",
+        "comment": "GetConn returns connection used for IOContext.\n"
+      },
+      {
         "name": "IOContext.GetPoolStats",
         "comment": "GetPoolStats returns a set of statistics about the pool associated with this I/O\ncontext.\n\nImplements:\n int rados_ioctx_pool_stat(rados_ioctx_t io,\n                           struct rados_pool_stat_t *stats);\n"
       },

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -100,7 +100,9 @@ func (c *Conn) ReadDefaultConfigFile() error {
 func (c *Conn) OpenIOContext(pool string) (*IOContext, error) {
 	cPool := C.CString(pool)
 	defer C.free(unsafe.Pointer(cPool))
-	ioctx := &IOContext{}
+	ioctx := &IOContext{
+		conn: c,
+	}
 	ret := C.rados_ioctx_create(c.cluster, cPool, &ioctx.ioctx)
 	if ret == 0 {
 		return ioctx, nil

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -93,6 +93,7 @@ type LockInfo struct {
 
 // IOContext represents a context for performing I/O within a pool.
 type IOContext struct {
+	conn  *Conn
 	ioctx C.rados_ioctx_t
 }
 
@@ -231,6 +232,11 @@ func (ioctx *IOContext) Truncate(oid string, size uint64) error {
 // context should not be used again after calling this method.
 func (ioctx *IOContext) Destroy() {
 	C.rados_ioctx_destroy(ioctx.ioctx)
+}
+
+// GetConn returns connection used for IOContext
+func (ioctx *IOContext) GetConn() *Conn {
+	return ioctx.conn
 }
 
 // GetPoolStats returns a set of statistics about the pool associated with this I/O

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -579,6 +579,13 @@ func (suite *RadosTestSuite) TestObjectStat() {
 	assert.NotNil(suite.T(), stat.ModTime)
 }
 
+func (suite *RadosTestSuite) TestGetConn() {
+	suite.SetupConnection()
+
+	conn := suite.ioctx.GetConn()
+	assert.Equal(suite.T(), suite.conn, conn)
+}
+
 func (suite *RadosTestSuite) TestGetPoolStats() {
 	suite.SetupConnection()
 


### PR DESCRIPTION
This can help to shutdown the connection used for the IOContext

Signed-off-by: Seena Fallah <seenafallah@gmail.com>

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Is this new API marked PREVIEW?
