### PR TITLE
apiage: Remove empty tables from API status markdown

### DIFF
--- a/contrib/apiage.py
+++ b/contrib/apiage.py
@@ -226,7 +226,7 @@ def format_markdown(tracked, outfh):
     for pkg, pkg_api in tracked.items():
         print(f"## Package: {pkg}", file=outfh)
         print("", file=outfh)
-        if "preview_api" in pkg_api:
+        if "preview_api" in pkg_api and pkg_api["preview_api"]:
             print("### Preview APIs", file=outfh)
             print("", file=outfh)
             _table(
@@ -239,7 +239,7 @@ def format_markdown(tracked, outfh):
                 outfh=outfh,
             )
             print("", file=outfh)
-        if "deprecated_api" in pkg_api:
+        if "deprecated_api" in pkg_api and pkg_api["deprecated_api"]:
             print("### Deprecated APIs", file=outfh)
             print("", file=outfh)
             _table(
@@ -252,7 +252,8 @@ def format_markdown(tracked, outfh):
                 outfh=outfh,
             )
             print("", file=outfh)
-        if all(x not in pkg_api for x in ("preview_api", "deprecated_api")):
+        if (all(x not in pkg_api for x in ("preview_api", "deprecated_api")) or
+            all(x in pkg_api and not pkg_api[x] for x in ("preview_api", "deprecated_api"))):
             print("No Preview/Deprecated APIs found. "
                   "All APIs are considered stable.", file=outfh)
             print("", file=outfh)

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -8,15 +8,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: cephfs/admin
 
-### Preview APIs
-
-Name | Added in Version | Expected Stable Version | 
----- | ---------------- | ----------------------- | 
-
-### Deprecated APIs
-
-Name | Deprecated in Version | Expected Removal Version | 
----- | --------------------- | ------------------------ | 
+No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rados
 
@@ -30,11 +22,6 @@ IOContext.Alignment | v0.17.0 | v0.19.0 |
 IOContext.RequiresAlignment | v0.17.0 | v0.19.0 | 
 
 ## Package: rbd
-
-### Preview APIs
-
-Name | Added in Version | Expected Stable Version | 
----- | ---------------- | ----------------------- | 
 
 ### Deprecated APIs
 
@@ -69,9 +56,4 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: common/admin/nfs
-
-### Preview APIs
-
-Name | Added in Version | Expected Stable Version | 
----- | ---------------- | ----------------------- | 
 


### PR DESCRIPTION
There are instances in API status [json](https://github.com/ceph/go-ceph/blob/master/docs/api-status.json) with empty list for preview or deprecated APIs. Due to a missing empty check we had corresponding tables created in [markdown](https://github.com/ceph/go-ceph/blob/master/docs/api-status.md) without any content. While adding the empty check also modify the condition which adds an entry indicating absence of any preview/deprecated APIs to consider empty lists.