### PR TITLE
Make preview apis stable for v0.18

### DIFF
--- a/cephfs/admin/clone_nautilus.go
+++ b/cephfs/admin/clone_nautilus.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 // GetFailure returns details about the CloneStatus when in CloneFailed state.

--- a/cephfs/admin/clone_nautilus_test.go
+++ b/cephfs/admin/clone_nautilus_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (

--- a/common/admin/nfs/admin.go
+++ b/common/admin/nfs/admin.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview
-// +build !nautilus,!octopus,ceph_preview
+//go:build !(nautilus || octopus)
+// +build !nautilus,!octopus
 
 package nfs
 

--- a/common/admin/nfs/export.go
+++ b/common/admin/nfs/export.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview
-// +build !nautilus,!octopus,ceph_preview
+//go:build !(nautilus || octopus)
+// +build !nautilus,!octopus
 
 package nfs
 

--- a/common/admin/nfs/export_test.go
+++ b/common/admin/nfs/export_test.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview
-// +build !nautilus,!octopus,ceph_preview
+//go:build !(nautilus || octopus)
+// +build !nautilus,!octopus
 
 package nfs
 

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -494,17 +494,16 @@
       {
         "name": "FSAdmin.VolumeStatus",
         "comment": "VolumeStatus returns a VolumeStatus object for the given volume name.\n\nSimilar To:\n ceph fs status cephfs <name>\n"
-      }
-    ],
-    "deprecated_api": [],
-    "preview_api": [
+      },
       {
         "name": "CloneStatus.GetFailure",
         "comment": "GetFailure returns details about the CloneStatus when in CloneFailed state.\n\nSimilar To:\n Reading the .failure object from the JSON returned by \"ceph fs subvolume\n snapshot clone\"\n",
         "added_in_version": "v0.16.0",
-        "expected_stable_version": "v0.18.0"
+        "became_stable_version": "v0.18.0"
       }
-    ]
+    ],
+    "deprecated_api": [],
+    "preview_api": []
   },
   "rados": {
     "stable_api": [

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1921,36 +1921,37 @@
     ]
   },
   "common/admin/nfs": {
-    "preview_api": [
+    "preview_api": [],
+    "stable_api": [
       {
         "name": "NewFromConn",
-        "comment": "NewFromConn creates an new management object from a preexisting\nrados connection. The existing connection can be rados.Conn or any\ntype implementing the RadosCommander interface.\n PREVIEW\n",
+        "comment": "NewFromConn creates an new management object from a preexisting\nrados connection. The existing connection can be rados.Conn or any\ntype implementing the RadosCommander interface.\n",
         "added_in_version": "v0.16.0",
-        "expected_stable_version": "v0.18.0"
+        "became_stable_version": "v0.18.0"
       },
       {
         "name": "Admin.CreateCephFSExport",
-        "comment": "CreateCephFSExport will create a new NFS export for a CephFS file system.\n PREVIEW\n\nSimilar To:\n ceph nfs export create cephfs\n",
+        "comment": "CreateCephFSExport will create a new NFS export for a CephFS file system.\n\nSimilar To:\n ceph nfs export create cephfs\n",
         "added_in_version": "v0.16.0",
-        "expected_stable_version": "v0.18.0"
+        "became_stable_version": "v0.18.0"
       },
       {
         "name": "Admin.RemoveExport",
-        "comment": "RemoveExport will remove an NFS export based on the pseudo-path of the export.\n PREVIEW\n\nSimilar To:\n ceph nfs export rm\n",
+        "comment": "RemoveExport will remove an NFS export based on the pseudo-path of the export.\n\nSimilar To:\n ceph nfs export rm\n",
         "added_in_version": "v0.16.0",
-        "expected_stable_version": "v0.18.0"
+        "became_stable_version": "v0.18.0"
       },
       {
         "name": "Admin.ListDetailedExports",
-        "comment": "ListDetailedExports will return a list of exports with details.\n PREVIEW\n\nSimilar To:\n ceph nfs export ls --detailed\n",
+        "comment": "ListDetailedExports will return a list of exports with details.\n\nSimilar To:\n ceph nfs export ls --detailed\n",
         "added_in_version": "v0.16.0",
-        "expected_stable_version": "v0.18.0"
+        "became_stable_version": "v0.18.0"
       },
       {
         "name": "Admin.ExportInfo",
-        "comment": "ExportInfo will return a structure describing the export specified by it's\npseudo-path.\n PREVIEW\n\nSimilar To:\n ceph nfs export info\n",
+        "comment": "ExportInfo will return a structure describing the export specified by it's\npseudo-path.\n\nSimilar To:\n ceph nfs export info\n",
         "added_in_version": "v0.16.0",
-        "expected_stable_version": "v0.18.0"
+        "became_stable_version": "v0.18.0"
       }
     ]
   }

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1668,16 +1668,15 @@
       {
         "name": "Watch.Unwatch",
         "comment": "Unwatch un-registers the image watch.\n\nImplements:\n int rbd_update_unwatch(rbd_image_t image, uint64_t handle);\n"
-      }
-    ],
-    "preview_api": [
+      },
       {
         "name": "Snapshot.Rename",
-        "comment": "Rename a snapshot.\n\nImplements:\n int rbd_snap_rename(rbd_image_t image, const char *snapname, const char* dstsnapsname);\n",
+        "comment": "Rename a snapshot.\n\nImplements:\n\tint rbd_snap_rename(rbd_image_t image, const char *snapname,\n\t\t\t\t const char* dstsnapsname);\n",
         "added_in_version": "v0.16.0",
-        "expected_stable_version": "v0.18.0"
+        "became_stable_version": "v0.18.0"
       }
-    ]
+    ],
+    "preview_api": []
   },
   "rbd/admin": {
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -74,9 +74,4 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-NewFromConn | v0.16.0 | v0.18.0 | 
-Admin.CreateCephFSExport | v0.16.0 | v0.18.0 | 
-Admin.RemoveExport | v0.16.0 | v0.18.0 | 
-Admin.ListDetailedExports | v0.16.0 | v0.18.0 | 
-Admin.ExportInfo | v0.16.0 | v0.18.0 | 
 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -35,7 +35,6 @@ IOContext.RequiresAlignment | v0.17.0 | v0.19.0 |
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-Snapshot.Rename | v0.16.0 | v0.18.0 | 
 
 ### Deprecated APIs
 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -12,7 +12,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-CloneStatus.GetFailure | v0.16.0 | v0.18.0 | 
 
 ### Deprecated APIs
 

--- a/rbd/snapshot_rename.go
+++ b/rbd/snapshot_rename.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rbd
 
 // #cgo LDFLAGS: -lrbd

--- a/rbd/snapshot_rename_test.go
+++ b/rbd/snapshot_rename_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rbd
 
 import (


### PR DESCRIPTION
Three packages had apis becoming stable for release v0.18, scheduled for tomorrow (2022-10-18).

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
