### PR TITLE
Rgw/admin: add num_shards to  bucket struct field

### DIFF
--- a/rgw/admin/bucket.go
+++ b/rgw/admin/bucket.go
@@ -9,9 +9,10 @@ import (
 
 // Bucket describes an object store bucket
 type Bucket struct {
-	Bucket            string `json:"bucket" url:"bucket"`
-	Zonegroup         string `json:"zonegroup"`
-	PlacementRule     string `json:"placement_rule"`
+	Bucket            string  `json:"bucket" url:"bucket"`
+	NumShards         *uint64 `json:"num_shards"`
+	Zonegroup         string  `json:"zonegroup"`
+	PlacementRule     string  `json:"placement_rule"`
 	ExplicitPlacement struct {
 		DataPool      string `json:"data_pool"`
 		DataExtraPool string `json:"data_extra_pool"`


### PR DESCRIPTION
This change add a new bucket struct field , so we can use rgw.admin.API.GetBucketInfo() to get a bucket's num_shards.


```
radosgw-admin bucket stats --bucket test
{
    "bucket": "test",
    "num_shards": 11,    <<<<    NumShards  *uint64 `json:"num_shards"
    "tenant": "",
    "zonegroup": "d9d22c42-ea25-44df-bded-506b5d64bc82",
    ... 
}
```



## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
