### PR TITLE
Make preview APIs stable for v0.19

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1750,14 +1750,7 @@
     ]
   },
   "rgw/admin": {
-    "preview_api": [
-      {
-        "name": "API.SetIndividualBucketQuota",
-        "comment": "SetIndividualBucketQuota sets quota to a specific bucket.\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#set-quota-for-an-individual-bucket.\n",
-        "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
-      }
-    ],
+    "preview_api": [],
     "stable_api": [
       {
         "name": "API.ListBuckets",
@@ -1875,6 +1868,12 @@
       {
         "name": "API.RemoveKey",
         "comment": "RemoveKey will remove an existing key\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#remove-key\nKeySpec.SecretKey parameter shouldn't be provided and will be ignored\n",
+        "added_in_version": "v0.17.0",
+        "became_stable_version": "v0.19.0"
+      },
+      {
+        "name": "API.SetIndividualBucketQuota",
+        "comment": "SetIndividualBucketQuota sets quota to a specific bucket\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#set-quota-for-an-individual-bucket\n",
         "added_in_version": "v0.17.0",
         "became_stable_version": "v0.19.0"
       }

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1024,15 +1024,15 @@
         "comment": "SetAllocationHint sets allocation hint for an object. This is an advisory\noperation, it will always succeed (as if it was submitted with a\nLIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on\nthe backend.\n\nImplements:\n void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,\n                                     uint64_t expected_object_size,\n                                     uint64_t expected_write_size,\n                                     uint32_t flags);\n",
         "added_in_version": "v0.17.0",
         "became_stable_version": "v0.19.0"
-      }
-    ],
-    "preview_api": [
+      },
       {
         "name": "IOContext.Alignment",
         "comment": "Alignment returns the required stripe size in bytes for pools supporting/requiring it, or an error if unsuccessful.\nFor an EC pool, a buffer size multiple of its stripe size is required to call Append. To know if the pool requires\nalignment or not, use RequiresAlignment.\n\nImplements:\n int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t *alignment)\n",
         "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
-      },
+        "became_stable_version": "v0.19.0"
+      }
+    ],
+    "preview_api": [
       {
         "name": "IOContext.RequiresAlignment",
         "comment": "RequiresAlignment returns true if the pool supports/requires alignment or an error if not successful.\nFor an EC pool, a buffer size multiple of its stripe size is required to call Append. See\nAlignment to know how to get the stripe size for pools requiring it.\n\nImplements:\n int rados_ioctx_pool_requires_alignment2(rados_ioctx_t io, int *req)\n",

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1018,15 +1018,15 @@
         "comment": "SetAllocationHint sets allocation hint for an object. This is an advisory\noperation, it will always succeed (as if it was submitted with a\nLIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on\nthe backend.\n\nImplements:\n int rados_set_alloc_hint2(rados_ioctx_t io,\n                           const char *o,\n                           uint64_t expected_object_size,\n                           uint64_t expected_write_size,\n                           uint32_t flags);\n",
         "added_in_version": "v0.17.0",
         "became_stable_version": "v0.19.0"
-      }
-    ],
-    "preview_api": [
+      },
       {
         "name": "WriteOp.SetAllocationHint",
         "comment": "SetAllocationHint sets allocation hint for an object. This is an advisory\noperation, it will always succeed (as if it was submitted with a\nLIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on\nthe backend.\n\nImplements:\n void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,\n                                     uint64_t expected_object_size,\n                                     uint64_t expected_write_size,\n                                     uint32_t flags);\n",
         "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
-      },
+        "became_stable_version": "v0.19.0"
+      }
+    ],
+    "preview_api": [
       {
         "name": "IOContext.Alignment",
         "comment": "Alignment returns the required stripe size in bytes for pools supporting/requiring it, or an error if unsuccessful.\nFor an EC pool, a buffer size multiple of its stripe size is required to call Append. To know if the pool requires\nalignment or not, use RequiresAlignment.\n\nImplements:\n int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t *alignment)\n",

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1030,16 +1030,15 @@
         "comment": "Alignment returns the required stripe size in bytes for pools supporting/requiring it, or an error if unsuccessful.\nFor an EC pool, a buffer size multiple of its stripe size is required to call Append. To know if the pool requires\nalignment or not, use RequiresAlignment.\n\nImplements:\n int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t *alignment)\n",
         "added_in_version": "v0.17.0",
         "became_stable_version": "v0.19.0"
-      }
-    ],
-    "preview_api": [
+      },
       {
         "name": "IOContext.RequiresAlignment",
         "comment": "RequiresAlignment returns true if the pool supports/requires alignment or an error if not successful.\nFor an EC pool, a buffer size multiple of its stripe size is required to call Append. See\nAlignment to know how to get the stripe size for pools requiring it.\n\nImplements:\n int rados_ioctx_pool_requires_alignment2(rados_ioctx_t io, int *req)\n",
         "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
+        "became_stable_version": "v0.19.0"
       }
-    ]
+    ],
+    "preview_api": []
   },
   "rbd": {
     "deprecated_api": [

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1752,18 +1752,6 @@
   "rgw/admin": {
     "preview_api": [
       {
-        "name": "API.ListUsersBuckets",
-        "comment": "ListUsersBuckets will return the list of all users buckets without stat.\n",
-        "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
-      },
-      {
-        "name": "API.ListUsersBucketsWithStat",
-        "comment": "ListUsersBucketsWithStat will return the list of all users buckets with stat.\n",
-        "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
-      },
-      {
         "name": "API.CreateKey",
         "comment": "CreateKey will generate new keys or add specified to keyring.\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#create-key.\n",
         "added_in_version": "v0.17.0",
@@ -1877,6 +1865,18 @@
       {
         "name": "API.ModifySubuser",
         "comment": "ModifySubuser - https://docs.ceph.com/en/latest/radosgw/adminops/#modify-subuser\n"
+      },
+      {
+        "name": "API.ListUsersBuckets",
+        "comment": "ListUsersBuckets will return the list of all users buckets without stat\n",
+        "added_in_version": "v0.17.0",
+        "became_stable_version": "v0.19.0"
+      },
+      {
+        "name": "API.ListUsersBucketsWithStat",
+        "comment": "ListUsersBucketsWithStat will return the list of all users buckets with stat\n",
+        "added_in_version": "v0.17.0",
+        "became_stable_version": "v0.19.0"
       }
     ]
   },

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1012,15 +1012,15 @@
       {
         "name": "IOContext.SetLocator",
         "comment": "SetLocator sets the key for mapping objects to pgs within an io context.\nUntil a different locator key is set, all objects in this io context will be placed in the same pg.\nTo reset the locator, an empty string must be set.\n\nImplements:\n void rados_ioctx_locator_set_key(rados_ioctx_t io, const char *key);\n"
-      }
-    ],
-    "preview_api": [
+      },
       {
         "name": "IOContext.SetAllocationHint",
         "comment": "SetAllocationHint sets allocation hint for an object. This is an advisory\noperation, it will always succeed (as if it was submitted with a\nLIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on\nthe backend.\n\nImplements:\n int rados_set_alloc_hint2(rados_ioctx_t io,\n                           const char *o,\n                           uint64_t expected_object_size,\n                           uint64_t expected_write_size,\n                           uint32_t flags);\n",
         "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
-      },
+        "became_stable_version": "v0.19.0"
+      }
+    ],
+    "preview_api": [
       {
         "name": "WriteOp.SetAllocationHint",
         "comment": "SetAllocationHint sets allocation hint for an object. This is an advisory\noperation, it will always succeed (as if it was submitted with a\nLIBRADOS_OP_FLAG_FAILOK flag set) and is not guaranteed to do anything on\nthe backend.\n\nImplements:\n void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,\n                                     uint64_t expected_object_size,\n                                     uint64_t expected_write_size,\n                                     uint32_t flags);\n",

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1752,18 +1752,6 @@
   "rgw/admin": {
     "preview_api": [
       {
-        "name": "API.CreateKey",
-        "comment": "CreateKey will generate new keys or add specified to keyring.\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#create-key.\n",
-        "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
-      },
-      {
-        "name": "API.RemoveKey",
-        "comment": "RemoveKey will remove an existing key.\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#remove-key\nKeySpec.SecretKey parameter shouldn't be provided and will be ignored.\n",
-        "added_in_version": "v0.17.0",
-        "expected_stable_version": "v0.19.0"
-      },
-      {
         "name": "API.SetIndividualBucketQuota",
         "comment": "SetIndividualBucketQuota sets quota to a specific bucket.\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#set-quota-for-an-individual-bucket.\n",
         "added_in_version": "v0.17.0",
@@ -1875,6 +1863,18 @@
       {
         "name": "API.ListUsersBucketsWithStat",
         "comment": "ListUsersBucketsWithStat will return the list of all users buckets with stat\n",
+        "added_in_version": "v0.17.0",
+        "became_stable_version": "v0.19.0"
+      },
+      {
+        "name": "API.CreateKey",
+        "comment": "CreateKey will generate new keys or add specified to keyring\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#create-key\n",
+        "added_in_version": "v0.17.0",
+        "became_stable_version": "v0.19.0"
+      },
+      {
+        "name": "API.RemoveKey",
+        "comment": "RemoveKey will remove an existing key\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#remove-key\nKeySpec.SecretKey parameter shouldn't be provided and will be ignored\n",
         "added_in_version": "v0.17.0",
         "became_stable_version": "v0.19.0"
       }

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -16,7 +16,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-IOContext.Alignment | v0.17.0 | v0.19.0 | 
 IOContext.RequiresAlignment | v0.17.0 | v0.19.0 | 
 
 ## Package: rbd

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -30,11 +30,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rgw/admin
 
-### Preview APIs
-
-Name | Added in Version | Expected Stable Version | 
----- | ---------------- | ----------------------- | 
-API.SetIndividualBucketQuota | v0.17.0 | v0.19.0 | 
+No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: common/admin/manager
 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -34,8 +34,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-API.ListUsersBuckets | v0.17.0 | v0.19.0 | 
-API.ListUsersBucketsWithStat | v0.17.0 | v0.19.0 | 
 API.CreateKey | v0.17.0 | v0.19.0 | 
 API.RemoveKey | v0.17.0 | v0.19.0 | 
 API.SetIndividualBucketQuota | v0.17.0 | v0.19.0 | 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -16,7 +16,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-IOContext.SetAllocationHint | v0.17.0 | v0.19.0 | 
 WriteOp.SetAllocationHint | v0.17.0 | v0.19.0 | 
 IOContext.Alignment | v0.17.0 | v0.19.0 | 
 IOContext.RequiresAlignment | v0.17.0 | v0.19.0 | 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -34,8 +34,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-API.CreateKey | v0.17.0 | v0.19.0 | 
-API.RemoveKey | v0.17.0 | v0.19.0 | 
 API.SetIndividualBucketQuota | v0.17.0 | v0.19.0 | 
 
 ## Package: common/admin/manager

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -12,11 +12,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rados
 
-### Preview APIs
-
-Name | Added in Version | Expected Stable Version | 
----- | ---------------- | ----------------------- | 
-IOContext.RequiresAlignment | v0.17.0 | v0.19.0 | 
+No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rbd
 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -16,7 +16,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-WriteOp.SetAllocationHint | v0.17.0 | v0.19.0 | 
 IOContext.Alignment | v0.17.0 | v0.19.0 | 
 IOContext.RequiresAlignment | v0.17.0 | v0.19.0 | 
 

--- a/rados/ioctx_pool_alignment.go
+++ b/rados/ioctx_pool_alignment.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/rados/ioctx_pool_alignment_test.go
+++ b/rados/ioctx_pool_alignment_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 import (

--- a/rados/ioctx_pool_requires_alignment.go
+++ b/rados/ioctx_pool_requires_alignment.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/rados/ioctx_pool_requires_alignment_test.go
+++ b/rados/ioctx_pool_requires_alignment_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 import (

--- a/rados/ioctx_set_alloc_hint.go
+++ b/rados/ioctx_set_alloc_hint.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/rados/write_op_set_alloc_hint.go
+++ b/rados/write_op_set_alloc_hint.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/rgw/admin/bucket_quota.go
+++ b/rgw/admin/bucket_quota.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (

--- a/rgw/admin/bucket_quota_test.go
+++ b/rgw/admin/bucket_quota_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (

--- a/rgw/admin/keys.go
+++ b/rgw/admin/keys.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (

--- a/rgw/admin/keys_test.go
+++ b/rgw/admin/keys_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (

--- a/rgw/admin/user_bucket.go
+++ b/rgw/admin/user_bucket.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (

--- a/rgw/admin/user_bucket_test.go
+++ b/rgw/admin/user_bucket_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (


### PR DESCRIPTION
Two packages had APIs becoming stable for release v0.19, scheduled for 13th December 2022.

Fixes #793 