### PR TITLE
rgw/admin: fix get user api if key is missed

### DIFF
--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -102,7 +102,7 @@ type UserStat struct {
 
 // GetUser retrieves a given object store user
 func (api *API) GetUser(ctx context.Context, user User) (User, error) {
-	if user.ID == "" && len(user.Keys) == 0 {
+	if user.ID == "" || len(user.Keys) == 0 {
 		return User{}, errMissingUserID
 	}
 	if len(user.Keys) > 0 {


### PR DESCRIPTION
The GetUser() api can work either with key or user id, current code
checks for both instead of either.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Is this new API marked PREVIEW?
