### PR TITLE
rados: Make sure Conn isn't GC'd while it has dependant IOContexts.

### DIFF
--- a/rados/conn.go
+++ b/rados/conn.go
@@ -100,7 +100,7 @@ func (c *Conn) ReadDefaultConfigFile() error {
 func (c *Conn) OpenIOContext(pool string) (*IOContext, error) {
 	cPool := C.CString(pool)
 	defer C.free(unsafe.Pointer(cPool))
-	ioctx := &IOContext{}
+	ioctx := &IOContext{conn: c}
 	ret := C.rados_ioctx_create(c.cluster, cPool, &ioctx.ioctx)
 	if ret == 0 {
 		return ioctx, nil

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -99,6 +99,11 @@ type LockInfo struct {
 // IOContext represents a context for performing I/O within a pool.
 type IOContext struct {
 	ioctx C.rados_ioctx_t
+
+	// Hold a reference back to the connection that the ioctx depends on so
+	// that Go's GC doesn't trigger the Conn's finalizer before this
+	// IOContext is destroyed.
+	conn *Conn
 }
 
 // validate returns an error if the ioctx is not ready to be used


### PR DESCRIPTION
Because we have a finalizer configured for Conn that cleans up Ceph resources, it's important that we don't let it get GC'd before anything that depends on it has been cleaned up. Since clients are free to hold a reference to an IOContext without maintaining a reference to the underlying Conn, we hold such a Conn reference within the IOContext to signal this dependency to the Go GC.

Fixes https://github.com/ceph/go-ceph/issues/569.