### PR TITLE
ci: automatically file issues with api stability changes

### DIFF
--- a/.github/workflows/report-stable.yml
+++ b/.github/workflows/report-stable.yml
@@ -10,9 +10,13 @@ jobs:
   find-updates:
     runs-on: ubuntu-latest
     steps:
+    # Checkout with fetch-depth=0 in order to fetch (all) tags.
+    # The Makefile runs git commands to pass tag info to the apiage script.
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Run makefile
-      run: make api-report-updates  RESULTS_DIR=_results
+      run: make api-report-issuetemplate  RESULTS_DIR=_results
     - name: Archive test results
       uses: actions/upload-artifact@v3
       with:
@@ -20,5 +24,14 @@ jobs:
         path: |
           _results/
         retention-days: 30
+      if: "!cancelled()"
+    - name: File Issue
+      uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        filename: _results/issue.md
+        update_existing: true
+
 
   # TODO: teach this thing how to file an issue automatically

--- a/Makefile
+++ b/Makefile
@@ -281,12 +281,23 @@ api-fix-versions:
 api-doc:
 	./contrib/apiage.py --mode=write-doc
 
-api-report-updates: $(RESULTS_DIR)
+.PHONY: api-check-updates
+api-check-updates: $(RESULTS_DIR)
 	./contrib/apiage.py --mode=find-updates \
 		--current-tag="$$(git describe --tags --abbrev=0)" \
 		> $(RESULTS_DIR)/updates-found.json
+
+.PHONY: api-report-updates
+api-report-updates: api-check-updates
 	./contrib/apiage.py --mode=updates-to-markdown \
 		< $(RESULTS_DIR)/updates-found.json > $(RESULTS_DIR)/updates-found.md
+
+.PHONY: api-report-issuetemplate
+api-report-issuetemplate: api-check-updates
+	./contrib/apiage.py --mode=updates-to-issuetemplate \
+		--current-tag="$$(git describe --tags --abbrev=0)" \
+		< $(RESULTS_DIR)/updates-found.json \
+		> $(RESULTS_DIR)/issue.md
 
 ifeq ($(RESULTS_DIR),)
 IMPLEMENTS_DIR:=$(PWD)/_results

--- a/Makefile
+++ b/Makefile
@@ -262,22 +262,27 @@ clean-implements:
 	$(RM) ./implements
 
 
+.PHONY: api-check
 api-check: implements-json
 	./contrib/apiage.py
 
+.PHONY: api-update
 api-update: implements-json
 	./contrib/apiage.py --mode=update --placeholder-versions
 
+.PHONY: api-promote
 api-promote: implements-json
 	./contrib/apiage.py --mode=promote \
 		--current-tag="$$(git describe --tags --abbrev=0)"
 	./contrib/apiage.py --mode=write-doc
 
+.PHONY: api-fix-versions
 api-fix-versions:
 	./contrib/apiage.py --mode=fix-versions \
 		--current-tag="$$(git describe --tags --abbrev=0)"
 	./contrib/apiage.py --mode=write-doc
 
+.PHONY: api-doc
 api-doc:
 	./contrib/apiage.py --mode=write-doc
 
@@ -310,4 +315,4 @@ implements-json: $(BUILDFILE)
 
 # force_go_build is phony and builds nothing, can be used for forcing
 # go toolchain commands to always run
-.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements clean-implements api-check api-update api-doc implements-json
+.PHONY: build fmt test test-docker check test-binaries test-bins force_go_build check-implements clean-implements implements-json

--- a/contrib/apiage.py
+++ b/contrib/apiage.py
@@ -259,7 +259,11 @@ def format_markdown(tracked, outfh):
             print("", file=outfh)
 
 
-def format_updates_markdown(updates, outfh):
+def format_updates_markdown(updates, outfh, issuetemplate=False, next_ver=""):
+    if issuetemplate:
+        print("---", file=outfh)
+        print(f"title: APIs pending stability updates in {next_ver}", file=outfh)
+        print("---", file=outfh)
     print("## Preview APIs due to become stable", file=outfh)
     if not updates.get("preview"):
         print("n/a", file=outfh)
@@ -274,6 +278,9 @@ def format_updates_markdown(updates, outfh):
         print(f"* {api['package']}/{api['name']}", file=outfh)
     print("", file=outfh)
     print("", file=outfh)
+    if issuetemplate:
+        print("> NOTE: This issue was automatically filed by a script.", file=outfh)
+        print("", file=outfh)
 
 
 def _table(data, columns, outfh):
@@ -388,6 +395,7 @@ def main():
             "fix-versions",
             "find-updates",
             "updates-to-markdown",
+            "updates-to-issuetemplate",
             "promote",
         ),
         default="compare",
@@ -520,6 +528,14 @@ def main():
     elif cli.mode == "updates-to-markdown":
         updates_needed = json.load(sys.stdin)
         format_updates_markdown(updates_needed, sys.stdout)
+    elif cli.mode == "updates-to-issuetemplate":
+        updates_needed = json.load(sys.stdin)
+        format_updates_markdown(
+            updates_needed,
+            sys.stdout,
+            issuetemplate=True,
+            next_ver=cli.added_in_version,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the workflow "report-stable" to automatically file an issue when stability updates are required. This can then be used as a step the release workflow for go-ceph.

Tested in my own fork of go-ceph.