### PR TITLE
rados: Implement rados_set_alloc_hint2

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1017,6 +1017,18 @@
         "comment": "SetLocator sets the key for mapping objects to pgs within an io context.\nUntil a different locator key is set, all objects in this io context will be placed in the same pg.\nTo reset the locator, an empty string must be set.\n\nImplements:\n void rados_ioctx_locator_set_key(rados_ioctx_t io, const char *key);\n",
         "added_in_version": "v0.15.0",
         "expected_stable_version": "v0.17.0"
+      },
+      {
+        "name": "IOContext.SetAllocationHint",
+        "comment": "SetAllocationHint sets allocation hint for an object. This is an advisory\noperation, it will always succeed (as if it was submitted with a\nLIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on\nthe backend.\n\nImplements:\n int rados_set_alloc_hint2(rados_ioctx_t io,\n                           const char *o,\n                           uint64_t expected_object_size,\n                           uint64_t expected_write_size,\n                           uint32_t flags);\n",
+        "added_in_version": "v0.17.0",
+        "expected_stable_version": "v0.19.0"
+      },
+      {
+        "name": "WriteOp.SetAllocationHint",
+        "comment": "SetAllocationHint sets allocation hint for an object. This is an advisory\noperation, it will always succeed (as if it was submitted with a\nLIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on\nthe backend.\n\nImplements:\n void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,\n                                     uint64_t expected_object_size,\n                                     uint64_t expected_write_size,\n                                     uint32_t flags);\n",
+        "added_in_version": "v0.17.0",
+        "expected_stable_version": "v0.19.0"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -26,6 +26,8 @@ FSAdmin.DisableModule | v0.14.0 | v0.16.0 |
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 IOContext.SetLocator | v0.15.0 | v0.17.0 | 
+IOContext.SetAllocationHint | v0.17.0 | v0.19.0 | 
+WriteOp.SetAllocationHint | v0.17.0 | v0.19.0 | 
 
 ## Package: rbd
 

--- a/rados/alloc_hint_flags.go
+++ b/rados/alloc_hint_flags.go
@@ -1,0 +1,37 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+//
+import "C"
+
+// AllocHintFlags control the behavior of read and write operations.
+type AllocHintFlags uint32
+
+const (
+	// AllocHintNoHint indicates no predefined behavior
+	AllocHintNoHint = AllocHintFlags(0)
+	// AllocHintSequentialWrite TODO
+	AllocHintSequentialWrite = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_SEQUENTIAL_WRITE)
+	// AllocHintRandomWrite TODO
+	AllocHintRandomWrite = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_RANDOM_WRITE)
+	// AllocHintSequentialRead TODO
+	AllocHintSequentialRead = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_SEQUENTIAL_READ)
+	// AllocHintRandomRead TODO
+	AllocHintRandomRead = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_RANDOM_READ)
+	// AllocHintAppendOnly TODO
+	AllocHintAppendOnly = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_APPEND_ONLY)
+	// AllocHintImmutable TODO
+	AllocHintImmutable = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_IMMUTABLE)
+	// AllocHintShortlived TODO
+	AllocHintShortlived = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_SHORTLIVED)
+	// AllocHintLonglived TODO
+	AllocHintLonglived = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_LONGLIVED)
+	// AllocHintCompressible TODO
+	AllocHintCompressible = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_COMPRESSIBLE)
+	// AllocHintIncompressible TODO
+	AllocHintIncompressible = AllocHintFlags(C.LIBRADOS_ALLOC_HINT_FLAG_INCOMPRESSIBLE)
+)

--- a/rados/ioctx_set_alloc_hint.go
+++ b/rados/ioctx_set_alloc_hint.go
@@ -1,0 +1,38 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+import (
+	"unsafe"
+)
+
+// SetAllocationHint sets allocation hint for an object. This is an advisory
+// operation, it will always succeed (as if it was submitted with a
+// LIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on
+// the backend.
+//
+// Implements:
+//  int rados_set_alloc_hint2(rados_ioctx_t io,
+//                            const char *o,
+//                            uint64_t expected_object_size,
+//                            uint64_t expected_write_size,
+//                            uint32_t flags);
+func (ioctx *IOContext) SetAllocationHint(oid string, expectedObjectSize uint64, expectedWriteSize uint64, flags AllocHintFlags) error {
+	coid := C.CString(oid)
+	defer C.free(unsafe.Pointer(coid))
+
+	return getError(C.rados_set_alloc_hint2(
+		ioctx.ioctx,
+		coid,
+		(C.uint64_t)(expectedObjectSize),
+		(C.uint64_t)(expectedWriteSize),
+		(C.uint32_t)(flags),
+	))
+}

--- a/rados/ioctx_set_alloc_hint_test.go
+++ b/rados/ioctx_set_alloc_hint_test.go
@@ -1,0 +1,26 @@
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestSetAllocationHint() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestSetAllocationHint"
+	data := []byte("write this")
+
+	ioctx, err := suite.conn.OpenIOContext(suite.pool)
+	ta.NoError(err)
+	err = ioctx.SetAllocationHint(oid, 4096, 20, AllocHintCompressible|AllocHintLonglived|AllocHintRandomRead|AllocHintSequentialWrite)
+	ta.NoError(err)
+	err = ioctx.WriteFull(oid, []byte(data))
+	ta.NoError(err)
+	err = ioctx.SetAllocationHint(oid, 128, 128, AllocHintShortlived|AllocHintAppendOnly)
+	ta.NoError(err)
+	err = ioctx.Append(oid, []byte(data))
+	ta.NoError(err)
+	err = ioctx.SetAllocationHint(oid, 20, 0, AllocHintNoHint)
+	ta.NoError(err)
+}

--- a/rados/write_op_set_alloc_hint.go
+++ b/rados/write_op_set_alloc_hint.go
@@ -1,0 +1,28 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// SetAllocationHint sets allocation hint for an object. This is an advisory
+// operation, it will always succeed (as if it was submitted with a
+// LIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on
+// the backend.
+//
+// Implements:
+//  void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,
+//                                      uint64_t expected_object_size,
+//                                      uint64_t expected_write_size,
+//                                      uint32_t flags);
+func (w *WriteOp) SetAllocationHint(expectedObjectSize uint64, expectedWriteSize uint64, flags AllocHintFlags) {
+	C.rados_write_op_set_alloc_hint2(
+		w.op,
+		C.uint64_t(expectedObjectSize),
+		C.uint64_t(expectedWriteSize),
+		C.uint32_t(flags))
+}

--- a/rados/write_op_set_alloc_hint_test.go
+++ b/rados/write_op_set_alloc_hint_test.go
@@ -1,0 +1,29 @@
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestWriteOpSetAllocationHint() {
+	suite.SetupConnection()
+	ta := assert.New(suite.T())
+
+	oid := "TestWriteOpSetAllocationHint"
+	data := []byte("write this")
+
+	// Create an object and populate it with data.
+	op1 := CreateWriteOp()
+	defer op1.Release()
+	op1.Create(CreateIdempotent)
+	op1.SetAllocationHint(4096, 20, AllocHintCompressible|AllocHintLonglived)
+	op1.WriteFull([]byte(data))
+	err := op1.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+
+	op2 := CreateWriteOp()
+	defer op2.Release()
+	op2.SetAllocationHint(4096, 200, AllocHintNoHint)
+	op2.WriteSame([]byte(data), 200, uint64(len(data)))
+	err = op2.Operate(suite.ioctx, oid, OperationNoFlag)
+	ta.NoError(err)
+}


### PR DESCRIPTION
Signed-off-by: Quentin Devos <4972091+Okhoshi@users.noreply.github.com>

Add support in go-ceph:
- rados_set_alloc_hint2
- rados_write_op_set_alloc_hint2

Closes #697 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`

I'm not sure how I'm supposed to test the Allocation Hint, especially since I'm not aware of a way to check the Allocation hints set on a file, and that the functions never return errors.