### PR TITLE
rgw:add "ListBucketsWithStat" function

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1848,7 +1848,14 @@
     ]
   },
   "rgw/admin": {
-    "preview_api": [],
+    "preview_api": [
+      {
+        "name": "API.ListBucketsWithStat",
+        "comment": "ListBucketsWithStat will return the list of all buckets with stat (system admin API only)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ],
     "stable_api": [
       {
         "name": "API.ListBuckets",

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -54,7 +54,11 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rgw/admin
 
-No Preview/Deprecated APIs found. All APIs are considered stable.
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+API.ListBucketsWithStat | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: common/admin/manager
 

--- a/rgw/admin/list_bucket_with_stats.go
+++ b/rgw/admin/list_bucket_with_stats.go
@@ -1,0 +1,32 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ListBucketsWithStat will return the list of all buckets with stat (system admin API only)
+func (api *API) ListBucketsWithStat(ctx context.Context) ([]Bucket, error) {
+	generateStat := true
+	listingSpec := BucketListingSpec{
+		GenerateStat: &generateStat,
+	}
+
+	body, err := api.call(ctx, http.MethodGet, "/bucket", valueToURLParams(listingSpec, []string{"stats"}))
+	if err != nil {
+		return nil, err
+	}
+
+	ref := []Bucket{}
+	err = json.Unmarshal(body, &ref)
+	if err != nil {
+		return nil, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+	}
+
+	return ref, nil
+}

--- a/rgw/admin/list_bucket_with_stats_test.go
+++ b/rgw/admin/list_bucket_with_stats_test.go
@@ -1,0 +1,35 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package admin
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func (suite *RadosGWTestSuite) TestListBucketsWithStat() {
+	suite.SetupConnection()
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
+	assert.NoError(suite.T(), err)
+
+	s3, err := newS3Agent(suite.accessKey, suite.secretKey, suite.endpoint, true)
+	assert.NoError(suite.T(), err)
+
+	err = s3.createBucket(suite.bucketTestName)
+	assert.NoError(suite.T(), err)
+
+	suite.T().Run("list buckets with stat", func(t *testing.T) {
+		buckets, err := co.ListBucketsWithStat(context.Background())
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), 1, len(buckets))
+		b := buckets[0]
+		assert.NotNil(suite.T(), b)
+		assert.Equal(suite.T(), suite.bucketTestName, b.Bucket)
+		assert.Equal(suite.T(), "admin", b.Owner)
+		assert.NotNil(suite.T(), b.BucketQuota.MaxSize)
+	})
+
+}


### PR DESCRIPTION
Added new function `ListBucketsWithStat` to get **all** buckets of all users info (for admin keys only).

fixes #800 
