### PR TITLE
github: update dependabot configuration to better match go-ceph style

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     rebase-strategy: "disabled"
     labels:
-      - rebase
+      - "no-API"
     commit-message:
-      prefix: "rebase"
+      prefix: "go-ceph"


### PR DESCRIPTION
Lower the frequency of updates. The monthly update is documented to
occur on the first of the month, which works better with our
every-other-month release cadence.
Automatically apply the "no-API" label. Do not add a rebase label, which
has not relevance to the go-ceph workflow.
Use the prefix "go-ceph:" which is what we normally use for changes only
to the go.mode, etc.
