### PR TITLE
cephfs: fix a minor typo in a doc comment

### DIFF
--- a/cephfs/file.go
+++ b/cephfs/file.go
@@ -337,7 +337,7 @@ const (
 	// LockEX places an exclusive lock.
 	// Only one process may hold an exclusive lock for a given file at a given time.
 	LockEX = LockOp(C.LOCK_EX)
-	// LockUN removes and existing lock held by this process.
+	// LockUN removes an existing lock held by this process.
 	LockUN = LockOp(C.LOCK_UN)
 	// LockNB can be ORed with any of the above to make a nonblocking call.
 	LockNB = LockOp(C.LOCK_NB)


### PR DESCRIPTION


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
