### PR TITLE
workflows: Add pre-release targets to ceph version matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ jobs:
         - "octopus"
         - "pacific"
         - "quincy"
+        - "pre-pacific"
+        - "pre-quincy"
+        - "main"
     steps:
     - uses: actions/checkout@v2
     - name: Run tests

--- a/cephfs/admin/fsadmin_test.go
+++ b/cephfs/admin/fsadmin_test.go
@@ -22,11 +22,12 @@ const (
 	cephOctopus  = "octopus"
 	cephPacfic   = "pacific"
 	cephQuincy   = "quincy"
+	cephMain     = "main"
 )
 
 func init() {
 	switch vname := os.Getenv("CEPH_VERSION"); vname {
-	case cephNautilus, cephOctopus, cephPacfic, cephQuincy:
+	case cephNautilus, cephOctopus, cephPacfic, cephQuincy, cephMain:
 		serverVersion = vname
 	}
 }


### PR DESCRIPTION
Adds GitHub CI jobs for pre-release versions of **quincy** and **pacific** along with **main** development branch.