### PR TITLE
CI: remove non-ptrguard tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run tests
       run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "RESULTS_DIR=$PWD/_results"
-    - name: Run tests without ptrguard
-      run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "NO_PTRGUARD=true" "RESULTS_DIR=$PWD/_results"
     - name: Clean up test containers
       run: make test-containers-clean "CEPH_VERSION=${{ matrix.ceph_version }}"
     - name: Archive coverage results


### PR DESCRIPTION
We will (most probably) remove non-ptrguard code before the next
release. Let's skip the tests already now, because they double the
likelihood of failing flaky tests.

Signed-off-by: Sven Anderson <sven@redhat.com>

