### PR TITLE
Remove left over `ceph_preview` tags from test related files

### DIFF
--- a/rados/alloc_hint_flags.go
+++ b/rados/alloc_hint_flags.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package rados
 
 // #cgo LDFLAGS: -lrados

--- a/rgw/admin/caps_test.go
+++ b/rgw/admin/caps_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (

--- a/rgw/admin/link_test.go
+++ b/rgw/admin/link_test.go
@@ -1,6 +1,3 @@
-//go:build ceph_preview
-// +build ceph_preview
-
 package admin
 
 import (


### PR DESCRIPTION
These are left overs from [v0.13.0](https://github.com/ceph/go-ceph/releases/tag/v0.13.0), [v0.17.0](https://github.com/ceph/go-ceph/releases/tag/v0.17.0) and [v0.19.0](https://github.com/ceph/go-ceph/releases/tag/v0.19.0) releases where we missed to remove preview tags when following APIs were promoted to stable.

* _API.AddUserCap_ and _API.RemoveUserCap_ in e23ab127c07c0914bbe4f794a28aabf3fee4664f
* _API.LinkBucket_ and _API.UnlinkBucket_ in 9d74c3c2b1a08ad171d14bb78cc59273434030e3
* _IOContext.SetAllocationHint_ in efa832cdd073807010504e7d948c12820b7d832b

Fixes #798 