### PR TITLE
github: enable dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
       - "no-API"
     commit-message:
       prefix: "go-ceph"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    rebase-strategy: disabled
+    labels:
+      - "no-API"
+    commit-message:
+      prefix: "go-ceph"


### PR DESCRIPTION
Turns out the dependabot tool can also indicate what github actions we are using can be updated. This can be handy in avoiding the warnings that github throws up all over an action that relies on a deprecated feature. Use a monthly update just like go modules to avoid being pestered all the time.

Blatantly ripped off from the ceph-csi repo.