### PR TITLE
contrib: add new fix-versions mode to apiage.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,8 +266,12 @@ api-check: implements-json
 	./contrib/apiage.py
 
 api-update: implements-json
-	./contrib/apiage.py --mode=update \
+	./contrib/apiage.py --mode=update --placeholder-versions
+
+api-fix-versions:
+	./contrib/apiage.py --mode=fix-versions \
 		--current-tag="$$(git describe --tags --abbrev=0)"
+	./contrib/apiage.py --mode=write-doc
 
 api-doc:
 	./contrib/apiage.py --mode=write-doc


### PR DESCRIPTION

Fixes: #718
    
This change adds a new "fix-versions" mode to apiage.py, as well as the ability to set placeholder version values when adding a new API. The fix-versions mode replaces placeholder versions with real version
numbers. When fixing versions, the --fix-filter-pkg & --fix-filter-func options can be used to narrow down what APIs will be fixed in case not all version placeholder should be fixed to the same values.

  
In order to simplify the workflow for contributors we'll continue to ask people to run `make api-update` when contributing new APIs. This will record the API in our api-status files. However, it will now use a
placeholder value without a real version number. If a PR is filed and is not accepted before the next scheduled release the maintenance team will not have to ask the contributor to update the API versions
to correct the numbers.
    
Instead, we need to run the new `make api-fix-versions` rule at least once before a release to replace the placeholder versions with real version numbers.
