### PR TITLE
cephfs admin: remove deprecated EnableModule, DisableModule funcs

### DIFF
--- a/cephfs/admin/mgrmodule.go
+++ b/cephfs/admin/mgrmodule.go
@@ -6,28 +6,6 @@ import (
 
 const mirroring = "mirroring"
 
-// EnableModule will enable the specified manager module.
-//
-// Deprecated: use the equivalent function in cluster/admin/manager.
-//
-// Similar To:
-//  ceph mgr module enable <module> [--force]
-func (fsa *FSAdmin) EnableModule(module string, force bool) error {
-	mgradmin := manager.NewFromConn(fsa.conn)
-	return mgradmin.EnableModule(module, force)
-}
-
-// DisableModule will disable the specified manager module.
-//
-// Deprecated: use the equivalent function in cluster/admin/manager.
-//
-// Similar To:
-//  ceph mgr module disable <module>
-func (fsa *FSAdmin) DisableModule(module string) error {
-	mgradmin := manager.NewFromConn(fsa.conn)
-	return mgradmin.DisableModule(module)
-}
-
 // EnableMirroringModule will enable the mirroring module for cephfs.
 //
 // Similar To:

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -496,20 +496,7 @@
         "comment": "VolumeStatus returns a VolumeStatus object for the given volume name.\n\nSimilar To:\n ceph fs status cephfs <name>\n"
       }
     ],
-    "deprecated_api": [
-      {
-        "name": "FSAdmin.EnableModule",
-        "comment": "EnableModule will enable the specified manager module.\n\nDeprecated: use the equivalent function in cluster/admin/manager.\n\nSimilar To:\n ceph mgr module enable <module> [--force]\n",
-        "deprecated_in_version": "v0.14.0",
-        "expected_remove_version": "v0.16.0"
-      },
-      {
-        "name": "FSAdmin.DisableModule",
-        "comment": "DisableModule will disable the specified manager module.\n\nDeprecated: use the equivalent function in cluster/admin/manager.\n\nSimilar To:\n ceph mgr module disable <module>\n",
-        "deprecated_in_version": "v0.14.0",
-        "expected_remove_version": "v0.16.0"
-      }
-    ],
+    "deprecated_api": [],
     "preview_api": [
       {
         "name": "CloneStatus.GetFailure",


### PR DESCRIPTION
As per the planned removal in api-status
