### PR TITLE
implements: a public function's type must be exported too

### DIFF
--- a/contrib/implements/internal/implements/gosrc.go
+++ b/contrib/implements/internal/implements/gosrc.go
@@ -106,7 +106,7 @@ func readDocComment(fdec *ast.FuncDecl, gfunc *goFunction) {
 }
 
 func isPublic(gfunc *goFunction) bool {
-	return ast.IsExported(gfunc.shortName)
+	return ast.IsExported(gfunc.shortName) && ast.IsExported(gfunc.fullName)
 }
 
 func (v *visitor) checkCalled(s *ast.SelectorExpr) {


### PR DESCRIPTION
The implements API checker should not treat a function as exported if it's type is not exported.

Certain APIs, such as those pertaining to JSON require public methods on unexported types. Since the type is not exported `implements` should not worry about it.