### PR TITLE
List oids null

### DIFF
--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -892,6 +892,7 @@ func (suite *RadosTestSuite) TestReadWriteOmap() {
 		"key1":          []byte("value1"),
 		"key2":          []byte("value2"),
 		"prefixed-key3": []byte("value3"),
+		"null\x00key4":  []byte("value4"),
 		"empty":         []byte(""),
 	}
 
@@ -905,7 +906,7 @@ func (suite *RadosTestSuite) TestReadWriteOmap() {
 		remaining[k] = v
 	}
 
-	err = suite.ioctx.ListOmapValues(oid, "", "", 4, func(key string, value []byte) {
+	err = suite.ioctx.ListOmapValues(oid, "", "", 5, func(key string, value []byte) {
 		assert.Equal(suite.T(), remaining[key], value)
 		delete(remaining, key)
 	})
@@ -914,7 +915,7 @@ func (suite *RadosTestSuite) TestReadWriteOmap() {
 	assert.Equal(suite.T(), len(remaining), 0)
 
 	// Get (with a fixed number of keys)
-	fetched, err := suite.ioctx.GetOmapValues(oid, "", "", 4)
+	fetched, err := suite.ioctx.GetOmapValues(oid, "", "", 5)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), orig, fetched)
 
@@ -924,15 +925,15 @@ func (suite *RadosTestSuite) TestReadWriteOmap() {
 	assert.Equal(suite.T(), orig, fetched)
 
 	// Get All (with an iterator size smaller than the map size)
-	fetched, err = suite.ioctx.GetAllOmapValues(oid, "", "", 1)
+	fetched, err = suite.ioctx.GetAllOmapValues(oid, "", "", 2)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), orig, fetched)
 
 	// Remove
-	err = suite.ioctx.RmOmapKeys(oid, []string{"key1", "prefixed-key3"})
+	err = suite.ioctx.RmOmapKeys(oid, []string{"key1", "prefixed-key3", "null\x00key4"})
 	assert.NoError(suite.T(), err)
 
-	fetched, err = suite.ioctx.GetOmapValues(oid, "", "", 4)
+	fetched, err = suite.ioctx.GetOmapValues(oid, "", "", 5)
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), map[string][]byte{
 		"key2":  []byte("value2"),


### PR DESCRIPTION
:wave: We've been using a patch that's similar to this in production for a while now, which has helped with our internal tooling to clean up broken MPUs created by RGW. Ideas welcome on how I could go about testing the changes to ListObjects. I don't know of a way to create an object with a null char in the key short of getting a new CLS function committed.

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
- [ ] Is this a new API? Is this new API marked PREVIEW?
