### PR TITLE
apiage: Do not leave empty sections for packages in markdown

### DIFF
--- a/contrib/apiage.py
+++ b/contrib/apiage.py
@@ -184,6 +184,10 @@ def format_markdown(tracked, outfh):
                 outfh=outfh,
             )
             print("", file=outfh)
+        if all(x not in pkg_api for x in ("preview_api", "deprecated_api")):
+            print("No Preview/Deprecated APIs found. "
+                  "All APIs are considered stable.", file=outfh)
+            print("", file=outfh)
 
 
 def _table(data, columns, outfh):

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -4,6 +4,8 @@
 
 ## Package: cephfs
 
+No Preview/Deprecated APIs found. All APIs are considered stable.
+
 ## Package: cephfs/admin
 
 ### Preview APIs
@@ -47,6 +49,8 @@ Snapshot.Set | v0.10.0 |  |
 
 ## Package: rbd/admin
 
+No Preview/Deprecated APIs found. All APIs are considered stable.
+
 ## Package: rgw/admin
 
 ### Preview APIs
@@ -65,6 +69,8 @@ API.RemoveKey | v0.17.0 | v0.19.0 |
 API.SetIndividualBucketQuota | v0.17.0 | v0.19.0 | 
 
 ## Package: common/admin/manager
+
+No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: common/log
 


### PR DESCRIPTION
For those packages without any preview/deprecated APIs we used to include a header despite any content under it. We could instead mention the state in a meaningful sentence.

Fixes: #595 