### PR TITLE
cutil: enable PtrGuard by default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,8 +22,8 @@
             "GODEBUG": "cgocheck=2",
             "CEPH_CONF": "/ceph_a/ceph.conf",
         },
-        "go.buildTags": "ptrguard",
-        "go.testTags": "ptrguard",
+        "go.buildTags": "",
+        "go.testTags": "",
         "go.testFlags": [
             "-v",
             "-count=1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run tests
       run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
-    - name: Run tests with ptrguard
-      run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "USE_PTRGUARD=true" "RESULTS_DIR=$PWD/_results"
+    - name: Run tests without ptrguard
+      run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "NO_PTRGUARD=true" "RESULTS_DIR=$PWD/_results"
     - name: Clean up test containers
       run: make test-containers-clean "CEPH_VERSION=${{ matrix.ceph_version }}"
     - name: Archive coverage results

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ TEST_CTR_NET=.run.test_ceph_net
 # the name of the image plus ceph version as tag
 CI_IMAGE_TAG=$(CI_IMAGE_NAME):$(CEPH_VERSION)
 
-ifneq ($(USE_PTRGUARD),)
-	CONTAINER_OPTS += -e USE_PTRGUARD=true
-	BUILD_TAGS := $(BUILD_TAGS),ptrguard
+ifneq ($(NO_PTRGUARD),)
+	CONTAINER_OPTS += -e NO_PTRGUARD=true
+	BUILD_TAGS := $(BUILD_TAGS),no_ptrguard
 endif
 
 ifneq ($(NO_PREVIEW),)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -308,8 +308,8 @@ if [ -n "${CEPH_VERSION}" ]; then
     add_build_tag "${CEPH_VERSION}"
 fi
 
-if [ -n "${USE_PTRGUARD}" ]; then
-    add_build_tag "ptrguard"
+if [ -n "${NO_PTRGUARD}" ]; then
+    add_build_tag "no_ptrguard"
 fi
 
 if [ -z "${NO_PREVIEW}" ]; then

--- a/internal/cutil/sync_buffer.go
+++ b/internal/cutil/sync_buffer.go
@@ -1,5 +1,5 @@
-//go:build ptrguard
-// +build ptrguard
+//go:build !no_ptrguard
+// +build !no_ptrguard
 
 package cutil
 

--- a/internal/cutil/sync_buffer_memcpy.go
+++ b/internal/cutil/sync_buffer_memcpy.go
@@ -1,5 +1,5 @@
-//go:build !ptrguard
-// +build !ptrguard
+//go:build no_ptrguard
+// +build no_ptrguard
 
 package cutil
 


### PR DESCRIPTION
Let's make PtrGuard the default, so we can remove the non-PtrGuard code in a later release.

Signed-off-by: Sven Anderson <sven@redhat.com>
