### PR TITLE
Add untracked Subvolume and Snapshot metadata APIs in `api-status`

### DIFF
--- a/cephfs/admin/metadata.go
+++ b/cephfs/admin/metadata.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
-// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
 
 package admin
 

--- a/cephfs/admin/metadata_test.go
+++ b/cephfs/admin/metadata_test.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
-// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
 
 package admin
 

--- a/cephfs/admin/snapshot_metadata.go
+++ b/cephfs/admin/snapshot_metadata.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
-// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
 
 package admin
 

--- a/cephfs/admin/snapshot_metadata_test.go
+++ b/cephfs/admin/snapshot_metadata_test.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
-// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
 
 package admin
 

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -503,7 +503,68 @@
       }
     ],
     "deprecated_api": [],
-    "preview_api": []
+    "preview_api": [
+      {
+        "name": "FSAdmin.GetMetadata",
+        "comment": "GetMetadata gets custom metadata on the subvolume in a volume belonging to\nan optional subvolume group based on provided key name.\n\nSimilar To:\n ceph fs subvolume metadata get <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>]\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.SetMetadata",
+        "comment": "SetMetadata sets custom metadata on the subvolume in a volume belonging to\nan optional subvolume group as a key-value pair.\n\nSimilar To:\n ceph fs subvolume metadata set <vol_name> <sub_name> <key_name> <value> [--group_name <subvol_group_name>]\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.RemoveMetadata",
+        "comment": "RemoveMetadata removes custom metadata set on the subvolume in a volume\nbelonging to an optional subvolume group using the metadata key.\n\nSimilar To:\n ceph fs subvolume metadata rm <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>]\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.ForceRemoveMetadata",
+        "comment": "ForceRemoveMetadata attempt to forcefully remove custom metadata set on\nthe subvolume in a volume belonging to an optional subvolume group using\nthe metadata key.\n\nSimilar To:\n ceph fs subvolume metadata rm <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>] --force\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.ListMetadata",
+        "comment": "ListMetadata lists custom metadata (key-value pairs) set on the subvolume\nin a volume belonging to an optional subvolume group.\n\nSimilar To:\n ceph fs subvolume metadata ls <vol_name> <sub_name> [--group_name <subvol_group_name>]\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.GetSnapshotMetadata",
+        "comment": "GetSnapshotMetadata gets custom metadata on the subvolume snapshot in a\nvolume belonging to an optional subvolume group based on provided key name.\n\nSimilar To:\n ceph fs subvolume snapshot metadata get <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>]\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.SetSnapshotMetadata",
+        "comment": "SetSnapshotMetadata sets custom metadata on the subvolume snapshot in a\nvolume belonging to an optional subvolume group as a key-value pair.\n\nSimilar To:\n ceph fs subvolume snapshot metadata set <vol_name> <sub_name> <snap_name> <key_name> <value> [--group_name <subvol_group_name>]\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.RemoveSnapshotMetadata",
+        "comment": "RemoveSnapshotMetadata removes custom metadata set on the subvolume\nsnapshot in a volume belonging to an optional subvolume group using the\nmetadata key.\n\nSimilar To:\n ceph fs subvolume snapshot metadata rm <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>]\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.ForceRemoveSnapshotMetadata",
+        "comment": "ForceRemoveSnapshotMetadata attempt to forcefully remove custom metadata\nset on the subvolume snapshot in a volume belonging to an optional\nsubvolume group using the metadata key.\n\nSimilar To:\n ceph fs subvolume snapshot metadata rm <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>] --force\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "FSAdmin.ListSnapshotMetadata",
+        "comment": "ListSnapshotMetadata lists custom metadata (key-value pairs) set on the subvolume\nsnapshot in a volume belonging to an optional subvolume group.\n\nSimilar To:\n ceph fs subvolume snapshot metadata ls <vol_name> <sub_name> <snap_name> [--group_name <subvol_group_name>]\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      }
+    ]
   },
   "rados": {
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -8,7 +8,20 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: cephfs/admin
 
-No Preview/Deprecated APIs found. All APIs are considered stable.
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+FSAdmin.GetMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.SetMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.RemoveMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.ForceRemoveMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.ListMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.GetSnapshotMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.SetSnapshotMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.RemoveSnapshotMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.ForceRemoveSnapshotMetadata | v0.20.0 | v0.22.0 | 
+FSAdmin.ListSnapshotMetadata | v0.20.0 | v0.22.0 | 
 
 ## Package: rados
 


### PR DESCRIPTION
Following APIs are being added as preview APIs after _ceph_pre__* tags are removed with an exception to Pacific where backports are not yet merged.
    
* FSAdmin.GetMetadata
* FSAdmin.SetMetadata
* FSAdmin.RemoveMetadata
* FSAdmin.ForceRemoveMetadata
* FSAdmin.ListMetadata
* FSAdmin.GetSnapshotMetadata
* FSAdmin.SetSnapshotMetadata
* FSAdmin.RemoveSnapshotMetadata
* FSAdmin.ForceRemoveSnapshotMetadata
* FSAdmin.ListSnapshotMetadata

fixes #752 