### PR TITLE
Fix recent revive failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,12 +19,12 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.14
+        go-version: 1.18
     - uses: actions/checkout@v2
     - name: Install revive
-      run: go get github.com/mgechev/revive
+      run: go install github.com/mgechev/revive@latest
     - name: Run checks
       run: make check
 

--- a/.revive.toml
+++ b/.revive.toml
@@ -20,7 +20,13 @@ warningCode = 0
 [rule.var-naming]
   arguments = [["ID", "UID"]]
 [rule.var-declaration]
+# We need to disable the package-comments check because we check all the .go
+# files in the repo individually. This appears to confuse the new
+# pacakge-comments implementation as it works correctly with ./... or ./a/b/c
+# but not ./a/b/c/*.go. We need the latter input style as we have files with
+# build tags we want to check, as well as multiple modules, within the repo.
 [rule.package-comments]
+  disabled = true
 [rule.range]
 [rule.receiver-naming]
 [rule.time-naming]


### PR DESCRIPTION
With the newest version of revive there appears to be no way to have it both check all .go files individually and have it properly detect the package-comments rule.

I took the lazy way out and simply disabled the rule in the config file rather than try to do something more complicated.

Fixes: #754 
