### PR TITLE
github: update PR template with new checklist item and helpful links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,3 +23,16 @@ Thank you for opening a pull request. Please provide:
 - [ ] Public functions and types are documented
 - [ ] Standard formatting is applied to Go code
 - [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
+- [ ] Ran `make api-update` to record new APIs
+
+New or infrequent contributors may want to review the go-ceph [Developer's
+Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md)
+including the section on how we track [API
+Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status)
+and the [API Stability
+Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).
+
+The go-ceph project uses mergify. View the [mergify command
+guide](https://docs.mergify.com/commands/#commands) for information on how to
+interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your
+PR when github indicates that the PR is out of date with the base branch.


### PR DESCRIPTION
Add a new checklist item reminding contributors to run `make api-update` to track new APIs. Add two short paragraphs that cover some of the common things I copy and paste or need to look up when working with contributors' PRs.


