### PR TITLE
CI: also disable TestCancelClone for pacific

### DIFF
--- a/cephfs/admin/clone_test.go
+++ b/cephfs/admin/clone_test.go
@@ -143,8 +143,8 @@ func TestCloneSubVolumeSnapshot(t *testing.T) {
 }
 
 func TestCancelClone(t *testing.T) {
-	if serverVersion == cephQuincy {
-		t.Skipf("temporarily disabled on quincy: very flaky")
+	if serverVersion == cephQuincy || serverVersion == cephPacfic {
+		t.Skipf("temporarily disabled on quincy and pacific: very flaky")
 	}
 
 	fsa := getFSAdmin(t)


### PR DESCRIPTION
The code causing this issue has been packported to pacific and blocks
the CI. We need to temporarily disable for pacific as well.

Signed-off-by: Sven Anderson <sven@redhat.com>
