### PR TITLE
rados: add support for retrieving the alignment (stripe) size

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1029,6 +1029,18 @@
         "comment": "SetAllocationHint sets allocation hint for an object. This is an advisory\noperation, it will always succeed (as if it was submitted with a\nLIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on\nthe backend.\n\nImplements:\n void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,\n                                     uint64_t expected_object_size,\n                                     uint64_t expected_write_size,\n                                     uint32_t flags);\n",
         "added_in_version": "v0.17.0",
         "expected_stable_version": "v0.19.0"
+      },
+      {
+        "name": "IOContext.Alignment",
+        "comment": "Alignment returns the required stripe size in bytes for pools supporting/requiring it, or an error if unsuccessful.\nFor an EC pool, a buffer size multiple of its stripe size is required to call Append. To know if the pool requires\nalignment or not, use RequiresAlignment.\n\nImplements:\n int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t *alignment)\n",
+        "added_in_version": "v0.17.0",
+        "expected_stable_version": "v0.19.0"
+      },
+      {
+        "name": "IOContext.RequiresAlignment",
+        "comment": "RequiresAlignment returns true if the pool supports/requires alignment or an error if not successful.\nFor an EC pool, a buffer size multiple of its stripe size is required to call Append. See\nAlignment to know how to get the stripe size for pools requiring it.\n\nImplements:\n int rados_ioctx_pool_requires_alignment2(rados_ioctx_t io, int *req)\n",
+        "added_in_version": "v0.17.0",
+        "expected_stable_version": "v0.19.0"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -16,8 +16,6 @@ CloneStatus.GetFailure | v0.16.0 | v0.18.0 |
 
 Name | Deprecated in Version | Expected Removal Version | 
 ---- | --------------------- | ------------------------ | 
-FSAdmin.EnableModule | v0.14.0 | v0.16.0 | 
-FSAdmin.DisableModule | v0.14.0 | v0.16.0 | 
 
 ## Package: rados
 
@@ -28,6 +26,8 @@ Name | Added in Version | Expected Stable Version |
 IOContext.SetLocator | v0.15.0 | v0.17.0 | 
 IOContext.SetAllocationHint | v0.17.0 | v0.19.0 | 
 WriteOp.SetAllocationHint | v0.17.0 | v0.19.0 | 
+IOContext.Alignment | v0.17.0 | v0.19.0 | 
+IOContext.RequiresAlignment | v0.17.0 | v0.19.0 | 
 
 ## Package: rbd
 

--- a/rados/ioctx_pool_alignment.go
+++ b/rados/ioctx_pool_alignment.go
@@ -1,0 +1,27 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// Alignment returns the required stripe size in bytes for pools supporting/requiring it, or an error if unsuccessful.
+// For an EC pool, a buffer size multiple of its stripe size is required to call Append. To know if the pool requires
+// alignment or not, use RequiresAlignment.
+//
+// Implements:
+//  int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t *alignment)
+func (ioctx *IOContext) Alignment() (uint64, error) {
+	var alignSizeBytes C.uint64_t
+	ret := C.rados_ioctx_pool_required_alignment2(
+		ioctx.ioctx,
+		&alignSizeBytes)
+	if ret != 0 {
+		return 0, getError(ret)
+	}
+	return uint64(alignSizeBytes), nil
+}

--- a/rados/ioctx_pool_alignment_test.go
+++ b/rados/ioctx_pool_alignment_test.go
@@ -1,0 +1,15 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestAlignment() {
+	suite.SetupConnection()
+
+	_, err := suite.ioctx.Alignment()
+	assert.NoError(suite.T(), err)
+}

--- a/rados/ioctx_pool_requires_alignment.go
+++ b/rados/ioctx_pool_requires_alignment.go
@@ -1,0 +1,27 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <rados/librados.h>
+// #include <stdlib.h>
+//
+import "C"
+
+// RequiresAlignment returns true if the pool supports/requires alignment or an error if not successful.
+// For an EC pool, a buffer size multiple of its stripe size is required to call Append. See
+// Alignment to know how to get the stripe size for pools requiring it.
+//
+// Implements:
+//  int rados_ioctx_pool_requires_alignment2(rados_ioctx_t io, int *req)
+func (ioctx *IOContext) RequiresAlignment() (bool, error) {
+	var alignRequired C.int
+	ret := C.rados_ioctx_pool_requires_alignment2(
+		ioctx.ioctx,
+		&alignRequired)
+	if ret != 0 {
+		return false, getError(ret)
+	}
+	return (alignRequired != 0), nil
+}

--- a/rados/ioctx_pool_requires_alignment_test.go
+++ b/rados/ioctx_pool_requires_alignment_test.go
@@ -1,0 +1,15 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestRequiresAlignment() {
+	suite.SetupConnection()
+
+	_, err := suite.ioctx.RequiresAlignment()
+	assert.NoError(suite.T(), err)
+}


### PR DESCRIPTION
Add support for retrieving whether a pool supports/requires write alignment and its size in bytes.

Fixes #739 
