### PR TITLE
cephfs: add SelectFilesystem, a 2nd fs to micro-osd.sh etc, and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,9 @@ test-containers-test: $(BUILDFILE) $(TEST_CTR_A) $(TEST_CTR_B)
 		--wait-for=/ceph_a/.ready:/ceph_b/.ready \
 		--mirror-state=/ceph_b/.mstate \
 		--ceph-conf=/ceph_a/ceph.conf \
-		--mirror=/ceph_b/ceph.conf $(ENTRYPOINT_ARGS)
+		--mirror=/ceph_b/ceph.conf \
+		--altfs=@/ceph_a/altfs.txt \
+		$(ENTRYPOINT_ARGS)
 
 ifdef RESULTS_DIR
 $(RESULTS_DIR):

--- a/cephfs/admin/volume_test.go
+++ b/cephfs/admin/volume_test.go
@@ -12,8 +12,8 @@ func TestListVolumes(t *testing.T) {
 
 	vl, err := fsa.ListVolumes()
 	assert.NoError(t, err)
-	assert.Len(t, vl, 1)
-	assert.Equal(t, "cephfs", vl[0])
+	assert.GreaterOrEqual(t, len(vl), 1)
+	assert.Contains(t, vl, "cephfs")
 }
 
 func TestEnumerateVolumes(t *testing.T) {
@@ -21,10 +21,16 @@ func TestEnumerateVolumes(t *testing.T) {
 
 	ve, err := fsa.EnumerateVolumes()
 	assert.NoError(t, err)
-	if assert.Len(t, ve, 1) {
-		assert.Equal(t, "cephfs", ve[0].Name)
-		assert.Equal(t, int64(1), ve[0].ID)
+
+	found := false
+	for i := range ve {
+		if ve[i].Name == "cephfs" {
+			assert.Equal(t, int64(1), ve[i].ID)
+			found = true
+			break
+		}
 	}
+	assert.True(t, found, "never found a cephfs entry in enumerated volumes")
 }
 
 // note: some of these dumps are simplified for testing purposes if we add
@@ -384,10 +390,19 @@ func TestListFileSystems(t *testing.T) {
 
 	l, err := fsa.ListFileSystems()
 	assert.NoError(t, err)
-	if assert.Len(t, l, 1) {
-		assert.Equal(t, "cephfs", l[0].Name)
-		assert.Equal(t, "cephfs_metadata", l[0].MetadataPool)
-		assert.Len(t, l[0].DataPools, 1)
-		assert.Contains(t, l[0].DataPools, "cephfs_data")
+	assert.GreaterOrEqual(t, len(l), 1)
+
+	idx := -1
+	for i := range l {
+		if l[i].Name == "cephfs" {
+			idx = i
+			break
+		}
+	}
+	if assert.NotEqual(t, -1, idx) {
+		assert.Equal(t, "cephfs", l[idx].Name)
+		assert.Equal(t, "cephfs_metadata", l[idx].MetadataPool)
+		assert.Len(t, l[idx].DataPools, 1)
+		assert.Contains(t, l[idx].DataPools, "cephfs_data")
 	}
 }

--- a/cephfs/select_fs.go
+++ b/cephfs/select_fs.go
@@ -1,0 +1,33 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package cephfs
+
+/*
+#cgo LDFLAGS: -lcephfs
+#cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <cephfs/libcephfs.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// SelectFilesystem selects a file system to be mounted. If the ceph cluster
+// supports more than one cephfs this optional function selects which one to
+// use. Can only be called prior to calling Mount. The name of the file system
+// is not validated by this call - if the supplied file system name is not
+// valid then only the subsequent mount call will fail.
+//
+// Implements:
+//  int ceph_select_filesystem(struct ceph_mount_info *cmount, const char *fs_name);
+func (mount *MountInfo) SelectFilesystem(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ret := C.ceph_select_filesystem(mount.mount, cName)
+	return getError(ret)
+}

--- a/cephfs/select_fs_test.go
+++ b/cephfs/select_fs_test.go
@@ -1,0 +1,107 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package cephfs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	altFSName = ""
+)
+
+func init() {
+	altFSName = os.Getenv("GO_CEPH_TEST_ALT_FS_NAME")
+}
+
+func TestSelectFS(t *testing.T) {
+	if altFSName == "" {
+		t.Skip("no alternative fs provided")
+	}
+
+	t.Run("selectFilesystem", func(t *testing.T) {
+		mount, err := CreateMount()
+		assert.NoError(t, err)
+		assert.NotNil(t, mount)
+
+		err = mount.SelectFilesystem(altFSName)
+		assert.NoError(t, err)
+
+		assert.NoError(t, mount.Release())
+	})
+
+	t.Run("selectFilesystemError", func(t *testing.T) {
+		mount := fsConnect(t)
+		defer fsDisconnect(t, mount)
+
+		// already mounted - this should return an error
+		err := mount.SelectFilesystem(altFSName)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalidName", func(t *testing.T) {
+		mount := fsConnect(t)
+		defer func() {
+			assert.NoError(t, mount.Release())
+		}()
+
+		assert.NoError(t, mount.Unmount())
+		// this call will not fail because the name isn't used until
+		// the file system is "mounted"
+		err := mount.SelectFilesystem("a.bunch-of~nonsense")
+		assert.NoError(t, err)
+
+		// this call is the one that fails because of the invalid name
+		assert.Error(t, mount.Mount())
+	})
+
+	t.Run("swapFS", func(t *testing.T) {
+		mount := fsConnect(t)
+		defer fsDisconnect(t, mount)
+
+		// create a file on the first file system
+		fname := "first_fs.txt"
+		f1, err := mount.Open(fname, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		assert.NoError(t, err)
+		assert.NoError(t, f1.Close())
+		_, err = mount.Statx(fname, StatxBasicStats, 0)
+		assert.NoError(t, err)
+
+		// swap file systems - unmount, select fs, and then mount again
+		assert.NoError(t, mount.Unmount())
+		err = mount.SelectFilesystem(altFSName)
+		assert.NoError(t, err)
+		assert.NoError(t, mount.Mount())
+
+		// now we're on a new fs. stat'ing the file should fail, as the file is
+		// on the other file system
+		_, err = mount.Statx(fname, StatxBasicStats, 0)
+		assert.Error(t, err)
+
+		// verify that other operations on the 2nd fs work the same
+		fname2 := "second_fs.txt"
+		f2, err := mount.Open(fname2, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		assert.NoError(t, err)
+		assert.NoError(t, f2.Close())
+		_, err = mount.Statx(fname2, StatxBasicStats, 0)
+		assert.NoError(t, err)
+		assert.NoError(t, mount.Unlink(fname2))
+
+		// swap back to the first file system
+		assert.NoError(t, mount.Unmount())
+		// first fs is always called cephfs for go-ceph tests
+		err = mount.SelectFilesystem("cephfs")
+		assert.NoError(t, err)
+		assert.NoError(t, mount.Mount())
+
+		// we're back on the first fs. see that the file still exists and then
+		// clean it up
+		_, err = mount.Statx(fname, StatxBasicStats, 0)
+		assert.NoError(t, err)
+		assert.NoError(t, mount.Unlink(fname))
+	})
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -312,6 +312,14 @@
         "name": "UserPerm.Destroy",
         "comment": "Destroy will explicitly free ceph resources associated with the UserPerm.\n\nImplements:\n void ceph_userperm_destroy(UserPerm *perm);\n"
       }
+    ],
+    "preview_api": [
+      {
+        "name": "MountInfo.SelectFilesystem",
+        "comment": "SelectFilesystem selects a file system to be mounted. If the ceph cluster\nsupports more than one cephfs this optional function selects which one to\nuse. Can only be called prior to calling Mount. The name of the file system\nis not validated by this call - if the supplied file system name is not\nvalid then only the subsequent mount call will fail.\n\nImplements:\n int ceph_select_filesystem(struct ceph_mount_info *cmount, const char *fs_name);\n",
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
+      }
     ]
   },
   "cephfs/admin": {

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -4,7 +4,11 @@
 
 ## Package: cephfs
 
-No Preview/Deprecated APIs found. All APIs are considered stable.
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+MountInfo.SelectFilesystem | v0.20.0 | v0.22.0 | 
 
 ## Package: cephfs/admin
 


### PR DESCRIPTION
This PR updates the micro-osd.sh script to host an alternate cephfs filesystem, on pacific and later. 
The entrypoint.sh and makefile are updated to plumb information about the alternate fs to the test suite.
The SelecFilesystem function is added implementing ceph_select_filesystem.
A group of tests, gated by the name of the alternate filesystem being provided, is added, along with API status updates.


Fixes: https://github.com/ceph/go-ceph/issues/262
Fixes: https://github.com/ceph/go-ceph/issues/818
Original-Version-By: "Arvid E. Picciani" <arvid@kraud.cloud>
Original-PR-URL: https://github.com/ceph/go-ceph/pull/819


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer'sGuide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
