### PR TITLE
rbd: expose rbd_snap_rename to Go clients

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1689,6 +1689,14 @@
         "name": "Watch.Unwatch",
         "comment": "Unwatch un-registers the image watch.\n\nImplements:\n int rbd_update_unwatch(rbd_image_t image, uint64_t handle);\n"
       }
+    ],
+    "preview_api": [
+      {
+        "name": "Snapshot.Rename",
+        "comment": "Rename a snapshot.\n PREVIEW\n\nImplements:\n int rbd_snap_rename(rbd_image_t image, const char *snapname, const char* dstsnapsname);\n",
+        "added_in_version": "v0.16.0",
+        "expected_stable_version": "v0.18.0"
+      }
     ]
   },
   "rbd/admin": {

--- a/rbd/snapshot_rename.go
+++ b/rbd/snapshot_rename.go
@@ -1,0 +1,38 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <stdlib.h>
+// #include <rbd/librbd.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+// Rename a snapshot.
+//  PREVIEW
+//
+// Implements:
+// 	int rbd_snap_rename(rbd_image_t image, const char *snapname,
+//				 const char* dstsnapsname);
+func (snapshot *Snapshot) Rename(destName string) error {
+	if err := snapshot.validate(imageNeedsIOContext | imageIsOpen | imageNeedsName | snapshotNeedsName); err != nil {
+		return err
+	}
+
+	cSrcName := C.CString(snapshot.name)
+	cDestName := C.CString(destName)
+	defer C.free(unsafe.Pointer(cSrcName))
+	defer C.free(unsafe.Pointer(cDestName))
+
+	err := C.rbd_snap_rename(snapshot.image.image, cSrcName, cDestName)
+	if err != 0 {
+		return getError(err)
+	}
+
+	snapshot.name = destName
+	return nil
+}

--- a/rbd/snapshot_rename_test.go
+++ b/rbd/snapshot_rename_test.go
@@ -1,0 +1,60 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenameSnapshot(t *testing.T) {
+	conn := radosConnect(t)
+	poolName := GetUUID()
+	err := conn.MakePool(poolName)
+	require.NoError(t, err)
+	ioctx, err := conn.OpenIOContext(poolName)
+	require.NoError(t, err)
+
+	name := GetUUID()
+	err = CreateImage(ioctx, name, 1<<22, NewRbdImageOptions())
+	require.NoError(t, err)
+
+	// create snapshot
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	require.NoError(t, err)
+	snapshotName := "mysnap"
+	snapshot, err := img.CreateSnapshot(snapshotName)
+	require.NoError(t, err)
+
+	// verify snapshot opens
+	snapImg, err := OpenImage(ioctx, name, snapshotName)
+	require.NoError(t, err)
+	err = snapImg.Close()
+	require.NoError(t, err)
+
+	// rename snapshot
+	newSnapshotName := "myrenamedsnap"
+	err = snapshot.Rename(newSnapshotName)
+	require.NoError(t, err)
+
+	// verify snapshot still opens
+	snapImg, err = OpenImage(ioctx, name, newSnapshotName)
+	require.NoError(t, err)
+	err = snapImg.Close()
+	require.NoError(t, err)
+
+	err = snapshot.Remove()
+	require.NoError(t, err)
+
+	err = img.Close()
+	require.NoError(t, err)
+	err = img.Remove()
+	require.NoError(t, err)
+
+	ioctx.Destroy()
+	err = conn.DeletePool(poolName)
+	require.NoError(t, err)
+	conn.Shutdown()
+}


### PR DESCRIPTION
This change creates a wrapper method for `rbd_snap_rename` so that Go clients can access that functionality. 

Let me know if there's anything that needs to be changed about this implementation! Once this is satisfactory, I would love to backport to v0.13 and v1.14.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Is this new API marked PREVIEW?