### PR TITLE
containers: update the go version used in the CI container

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -22,7 +22,7 @@ RUN true && \
     yum clean all && \
     true
 
-ARG GO_VERSION=1.16.7
+ARG GO_VERSION=1.17.9
 ENV GO_VERSION=${GO_VERSION}
 RUN true && \
     gotar=go${GO_VERSION}.linux-amd64.tar.gz && \


### PR DESCRIPTION
The Go 1.18 release was done in march 2022 and so we should
continue to use the older of the two supported releases which
is now Go 1.17.x.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Is this new API marked PREVIEW?
