### PR TITLE
github: fix linebreaks in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,14 +25,6 @@ Thank you for opening a pull request. Please provide:
 - [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
 - [ ] Ran `make api-update` to record new APIs
 
-New or infrequent contributors may want to review the go-ceph [Developer's
-Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md)
-including the section on how we track [API
-Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status)
-and the [API Stability
-Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).
+New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).
 
-The go-ceph project uses mergify. View the [mergify command
-guide](https://docs.mergify.com/commands/#commands) for information on how to
-interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your
-PR when github indicates that the PR is out of date with the base branch.
+The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.


### PR DESCRIPTION
The linebreaks within the 2 bottom paragraphs look fine in an editor such as vim, but look odd when viewed as part of the PR on github. Improve the visuals and make it more readable in the github UI by removing linebreaks.

If you view the file through the GH UI it's easier to see the difference than looking at the diff IMO.