### PR TITLE
Build arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ endif
 
 GO_CMD:=go
 GOFMT_CMD:=gofmt
+GOARCH:=$(shell $(GO_CMD) env GOARCH)
 
 # the full name of the marker file including the ceph version
 BUILDFILE=.build.$(CEPH_VERSION)
@@ -98,6 +99,7 @@ endif
 
 # Assemble the various build args that will be passed container build command(s)
 CONTAINER_BUILD_ARGS:=$(DEFAULT_BUILD_ARGS)
+CONTAINER_BUILD_ARGS += --build-arg GOARCH=$(GOARCH)
 ifdef CEPH_IMG
 	CONTAINER_BUILD_ARGS += --build-arg CEPH_IMG=$(CEPH_IMG)
 endif

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -22,8 +22,10 @@ RUN true && \
 
 ARG GO_VERSION=1.17.9
 ENV GO_VERSION=${GO_VERSION}
+ARG GOARCH
+ENV GOARCH=${GOARCH}
 RUN true && \
-    gotar=go${GO_VERSION}.linux-amd64.tar.gz && \
+    gotar=go${GO_VERSION}.linux-${GOARCH}.tar.gz && \
     gourl="https://dl.google.com/go/${gotar}" && \
     curl -o /tmp/${gotar} "${gourl}" && \
     tar -x -C /opt/ -f /tmp/${gotar} && \


### PR DESCRIPTION
Execute `make ci-image` on ARM64 machine and produce valid image. Tested on AWS-Graviton machine.