### PR TITLE
apiage: ability to promote apis tracked in JSON from preview to stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,11 @@ api-check: implements-json
 api-update: implements-json
 	./contrib/apiage.py --mode=update --placeholder-versions
 
+api-promote: implements-json
+	./contrib/apiage.py --mode=promote \
+		--current-tag="$$(git describe --tags --abbrev=0)"
+	./contrib/apiage.py --mode=write-doc
+
 api-fix-versions:
 	./contrib/apiage.py --mode=fix-versions \
 		--current-tag="$$(git describe --tags --abbrev=0)"


### PR DESCRIPTION
Depends on #759 

Fixes: #760 

The intended workflow is to update the Go source code and then run `make
api-promote` which will detect the changes to the ceph_preview tag(s) in
the sources and then promote apis from preview to stable in the
tracking json.

I explicitly do not want apiage.py (or the makefile) to make changes to
the source code. The contributor may or may not want to make changes
incrementally, also some times a preview function may be moved to
another source file. Plus, I simply think this is a job for a human.
But we can avoid having to edit the JSON and markdown files afterward.