### PR TITLE
cephfs admin: remove unnecessary import C lines

### DIFF
--- a/cephfs/admin/metadata.go
+++ b/cephfs/admin/metadata.go
@@ -3,8 +3,6 @@
 
 package admin
 
-import "C"
-
 // GetMetadata gets custom metadata on the subvolume in a volume belonging to
 // an optional subvolume group based on provided key name.
 //

--- a/cephfs/admin/snapshot_metadata.go
+++ b/cephfs/admin/snapshot_metadata.go
@@ -3,8 +3,6 @@
 
 package admin
 
-import "C"
-
 // GetSnapshotMetadata gets custom metadata on the subvolume snapshot in a
 // volume belonging to an optional subvolume group based on provided key name.
 //


### PR DESCRIPTION
All the C functions needed by cephfs/admin package come from
one of the other go-ceph packages (rados, cephfs, etc) there's
no good reason to have this unused import in these files.

