### PR TITLE
Remove ceph_pre_quincy tags from Snapshot and Subvolume metadata API sources

### DIFF
--- a/cephfs/admin/metadata.go
+++ b/cephfs/admin/metadata.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
-// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
 
 package admin
 

--- a/cephfs/admin/metadata_test.go
+++ b/cephfs/admin/metadata_test.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
-// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
 
 package admin
 

--- a/cephfs/admin/snapshot_metadata.go
+++ b/cephfs/admin/snapshot_metadata.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
-// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
 
 package admin
 

--- a/cephfs/admin/snapshot_metadata_test.go
+++ b/cephfs/admin/snapshot_metadata_test.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus) && ceph_preview && ceph_pre_quincy
-// +build !nautilus,!octopus,ceph_preview,ceph_pre_quincy
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
 
 package admin
 


### PR DESCRIPTION
With an exemption to Pacific, necessary backports are already available with recent Quincy releases.

fixes #752 