### PR TITLE
common/log: add missing api-status entries

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1900,5 +1900,21 @@
         "comment": "ListModules returns a module info struct reporting the lists of\nenabled, disabled, and always-on modules in the Ceph mgr.\n"
       }
     ]
+  },
+  "common/log": {
+    "preview_api": [
+      {
+        "name": "SetWarnf",
+        "comment": "SetWarnf sets the log.Printf compatible receiver for warning logs.\n PREVIEW\n",
+        "added_in_version": "v0.15.0",
+        "expected_stable_version": "v0.17.0"
+      },
+      {
+        "name": "SetDebugf",
+        "comment": "SetDebugf sets the log.Printf compatible receiver for debug logs.\n PREVIEW\n",
+        "added_in_version": "v0.15.0",
+        "expected_stable_version": "v0.17.0"
+      }
+    ]
   }
 }

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -65,3 +65,12 @@ API.ModifySubuser | v0.15.0 | v0.17.0 |
 
 ## Package: common/admin/manager
 
+## Package: common/log
+
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+SetWarnf | v0.15.0 | v0.17.0 | 
+SetDebugf | v0.15.0 | v0.17.0 | 
+


### PR DESCRIPTION
Because implements tool only looked at certain packages so far, there were no entries for the new package `common/log` in the api-status files.

Signed-off-by: Sven Anderson <sven@redhat.com>
