### PR TITLE
cephfs: add subvolume snapshot metadata APIs

### DIFF
--- a/cephfs/admin/snapshot_metadata.go
+++ b/cephfs/admin/snapshot_metadata.go
@@ -1,0 +1,109 @@
+//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
+// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+
+package admin
+
+import "C"
+
+// GetSnapshotMetadata gets custom metadata on the subvolume snapshot in a
+// volume belonging to an optional subvolume group based on provided key name.
+//
+// Similar To:
+//  ceph fs subvolume snapshot metadata get <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>]
+func (fsa *FSAdmin) GetSnapshotMetadata(volume, group, subvolume, snapname, key string) (string, error) {
+	m := map[string]string{
+		"prefix":    "fs subvolume snapshot metadata get",
+		"format":    "json",
+		"vol_name":  volume,
+		"sub_name":  subvolume,
+		"snap_name": snapname,
+		"key_name":  key,
+	}
+
+	if group != NoGroup {
+		m["group_name"] = group
+	}
+
+	return parsePathResponse(fsa.marshalMgrCommand(m))
+}
+
+// SetSnapshotMetadata sets custom metadata on the subvolume snapshot in a
+// volume belonging to an optional subvolume group as a key-value pair.
+//
+// Similar To:
+//  ceph fs subvolume snapshot metadata set <vol_name> <sub_name> <snap_name> <key_name> <value> [--group_name <subvol_group_name>]
+func (fsa *FSAdmin) SetSnapshotMetadata(volume, group, subvolume, snapname, key, value string) error {
+	m := map[string]string{
+		"prefix":    "fs subvolume snapshot metadata set",
+		"format":    "json",
+		"vol_name":  volume,
+		"sub_name":  subvolume,
+		"snap_name": snapname,
+		"key_name":  key,
+		"value":     value,
+	}
+
+	if group != NoGroup {
+		m["group_name"] = group
+	}
+
+	return fsa.marshalMgrCommand(m).NoData().End()
+}
+
+// RemoveSnapshotMetadata removes custom metadata set on the subvolume
+// snapshot in a volume belonging to an optional subvolume group using the
+// metadata key.
+//
+// Similar To:
+//  ceph fs subvolume snapshot metadata rm <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>]
+func (fsa *FSAdmin) RemoveSnapshotMetadata(volume, group, subvolume, snapname, key string) error {
+	return fsa.rmSubVolumeSnapShotMetadata(volume, group, subvolume, snapname, key, commonRmFlags{})
+}
+
+// ForceRemoveSnapshotMetadata attempt to forcefully remove custom metadata
+// set on the subvolume snapshot in a volume belonging to an optional
+// subvolume group using the metadata key.
+//
+// Similar To:
+//  ceph fs subvolume snapshot metadata rm <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>] --force
+func (fsa *FSAdmin) ForceRemoveSnapshotMetadata(volume, group, subvolume, snapname, key string) error {
+	return fsa.rmSubVolumeSnapShotMetadata(volume, group, subvolume, snapname, key, commonRmFlags{force: true})
+}
+
+func (fsa *FSAdmin) rmSubVolumeSnapShotMetadata(volume, group, subvolume, snapname, key string, o commonRmFlags) error {
+	m := map[string]string{
+		"prefix":    "fs subvolume snapshot metadata rm",
+		"format":    "json",
+		"vol_name":  volume,
+		"sub_name":  subvolume,
+		"snap_name": snapname,
+		"key_name":  key,
+	}
+
+	if group != NoGroup {
+		m["group_name"] = group
+	}
+
+	return fsa.marshalMgrCommand(mergeFlags(m, o)).NoData().End()
+}
+
+// ListSnapshotMetadata lists custom metadata (key-value pairs) set on the subvolume
+// snapshot in a volume belonging to an optional subvolume group.
+//
+// Similar To:
+//  ceph fs subvolume snapshot metadata ls <vol_name> <sub_name> <snap_name> [--group_name <subvol_group_name>]
+func (fsa *FSAdmin) ListSnapshotMetadata(volume, group, subvolume, snapname string) (map[string]string, error) {
+	m := map[string]string{
+		"prefix":    "fs subvolume snapshot metadata ls",
+		"format":    "json",
+		"vol_name":  volume,
+		"sub_name":  subvolume,
+		"snap_name": snapname,
+	}
+
+	if group != NoGroup {
+		m["group_name"] = group
+	}
+
+	return parseListKeyValues(fsa.marshalMgrCommand(m))
+}

--- a/cephfs/admin/snapshot_metadata_test.go
+++ b/cephfs/admin/snapshot_metadata_test.go
@@ -1,0 +1,179 @@
+//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
+// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+
+package admin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetSnapshotMetadata(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	group := "group"
+	subname := "subVol"
+	snapname := "snap1"
+	key := "hi"
+	value := "hello"
+
+	err := fsa.CreateSubVolumeGroup(volume, group, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolume(volume, group, subname, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+
+	err = fsa.SetSnapshotMetadata(volume, group, subname, snapname, key, value)
+	assert.NoError(t, err)
+
+	err := fsa.RemoveSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolume(volume, group, subname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolumeGroup(volume, group)
+	assert.NoError(t, err)
+}
+
+func TestGetSnapshotMetadata(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	group := "group"
+	subname := "subVol"
+	snapname := "snap1"
+	key := "hi"
+	value := "hello"
+
+	err := fsa.CreateSubVolumeGroup(volume, group, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolume(volume, group, subname, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+
+	err = fsa.SetSnapshotMetadata(volume, group, subname, snapname, key, value)
+	assert.NoError(t, err)
+
+	metaValue, err := fsa.GetSnapshotMetadata(volume, group, subname, snapname, key)
+	assert.NoError(t, err)
+	assert.Equal(t, metaValue, value)
+
+	err := fsa.RemoveSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolume(volume, group, subname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolumeGroup(volume, group)
+	assert.NoError(t, err)
+}
+
+func TestRemoveSnapshotMetadata(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	group := "group"
+	subname := "subVol"
+	snapname := "snap1"
+	key := "hi"
+	value := "hello"
+
+	err := fsa.CreateSubVolumeGroup(volume, group, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolume(volume, group, subname, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+
+	err = fsa.SetSnapshotMetadata(volume, group, subname, snapname, key, value)
+	assert.NoError(t, err)
+
+	metaValue, err := fsa.GetSnapshotMetadata(volume, group, subname, snapname, key)
+	assert.NoError(t, err)
+	assert.Equal(t, metaValue, value)
+
+	err = fsa.RemoveSnapshotMetadata(volume, group, subname, snapname, key)
+	assert.NoError(t, err)
+
+	metaValue, err = fsa.GetSnapshotMetadata(volume, group, subname, snapname, key)
+	assert.Error(t, err)
+
+	err := fsa.RemoveSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolume(volume, group, subname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolumeGroup(volume, group)
+	assert.NoError(t, err)
+}
+
+func TestForceRemoveSnapshotMetadata(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	group := "group"
+	subname := "subVol"
+	snapname := "snap1"
+	key := "hi"
+	value := "hello"
+
+	err := fsa.CreateSubVolumeGroup(volume, group, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolume(volume, group, subname, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+
+	err = fsa.SetSnapshotMetadata(volume, group, subname, snapname, key, value)
+	assert.NoError(t, err)
+
+	metaValue, err := fsa.GetSnapshotMetadata(volume, group, subname, snapname, key)
+	assert.NoError(t, err)
+	assert.Equal(t, metaValue, value)
+
+	err = fsa.ForceRemoveSnapshotMetadata(volume, group, subname, snapname, key)
+	assert.NoError(t, err)
+
+	metaValue, err = fsa.GetSnapshotMetadata(volume, group, subname, snapname, key)
+	assert.Error(t, err)
+
+	err := fsa.RemoveSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolume(volume, group, subname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolumeGroup(volume, group)
+	assert.NoError(t, err)
+}
+
+func TestListSnapshotMetadata(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	group := "group"
+	subname := "subVol"
+	snapname := "snap1"
+	key1 := "hi1"
+	value1 := "hello1"
+	key2 := "hi2"
+	value2 := "hello2"
+
+	err := fsa.CreateSubVolumeGroup(volume, group, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolume(volume, group, subname, nil)
+	assert.NoError(t, err)
+	err = fsa.CreateSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+
+	err = fsa.SetSnapshotMetadata(volume, group, subname, snapname, key1, value1)
+	assert.NoError(t, err)
+	err = fsa.SetSnapshotMetadata(volume, group, subname, snapname, key2, value2)
+	assert.NoError(t, err)
+
+	metaList, err := fsa.ListSnapshotMetadata(volume, group, subname, snapname)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(metaList), 2)
+	assert.Contains(t, metaList, key1)
+	assert.Contains(t, metaList, key2)
+
+	err := fsa.RemoveSubVolumeSnapshot(volume, group, subname, snapname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolume(volume, group, subname)
+	assert.NoError(t, err)
+	err = fsa.RemoveSubVolumeGroup(volume, group)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Description
Exports below APIs:
SetSnapshotMetadata,
GetSnapshotMetadata(),
RemoveSnapshotMetadata(),
ForceRemoveSnapshotMetadata() and
ListSnapshotMetadata()

Signed-off-by: Prasanna Kumar Kalever \<prasanna.kalever@redhat.com\>



## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Is this new API marked PREVIEW?

Additional information to reviewers/Maintainers:
~~This PR needs https://github.com/ceph/ceph/pull/46086 which is not merged upstream yet, but the cmd schemas will mostly be same.~~
Update: https://github.com/ceph/ceph/pull/46086 is merged upstream now.
