### PR TITLE
github: add Dependabot for managing versions in go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    labels:
+      - rebase
+    commit-message:
+      prefix: "rebase"


### PR DESCRIPTION
Dependabot can automatically create PRs for packages that have have a
new release. By depending on recent versions of the consumed packages,
the result of the OpenSSF scorecard will improve.

See-also: https://deps.dev/go/github.com%2Fceph%2Fgo-ceph/
Doc: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates