### PR TITLE
go-ceph: bump Go version of module to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,17 @@
 module github.com/ceph/go-ceph
 
-go 1.12
+go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.44.47
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Updates the Go version of the module with `go mod tidy -go 1.17`,
which also adds some explicit requirements in order to support lazy
module loading.

Signed-off-by: Sven Anderson <sven@redhat.com>
