### PR TITLE
docs: fix version values for new rdb migration APIs

### DIFF
--- a/contrib/apiage.py
+++ b/contrib/apiage.py
@@ -277,10 +277,7 @@ def format_markdown(tracked, outfh):
             )
             print("", file=outfh)
         if all(
-            x not in pkg_api for x in ("preview_api", "deprecated_api")
-        ) or all(
-            x in pkg_api and not pkg_api[x]
-            for x in ("preview_api", "deprecated_api")
+            not pkg_api.get(x, []) for x in ("preview_api", "deprecated_api")
         ):
             print(
                 "No Preview/Deprecated APIs found. "

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1679,38 +1679,38 @@
       {
         "name": "MigrationPrepare",
         "comment": "MigrationPrepare prepares a migration\ncreating a target image with a link\nto source and making source read-only.\n\nImplements:\n int rbd_migration_prepare(rados_ioctx_t ioctx,\n                           const char *image_name,\n                           rados_ioctx_t dest_ioctx,\n                           const char *dest_image_name,\n                           rbd_image_options_t opts);\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
       },
       {
         "name": "MigrationPrepareImport",
         "comment": "MigrationPrepareImport prepares a migration for import\nfrom a specified source to a new target image.\n\nImplements:\n int rbd_migration_prepare_import(const char *source_spec,\n                                  rados_ioctx_t dest_ioctx,\n                                  const char *dest_image_name,\n                                  rbd_image_options_t opts);\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
       },
       {
         "name": "MigrationExecute",
         "comment": "MigrationExecute starts copying the image blocks\nfrom the source image to the target image.\n\nImplements:\n int rbd_migration_execute(rados_ioctx_t ioctx,\n                           const char *image_name);\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
       },
       {
         "name": "MigrationCommit",
         "comment": "MigrationCommit commits a migration after execution\nbreaking the relationship of image to the source.\n\nImplements:\n int rbd_migration_commit(rados_ioctx_t ioctx,\n                          const char *image_name);\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
       },
       {
         "name": "MigrationAbort",
         "comment": "MigrationAbort aborts a migration in progress\nbreaking the relationship of image to the source.\n\nImplements:\n int rbd_migration_abort(rados_ioctx_t ioctx,\n                         const char *image_name);\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
       },
       {
         "name": "MigrationStatus",
         "comment": "MigrationStatus retrieve status of a live migration\nfor the specified image.\n\nImplements:\n int rbd_migration_status(rados_ioctx_t ioctx,\n                          const char *image_name,\n                          rbd_image_migration_status_t *status,\n                          size_t status_size);\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -53,3 +53,5 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: common/admin/nfs
 
+No Preview/Deprecated APIs found. All APIs are considered stable.
+

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -20,12 +20,12 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-MigrationPrepare | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-MigrationPrepareImport | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-MigrationExecute | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-MigrationCommit | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-MigrationAbort | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-MigrationStatus | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+MigrationPrepare | v0.20.0 | v0.22.0 | 
+MigrationPrepareImport | v0.20.0 | v0.22.0 | 
+MigrationExecute | v0.20.0 | v0.22.0 | 
+MigrationCommit | v0.20.0 | v0.22.0 | 
+MigrationAbort | v0.20.0 | v0.22.0 | 
+MigrationStatus | v0.20.0 | v0.22.0 | 
 
 ### Deprecated APIs
 


### PR DESCRIPTION
First, I fix a small bug in the way apiage.py is generating the markdown.

Then, as of https://github.com/ceph/go-ceph/commit/d6bf51115d8f1075f1dc12887a41274b5dd196f0 we've tried to make API stability less burdensome on contributors by putting in placeholder values in the status files. However, we haven't used it much yet. This change executes `make api-fix-versions` in order to convert the placeholder versions into real version numbers - both for the real reason of tracking the values and also for a more real world test of the apiage feature.


