### PR TITLE
rbd: increase maximum number of trash entries listable

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -984,7 +984,7 @@ func GetTrashList(ioctx *rados.IOContext) ([]TrashInfo, error) {
 		count   C.size_t
 		entries []C.rbd_trash_image_info_t
 	)
-	retry.WithSizes(32, 1024, func(size int) retry.Hint {
+	retry.WithSizes(32, 10240, func(size int) retry.Hint {
 		count = C.size_t(size)
 		entries = make([]C.rbd_trash_image_info_t, count)
 		ret := C.rbd_trash_list(cephIoctx(ioctx), &entries[0], &count)


### PR DESCRIPTION
Work around an issue reported that due to a large number of items in the rbd trash the function fails rather than listing the items as desired. This short term fix simply increases the limit rather than doing anything long term.

Fixes: #779

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
