### PR TITLE
implements: analyze all but internal packages

### DIFF
--- a/contrib/apiage.py
+++ b/contrib/apiage.py
@@ -54,7 +54,7 @@ def copy_api(tracked, keys, src, defaults=None):
 def compare_and_update(tracked, pkg, pkg_api, defaults=None):
     if defaults is None:
         defaults = {}
-    new_deprecated = new_preview = []
+    new_deprecated = new_preview = new_stable = []
     if "deprecated_api" in pkg_api:
         new_deprecated = copy_api(
             tracked=tracked,

--- a/contrib/implements/main.go
+++ b/contrib/implements/main.go
@@ -17,10 +17,9 @@ package main
 
 import (
 	"flag"
+	"implements/internal/implements"
 	"log"
 	"os"
-
-	"implements/internal/implements"
 )
 
 var (
@@ -110,12 +109,10 @@ func main() {
 			if verbose {
 				logger.Printf("Processing package (with C): %s\n", pkg)
 			}
-		case "cephfs/admin", "rbd/admin", "rgw/admin", "common/admin/manager":
+		default:
 			if verbose {
 				logger.Printf("Processing package: %s\n", pkg)
 			}
-		default:
-			abort("unknown package name: " + pkg)
 		}
 		if source == "" {
 			source = "."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ BUILD_TAGS=""
 RESULTS_DIR=/results
 CEPH_CONF=/tmp/ceph/ceph.conf
 MIRROR_STATE=/dev/null
+PKG_PREFIX=github.com/ceph/go-ceph
 
 
 # Default env vars that are not currently changed by this script
@@ -242,10 +243,12 @@ pre_all_tests() {
 
 implements_tool() {
     mkdir -p "${RESULTS_DIR}"
+    pkgs=$(go list ${BUILD_TAGS} ./... | sed -e "s,^${PKG_PREFIX}/\?,," | \
+        grep -v ^contrib | grep -v ^internal)
     show ./implements --list \
         --report-json "${RESULTS_DIR}/implements.json" \
         --report-text "${RESULTS_DIR}/implements.txt" \
-        cephfs rados rbd cephfs/admin rbd/admin rgw/admin common/admin/manager
+        ${pkgs}
     # output the brief summary info onto stdout
     grep '^[A-Z]' "${RESULTS_DIR}/implements.txt"
 }
@@ -278,8 +281,7 @@ test_go_ceph() {
         return $?
     fi
 
-    PKG_PREFIX=github.com/ceph/go-ceph
-    pkgs=$(go list ./... | sed -e "s,^${PKG_PREFIX}/\?,," | grep -v ^contrib)
+    pkgs=$(go list ${BUILD_TAGS} ./... | sed -e "s,^${PKG_PREFIX}/\?,," | grep -v ^contrib)
     pre_all_tests
     if [[ ${WAIT_FILES} ]]; then
         wait_for_files ${WAIT_FILES//:/ }


### PR DESCRIPTION
The implements tool and the api-update target ignored a couple of packages. Instead of adding each package explicitly, I changed the logic, so that all packages but the internal ones are scanned.

Signed-off-by: Sven Anderson <sven@redhat.com>
