### PR TITLE
cephfs/admin: Replace 'untested' with pre-release tags

### DIFF
--- a/cephfs/admin/metadata.go
+++ b/cephfs/admin/metadata.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
-// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
+// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
 
 package admin
 

--- a/cephfs/admin/metadata_test.go
+++ b/cephfs/admin/metadata_test.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
-// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
+// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
 
 package admin
 

--- a/cephfs/admin/snapshot_metadata.go
+++ b/cephfs/admin/snapshot_metadata.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
-// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
+// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
 
 package admin
 

--- a/cephfs/admin/snapshot_metadata_test.go
+++ b/cephfs/admin/snapshot_metadata_test.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_ci_untested
-// +build !nautilus,!octopus,ceph_preview,ceph_ci_untested
+//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
+// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
 
 package admin
 


### PR DESCRIPTION
Now that we have support for testing APIs from pre-release Ceph versions lets convert the current **ceph_ci_untested** tag into
corresponding pre-release version tags.

Depends on: #743