### PR TITLE
CI: disable fail-fast in test-suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
   test-suite:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ceph_version:
         - "nautilus"


### PR DESCRIPTION
Because of the flaky tests sometimes the non-required test cancels the required one, which makes the flaky tests even more annoying.
