### PR TITLE
Go: bump tested Go version to 1.19.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
     - uses: actions/checkout@v3
     - name: Install revive
       run: go install github.com/mgechev/revive@latest

--- a/cephfs/admin/clone.go
+++ b/cephfs/admin/clone.go
@@ -28,7 +28,8 @@ type CloneOptions struct {
 // specified using the clone options parameter.
 //
 // Similar To:
-//  ceph fs subvolume snapshot clone <volume> --group_name=<group> <subvolume> <snapshot> <name> [...]
+//
+//	ceph fs subvolume snapshot clone <volume> --group_name=<group> <subvolume> <snapshot> <name> [...]
 func (fsa *FSAdmin) CloneSubVolumeSnapshot(volume, group, subvolume, snapshot, name string, o *CloneOptions) error {
 	m := map[string]string{
 		"prefix":          "fs subvolume snapshot clone",
@@ -114,7 +115,8 @@ func parseCloneStatus(res response) (*CloneStatus, error) {
 // CloneStatus returns data reporting the status of a subvolume clone.
 //
 // Similar To:
-//  ceph fs clone status <volume> --group_name=<group> <clone>
+//
+//	ceph fs clone status <volume> --group_name=<group> <clone>
 func (fsa *FSAdmin) CloneStatus(volume, group, clone string) (*CloneStatus, error) {
 	m := map[string]string{
 		"prefix":     "fs clone status",
@@ -132,7 +134,8 @@ func (fsa *FSAdmin) CloneStatus(volume, group, clone string) (*CloneStatus, erro
 // CancelClone does not delete the clone.
 //
 // Similar To:
-//  ceph fs clone cancel <volume> --group_name=<group> <clone>
+//
+//	ceph fs clone cancel <volume> --group_name=<group> <clone>
 func (fsa *FSAdmin) CancelClone(volume, group, clone string) error {
 	m := map[string]string{
 		"prefix":     "fs clone cancel",

--- a/cephfs/admin/clone_nautilus.go
+++ b/cephfs/admin/clone_nautilus.go
@@ -3,8 +3,9 @@ package admin
 // GetFailure returns details about the CloneStatus when in CloneFailed state.
 //
 // Similar To:
-//  Reading the .failure object from the JSON returned by "ceph fs subvolume
-//  snapshot clone"
+//
+//	Reading the .failure object from the JSON returned by "ceph fs subvolume
+//	snapshot clone"
 func (cs *CloneStatus) GetFailure() *CloneFailure {
 	return cs.failure
 }

--- a/cephfs/admin/metadata.go
+++ b/cephfs/admin/metadata.go
@@ -7,7 +7,8 @@ package admin
 // an optional subvolume group based on provided key name.
 //
 // Similar To:
-//  ceph fs subvolume metadata get <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>]
+//
+//	ceph fs subvolume metadata get <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>]
 func (fsa *FSAdmin) GetMetadata(volume, group, subvolume, key string) (string, error) {
 	m := map[string]string{
 		"prefix":   "fs subvolume metadata get",
@@ -28,7 +29,8 @@ func (fsa *FSAdmin) GetMetadata(volume, group, subvolume, key string) (string, e
 // an optional subvolume group as a key-value pair.
 //
 // Similar To:
-//  ceph fs subvolume metadata set <vol_name> <sub_name> <key_name> <value> [--group_name <subvol_group_name>]
+//
+//	ceph fs subvolume metadata set <vol_name> <sub_name> <key_name> <value> [--group_name <subvol_group_name>]
 func (fsa *FSAdmin) SetMetadata(volume, group, subvolume, key, value string) error {
 	m := map[string]string{
 		"prefix":   "fs subvolume metadata set",
@@ -50,7 +52,8 @@ func (fsa *FSAdmin) SetMetadata(volume, group, subvolume, key, value string) err
 // belonging to an optional subvolume group using the metadata key.
 //
 // Similar To:
-//  ceph fs subvolume metadata rm <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>]
+//
+//	ceph fs subvolume metadata rm <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>]
 func (fsa *FSAdmin) RemoveMetadata(volume, group, subvolume, key string) error {
 	return fsa.rmSubVolumeMetadata(volume, group, subvolume, key, commonRmFlags{})
 }
@@ -60,7 +63,8 @@ func (fsa *FSAdmin) RemoveMetadata(volume, group, subvolume, key string) error {
 // the metadata key.
 //
 // Similar To:
-//  ceph fs subvolume metadata rm <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>] --force
+//
+//	ceph fs subvolume metadata rm <vol_name> <sub_name> <key_name> [--group_name <subvol_group_name>] --force
 func (fsa *FSAdmin) ForceRemoveMetadata(volume, group, subvolume, key string) error {
 	return fsa.rmSubVolumeMetadata(volume, group, subvolume, key, commonRmFlags{force: true})
 }
@@ -85,7 +89,8 @@ func (fsa *FSAdmin) rmSubVolumeMetadata(volume, group, subvolume, key string, o 
 // in a volume belonging to an optional subvolume group.
 //
 // Similar To:
-//  ceph fs subvolume metadata ls <vol_name> <sub_name> [--group_name <subvol_group_name>]
+//
+//	ceph fs subvolume metadata ls <vol_name> <sub_name> [--group_name <subvol_group_name>]
 func (fsa *FSAdmin) ListMetadata(volume, group, subvolume string) (map[string]string, error) {
 	m := map[string]string{
 		"prefix":   "fs subvolume metadata ls",

--- a/cephfs/admin/mgrmodule.go
+++ b/cephfs/admin/mgrmodule.go
@@ -9,7 +9,8 @@ const mirroring = "mirroring"
 // EnableMirroringModule will enable the mirroring module for cephfs.
 //
 // Similar To:
-//  ceph mgr module enable mirroring [--force]
+//
+//	ceph mgr module enable mirroring [--force]
 func (fsa *FSAdmin) EnableMirroringModule(force bool) error {
 	mgradmin := manager.NewFromConn(fsa.conn)
 	return mgradmin.EnableModule(mirroring, force)
@@ -18,7 +19,8 @@ func (fsa *FSAdmin) EnableMirroringModule(force bool) error {
 // DisableMirroringModule will disable the mirroring module for cephfs.
 //
 // Similar To:
-//  ceph mgr module disable mirroring
+//
+//	ceph mgr module disable mirroring
 func (fsa *FSAdmin) DisableMirroringModule() error {
 	mgradmin := manager.NewFromConn(fsa.conn)
 	return mgradmin.DisableModule(mirroring)

--- a/cephfs/admin/mirror.go
+++ b/cephfs/admin/mirror.go
@@ -20,7 +20,8 @@ func (fsa *FSAdmin) SnapshotMirror() *SnapshotMirrorAdmin {
 // Enable snapshot mirroring for the given file system.
 //
 // Similar To:
-//  ceph fs snapshot mirror enable <fs_name>
+//
+//	ceph fs snapshot mirror enable <fs_name>
 func (sma *SnapshotMirrorAdmin) Enable(fsname string) error {
 	m := map[string]string{
 		"prefix":  "fs snapshot mirror enable",
@@ -33,7 +34,8 @@ func (sma *SnapshotMirrorAdmin) Enable(fsname string) error {
 // Disable snapshot mirroring for the given file system.
 //
 // Similar To:
-//  ceph fs snapshot mirror disable <fs_name>
+//
+//	ceph fs snapshot mirror disable <fs_name>
 func (sma *SnapshotMirrorAdmin) Disable(fsname string) error {
 	m := map[string]string{
 		"prefix":  "fs snapshot mirror disable",
@@ -46,7 +48,8 @@ func (sma *SnapshotMirrorAdmin) Disable(fsname string) error {
 // Add a path in the file system to be mirrored.
 //
 // Similar To:
-//  ceph fs snapshot mirror add <fs_name> <path>
+//
+//	ceph fs snapshot mirror add <fs_name> <path>
 func (sma *SnapshotMirrorAdmin) Add(fsname, path string) error {
 	m := map[string]string{
 		"prefix":  "fs snapshot mirror add",
@@ -60,7 +63,8 @@ func (sma *SnapshotMirrorAdmin) Add(fsname, path string) error {
 // Remove a path in the file system from mirroring.
 //
 // Similar To:
-//  ceph fs snapshot mirror remove <fs_name> <path>
+//
+//	ceph fs snapshot mirror remove <fs_name> <path>
 func (sma *SnapshotMirrorAdmin) Remove(fsname, path string) error {
 	m := map[string]string{
 		"prefix":  "fs snapshot mirror remove",
@@ -79,7 +83,8 @@ type bootstrapTokenResponse struct {
 // a peering association between this site an another site.
 //
 // Similar To:
-//  ceph fs snapshot mirror peer_bootstrap create <fs_name> <client_entity> <site-name>
+//
+//	ceph fs snapshot mirror peer_bootstrap create <fs_name> <client_entity> <site-name>
 func (sma *SnapshotMirrorAdmin) CreatePeerBootstrapToken(
 	fsname, client, site string) (string, error) {
 	m := map[string]string{
@@ -100,7 +105,8 @@ func (sma *SnapshotMirrorAdmin) CreatePeerBootstrapToken(
 // that has provided a token, with the current site.
 //
 // Similar To:
-//  ceph fs snapshot mirror peer_bootstrap import <fs_name> <token>
+//
+//	ceph fs snapshot mirror peer_bootstrap import <fs_name> <token>
 func (sma *SnapshotMirrorAdmin) ImportPeerBoostrapToken(fsname, token string) error {
 	m := map[string]string{
 		"prefix":  "fs snapshot mirror peer_bootstrap import",
@@ -170,7 +176,8 @@ func parseDaemonStatus(res response) (DaemonStatusResults, error) {
 // associated with the given file system.
 //
 // Similar To:
-//  ceph fs snapshot mirror daemon status <fs_name>
+//
+//	ceph fs snapshot mirror daemon status <fs_name>
 func (sma *SnapshotMirrorAdmin) DaemonStatus(fsname string) (
 	DaemonStatusResults, error) {
 	// ---
@@ -204,7 +211,8 @@ func parsePeerList(res response) (PeerListResults, error) {
 // PeerList returns information about peers associated with the given file system.
 //
 // Similar To:
-//  ceph fs snapshot mirror peer_list <fs_name>
+//
+//	ceph fs snapshot mirror peer_list <fs_name>
 func (sma *SnapshotMirrorAdmin) PeerList(fsname string) (
 	PeerListResults, error) {
 	// ---

--- a/cephfs/admin/snapshot_metadata.go
+++ b/cephfs/admin/snapshot_metadata.go
@@ -7,7 +7,8 @@ package admin
 // volume belonging to an optional subvolume group based on provided key name.
 //
 // Similar To:
-//  ceph fs subvolume snapshot metadata get <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>]
+//
+//	ceph fs subvolume snapshot metadata get <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>]
 func (fsa *FSAdmin) GetSnapshotMetadata(volume, group, subvolume, snapname, key string) (string, error) {
 	m := map[string]string{
 		"prefix":    "fs subvolume snapshot metadata get",
@@ -29,7 +30,8 @@ func (fsa *FSAdmin) GetSnapshotMetadata(volume, group, subvolume, snapname, key 
 // volume belonging to an optional subvolume group as a key-value pair.
 //
 // Similar To:
-//  ceph fs subvolume snapshot metadata set <vol_name> <sub_name> <snap_name> <key_name> <value> [--group_name <subvol_group_name>]
+//
+//	ceph fs subvolume snapshot metadata set <vol_name> <sub_name> <snap_name> <key_name> <value> [--group_name <subvol_group_name>]
 func (fsa *FSAdmin) SetSnapshotMetadata(volume, group, subvolume, snapname, key, value string) error {
 	m := map[string]string{
 		"prefix":    "fs subvolume snapshot metadata set",
@@ -53,7 +55,8 @@ func (fsa *FSAdmin) SetSnapshotMetadata(volume, group, subvolume, snapname, key,
 // metadata key.
 //
 // Similar To:
-//  ceph fs subvolume snapshot metadata rm <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>]
+//
+//	ceph fs subvolume snapshot metadata rm <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>]
 func (fsa *FSAdmin) RemoveSnapshotMetadata(volume, group, subvolume, snapname, key string) error {
 	return fsa.rmSubVolumeSnapShotMetadata(volume, group, subvolume, snapname, key, commonRmFlags{})
 }
@@ -63,7 +66,8 @@ func (fsa *FSAdmin) RemoveSnapshotMetadata(volume, group, subvolume, snapname, k
 // subvolume group using the metadata key.
 //
 // Similar To:
-//  ceph fs subvolume snapshot metadata rm <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>] --force
+//
+//	ceph fs subvolume snapshot metadata rm <vol_name> <sub_name> <snap_name> <key_name> [--group_name <subvol_group_name>] --force
 func (fsa *FSAdmin) ForceRemoveSnapshotMetadata(volume, group, subvolume, snapname, key string) error {
 	return fsa.rmSubVolumeSnapShotMetadata(volume, group, subvolume, snapname, key, commonRmFlags{force: true})
 }
@@ -89,7 +93,8 @@ func (fsa *FSAdmin) rmSubVolumeSnapShotMetadata(volume, group, subvolume, snapna
 // snapshot in a volume belonging to an optional subvolume group.
 //
 // Similar To:
-//  ceph fs subvolume snapshot metadata ls <vol_name> <sub_name> <snap_name> [--group_name <subvol_group_name>]
+//
+//	ceph fs subvolume snapshot metadata ls <vol_name> <sub_name> <snap_name> [--group_name <subvol_group_name>]
 func (fsa *FSAdmin) ListSnapshotMetadata(volume, group, subvolume, snapname string) (map[string]string, error) {
 	m := map[string]string{
 		"prefix":    "fs subvolume snapshot metadata ls",

--- a/cephfs/admin/subvolume.go
+++ b/cephfs/admin/subvolume.go
@@ -53,7 +53,8 @@ const NoGroup = ""
 // belonging to an optional subvolume group.
 //
 // Similar To:
-//  ceph fs subvolume create <volume> --group-name=<group> <name> ...
+//
+//	ceph fs subvolume create <volume> --group-name=<group> <name> ...
 func (fsa *FSAdmin) CreateSubVolume(volume, group, name string, o *SubVolumeOptions) error {
 	if o == nil {
 		o = &SubVolumeOptions{}
@@ -66,7 +67,8 @@ func (fsa *FSAdmin) CreateSubVolume(volume, group, name string, o *SubVolumeOpti
 // optional subvolume group.
 //
 // Similar To:
-//  ceph fs subvolume ls <volume> --group-name=<group>
+//
+//	ceph fs subvolume ls <volume> --group-name=<group>
 func (fsa *FSAdmin) ListSubVolumes(volume, group string) ([]string, error) {
 	m := map[string]string{
 		"prefix":   "fs subvolume ls",
@@ -83,7 +85,8 @@ func (fsa *FSAdmin) ListSubVolumes(volume, group string) ([]string, error) {
 // subvolume group.
 //
 // Similar To:
-//  ceph fs subvolume rm <volume> --group-name=<group> <name>
+//
+//	ceph fs subvolume rm <volume> --group-name=<group> <name>
 func (fsa *FSAdmin) RemoveSubVolume(volume, group, name string) error {
 	return fsa.RemoveSubVolumeWithFlags(volume, group, name, SubVolRmFlags{})
 }
@@ -92,7 +95,8 @@ func (fsa *FSAdmin) RemoveSubVolume(volume, group, name string) error {
 // subvolume group.
 //
 // Similar To:
-//  ceph fs subvolume rm <volume> --group-name=<group> <name> --force
+//
+//	ceph fs subvolume rm <volume> --group-name=<group> <name> --force
 func (fsa *FSAdmin) ForceRemoveSubVolume(volume, group, name string) error {
 	return fsa.RemoveSubVolumeWithFlags(volume, group, name, SubVolRmFlags{Force: true})
 }
@@ -104,7 +108,8 @@ func (fsa *FSAdmin) ForceRemoveSubVolume(volume, group, name string) error {
 // Equivalent to ForceRemoveSubVolume if only the "Force" flag is set.
 //
 // Similar To:
-//  ceph fs subvolume rm <volume> --group-name=<group> <name> [...flags...]
+//
+//	ceph fs subvolume rm <volume> --group-name=<group> <name> [...flags...]
 func (fsa *FSAdmin) RemoveSubVolumeWithFlags(volume, group, name string, o SubVolRmFlags) error {
 	m := map[string]string{
 		"prefix":   "fs subvolume rm",
@@ -141,7 +146,8 @@ type SubVolumeResizeResult struct {
 // prevent reducing the size of the volume below the current used size.
 //
 // Similar To:
-//  ceph fs subvolume resize <volume> --group-name=<group> <name> ...
+//
+//	ceph fs subvolume resize <volume> --group-name=<group> <name> ...
 func (fsa *FSAdmin) ResizeSubVolume(
 	volume, group, name string,
 	newSize QuotaSize, noShrink bool) (*SubVolumeResizeResult, error) {
@@ -166,7 +172,8 @@ func (fsa *FSAdmin) ResizeSubVolume(
 // SubVolumePath returns the path to the subvolume from the root of the file system.
 //
 // Similar To:
-//  ceph fs subvolume getpath <volume> --group-name=<group> <name>
+//
+//	ceph fs subvolume getpath <volume> --group-name=<group> <name>
 func (fsa *FSAdmin) SubVolumePath(volume, group, name string) (string, error) {
 	m := map[string]string{
 		"prefix":   "fs subvolume getpath",
@@ -258,7 +265,8 @@ func parseSubVolumeInfo(res response) (*SubVolumeInfo, error) {
 // SubVolumeInfo returns information about the specified subvolume.
 //
 // Similar To:
-//  ceph fs subvolume info <volume> --group-name=<group> <name>
+//
+//	ceph fs subvolume info <volume> --group-name=<group> <name>
 func (fsa *FSAdmin) SubVolumeInfo(volume, group, name string) (*SubVolumeInfo, error) {
 	m := map[string]string{
 		"prefix":   "fs subvolume info",
@@ -275,7 +283,8 @@ func (fsa *FSAdmin) SubVolumeInfo(volume, group, name string) (*SubVolumeInfo, e
 // CreateSubVolumeSnapshot creates a new snapshot from the source subvolume.
 //
 // Similar To:
-//  ceph fs subvolume snapshot create <volume> --group-name=<group> <source> <name>
+//
+//	ceph fs subvolume snapshot create <volume> --group-name=<group> <source> <name>
 func (fsa *FSAdmin) CreateSubVolumeSnapshot(volume, group, source, name string) error {
 	m := map[string]string{
 		"prefix":    "fs subvolume snapshot create",
@@ -293,7 +302,8 @@ func (fsa *FSAdmin) CreateSubVolumeSnapshot(volume, group, source, name string) 
 // RemoveSubVolumeSnapshot removes the specified snapshot from the subvolume.
 //
 // Similar To:
-//  ceph fs subvolume snapshot rm <volume> --group-name=<group> <subvolume> <name>
+//
+//	ceph fs subvolume snapshot rm <volume> --group-name=<group> <subvolume> <name>
 func (fsa *FSAdmin) RemoveSubVolumeSnapshot(volume, group, subvolume, name string) error {
 	return fsa.rmSubVolumeSnapshot(volume, group, subvolume, name, commonRmFlags{})
 }
@@ -301,7 +311,8 @@ func (fsa *FSAdmin) RemoveSubVolumeSnapshot(volume, group, subvolume, name strin
 // ForceRemoveSubVolumeSnapshot removes the specified snapshot from the subvolume.
 //
 // Similar To:
-//  ceph fs subvolume snapshot rm <volume> --group-name=<group> <subvolume> <name> --force
+//
+//	ceph fs subvolume snapshot rm <volume> --group-name=<group> <subvolume> <name> --force
 func (fsa *FSAdmin) ForceRemoveSubVolumeSnapshot(volume, group, subvolume, name string) error {
 	return fsa.rmSubVolumeSnapshot(volume, group, subvolume, name, commonRmFlags{force: true})
 }
@@ -324,7 +335,8 @@ func (fsa *FSAdmin) rmSubVolumeSnapshot(volume, group, subvolume, name string, o
 // ListSubVolumeSnapshots returns a listing of snapshots for a given subvolume.
 //
 // Similar To:
-//  ceph fs subvolume snapshot ls <volume> --group-name=<group> <name>
+//
+//	ceph fs subvolume snapshot ls <volume> --group-name=<group> <name>
 func (fsa *FSAdmin) ListSubVolumeSnapshots(volume, group, name string) ([]string, error) {
 	m := map[string]string{
 		"prefix":   "fs subvolume snapshot ls",
@@ -358,7 +370,8 @@ func parseSubVolumeSnapshotInfo(res response) (*SubVolumeSnapshotInfo, error) {
 // SubVolumeSnapshotInfo returns information about the specified subvolume snapshot.
 //
 // Similar To:
-//  ceph fs subvolume snapshot info <volume> --group-name=<group> <subvolume> <name>
+//
+//	ceph fs subvolume snapshot info <volume> --group-name=<group> <subvolume> <name>
 func (fsa *FSAdmin) SubVolumeSnapshotInfo(volume, group, subvolume, name string) (*SubVolumeSnapshotInfo, error) {
 	m := map[string]string{
 		"prefix":    "fs subvolume snapshot info",
@@ -376,7 +389,8 @@ func (fsa *FSAdmin) SubVolumeSnapshotInfo(volume, group, subvolume, name string)
 // ProtectSubVolumeSnapshot protects the specified snapshot.
 //
 // Similar To:
-//  ceph fs subvolume snapshot protect <volume> --group-name=<group> <subvolume> <name>
+//
+//	ceph fs subvolume snapshot protect <volume> --group-name=<group> <subvolume> <name>
 func (fsa *FSAdmin) ProtectSubVolumeSnapshot(volume, group, subvolume, name string) error {
 	m := map[string]string{
 		"prefix":    "fs subvolume snapshot protect",
@@ -394,7 +408,8 @@ func (fsa *FSAdmin) ProtectSubVolumeSnapshot(volume, group, subvolume, name stri
 // UnprotectSubVolumeSnapshot removes protection from the specified snapshot.
 //
 // Similar To:
-//  ceph fs subvolume snapshot unprotect <volume> --group-name=<group> <subvolume> <name>
+//
+//	ceph fs subvolume snapshot unprotect <volume> --group-name=<group> <subvolume> <name>
 func (fsa *FSAdmin) UnprotectSubVolumeSnapshot(volume, group, subvolume, name string) error {
 	m := map[string]string{
 		"prefix":    "fs subvolume snapshot unprotect",

--- a/cephfs/admin/subvolumegroup.go
+++ b/cephfs/admin/subvolumegroup.go
@@ -40,7 +40,8 @@ func (s *SubVolumeGroupOptions) toFields(v, g string) *subVolumeGroupFields {
 // CreateSubVolumeGroup sends a request to create a subvolume group in a volume.
 //
 // Similar To:
-//  ceph fs subvolumegroup create <volume> <group_name>  ...
+//
+//	ceph fs subvolumegroup create <volume> <group_name>  ...
 func (fsa *FSAdmin) CreateSubVolumeGroup(volume, name string, o *SubVolumeGroupOptions) error {
 	if o == nil {
 		o = &SubVolumeGroupOptions{}
@@ -53,7 +54,8 @@ func (fsa *FSAdmin) CreateSubVolumeGroup(volume, name string, o *SubVolumeGroupO
 // specified volume.
 //
 // Similar To:
-//  ceph fs subvolumegroup ls cephfs <volume>
+//
+//	ceph fs subvolumegroup ls cephfs <volume>
 func (fsa *FSAdmin) ListSubVolumeGroups(volume string) ([]string, error) {
 	res := fsa.marshalMgrCommand(map[string]string{
 		"prefix":   "fs subvolumegroup ls",
@@ -65,14 +67,16 @@ func (fsa *FSAdmin) ListSubVolumeGroups(volume string) ([]string, error) {
 
 // RemoveSubVolumeGroup will delete a subvolume group in a volume.
 // Similar To:
-//  ceph fs subvolumegroup rm <volume> <group_name>
+//
+//	ceph fs subvolumegroup rm <volume> <group_name>
 func (fsa *FSAdmin) RemoveSubVolumeGroup(volume, name string) error {
 	return fsa.rmSubVolumeGroup(volume, name, commonRmFlags{})
 }
 
 // ForceRemoveSubVolumeGroup will delete a subvolume group in a volume.
 // Similar To:
-//  ceph fs subvolumegroup rm <volume> <group_name> --force
+//
+//	ceph fs subvolumegroup rm <volume> <group_name> --force
 func (fsa *FSAdmin) ForceRemoveSubVolumeGroup(volume, name string) error {
 	return fsa.rmSubVolumeGroup(volume, name, commonRmFlags{force: true})
 }
@@ -91,7 +95,8 @@ func (fsa *FSAdmin) rmSubVolumeGroup(volume, name string, o commonRmFlags) error
 // file system.
 //
 // Similar To:
-//  ceph fs subvolumegroup getpath <volume> <group_name>
+//
+//	ceph fs subvolumegroup getpath <volume> <group_name>
 func (fsa *FSAdmin) SubVolumeGroupPath(volume, name string) (string, error) {
 	m := map[string]string{
 		"prefix":     "fs subvolumegroup getpath",

--- a/cephfs/admin/volume.go
+++ b/cephfs/admin/volume.go
@@ -14,7 +14,8 @@ var (
 // ListVolumes return a list of volumes in this Ceph cluster.
 //
 // Similar To:
-//  ceph fs volume ls
+//
+//	ceph fs volume ls
 func (fsa *FSAdmin) ListVolumes() ([]string, error) {
 	res := fsa.rawMgrCommand(listVolumesCmd)
 	return parseListNames(res)
@@ -34,7 +35,8 @@ type FSPoolInfo struct {
 // file systems.
 //
 // Similar To:
-//  ceph fs ls
+//
+//	ceph fs ls
 func (fsa *FSAdmin) ListFileSystems() ([]FSPoolInfo, error) {
 	res := fsa.rawMonCommand(listFsCmd)
 	return parseFsList(res)
@@ -168,7 +170,8 @@ func parseVolumeStatus(res response) (*volumeStatusResponse, error) {
 // VolumeStatus returns a VolumeStatus object for the given volume name.
 //
 // Similar To:
-//  ceph fs status cephfs <name>
+//
+//	ceph fs status cephfs <name>
 func (fsa *FSAdmin) VolumeStatus(name string) (*VolumeStatus, error) {
 	res := fsa.marshalMgrCommand(map[string]string{
 		"fs":     name,

--- a/cephfs/cephfs.go
+++ b/cephfs/cephfs.go
@@ -61,7 +61,8 @@ func CreateMountWithId(id string) (*MountInfo, error) {
 // connection.
 //
 // Implements:
-//  int ceph_create_from_rados(struct ceph_mount_info **cmount, rados_t cluster);
+//
+//	int ceph_create_from_rados(struct ceph_mount_info **cmount, rados_t cluster);
 func CreateFromRados(conn *rados.Conn) (*MountInfo, error) {
 	mount := &MountInfo{}
 	ret := C.ceph_create_from_rados(&mount.mount, C.rados_t(conn.Cluster()))
@@ -74,7 +75,8 @@ func CreateFromRados(conn *rados.Conn) (*MountInfo, error) {
 // ReadDefaultConfigFile loads the ceph configuration from the default config file.
 //
 // Implements:
-//  int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
+//
+//	int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
 func (mount *MountInfo) ReadDefaultConfigFile() error {
 	ret := C.ceph_conf_read_file(mount.mount, nil)
 	return getError(ret)
@@ -83,7 +85,8 @@ func (mount *MountInfo) ReadDefaultConfigFile() error {
 // ReadConfigFile loads the ceph configuration from the specified config file.
 //
 // Implements:
-//  int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
+//
+//	int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
 func (mount *MountInfo) ReadConfigFile(path string) error {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
@@ -95,7 +98,8 @@ func (mount *MountInfo) ReadConfigFile(path string) error {
 // argument vector.
 //
 // Implements:
-//  int ceph_conf_parse_argv(struct ceph_mount_info *cmount, int argc, const char **argv);
+//
+//	int ceph_conf_parse_argv(struct ceph_mount_info *cmount, int argc, const char **argv);
 func (mount *MountInfo) ParseConfigArgv(argv []string) error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -117,7 +121,8 @@ func (mount *MountInfo) ParseConfigArgv(argv []string) error {
 // environment variable CEPH_ARGS.
 //
 // Implements:
-//  int ceph_conf_parse_env(struct ceph_mount_info *cmount, const char *var);
+//
+//	int ceph_conf_parse_env(struct ceph_mount_info *cmount, const char *var);
 func (mount *MountInfo) ParseDefaultConfigEnv() error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -130,7 +135,8 @@ func (mount *MountInfo) ParseDefaultConfigEnv() error {
 // the given name.
 //
 // Implements:
-//  int ceph_conf_set(struct ceph_mount_info *cmount, const char *option, const char *value);
+//
+//	int ceph_conf_set(struct ceph_mount_info *cmount, const char *option, const char *value);
 func (mount *MountInfo) SetConfigOption(option, value string) error {
 	cOption := C.CString(option)
 	defer C.free(unsafe.Pointer(cOption))
@@ -143,7 +149,8 @@ func (mount *MountInfo) SetConfigOption(option, value string) error {
 // identified by the given name.
 //
 // Implements:
-//  int ceph_conf_get(struct ceph_mount_info *cmount, const char *option, char *buf, size_t len);
+//
+//	int ceph_conf_get(struct ceph_mount_info *cmount, const char *option, char *buf, size_t len);
 func (mount *MountInfo) GetConfigOption(option string) (string, error) {
 	cOption := C.CString(option)
 	defer C.free(unsafe.Pointer(cOption))
@@ -173,7 +180,8 @@ func (mount *MountInfo) GetConfigOption(option string) (string, error) {
 // Init the file system client without actually mounting the file system.
 //
 // Implements:
-//  int ceph_init(struct ceph_mount_info *cmount);
+//
+//	int ceph_init(struct ceph_mount_info *cmount);
 func (mount *MountInfo) Init() error {
 	return getError(C.ceph_init(mount.mount))
 }
@@ -181,7 +189,8 @@ func (mount *MountInfo) Init() error {
 // Mount the file system, establishing a connection capable of I/O.
 //
 // Implements:
-//  int ceph_mount(struct ceph_mount_info *cmount, const char *root);
+//
+//	int ceph_mount(struct ceph_mount_info *cmount, const char *root);
 func (mount *MountInfo) Mount() error {
 	ret := C.ceph_mount(mount.mount, nil)
 	return getError(ret)
@@ -191,7 +200,8 @@ func (mount *MountInfo) Mount() error {
 // the mount. This establishes a connection capable of I/O.
 //
 // Implements:
-//  int ceph_mount(struct ceph_mount_info *cmount, const char *root);
+//
+//	int ceph_mount(struct ceph_mount_info *cmount, const char *root);
 func (mount *MountInfo) MountWithRoot(root string) error {
 	croot := C.CString(root)
 	defer C.free(unsafe.Pointer(croot))
@@ -201,7 +211,8 @@ func (mount *MountInfo) MountWithRoot(root string) error {
 // Unmount the file system.
 //
 // Implements:
-//  int ceph_unmount(struct ceph_mount_info *cmount);
+//
+//	int ceph_unmount(struct ceph_mount_info *cmount);
 func (mount *MountInfo) Unmount() error {
 	ret := C.ceph_unmount(mount.mount)
 	return getError(ret)
@@ -210,7 +221,8 @@ func (mount *MountInfo) Unmount() error {
 // Release destroys the mount handle.
 //
 // Implements:
-//  int ceph_release(struct ceph_mount_info *cmount);
+//
+//	int ceph_release(struct ceph_mount_info *cmount);
 func (mount *MountInfo) Release() error {
 	if mount.mount == nil {
 		return nil

--- a/cephfs/command.go
+++ b/cephfs/command.go
@@ -32,13 +32,14 @@ func (mount *MountInfo) MdsCommandWithInputBuffer(mdsSpec string, args [][]byte,
 // mdsCommand supports sending formatted commands to MDS.
 //
 // Implements:
-//  int ceph_mds_command(struct ceph_mount_info *cmount,
-//      const char *mds_spec,
-//      const char **cmd,
-//      size_t cmdlen,
-//      const char *inbuf, size_t inbuflen,
-//      char **outbuf, size_t *outbuflen,
-//      char **outs, size_t *outslen);
+//
+//	int ceph_mds_command(struct ceph_mount_info *cmount,
+//	    const char *mds_spec,
+//	    const char **cmd,
+//	    size_t cmdlen,
+//	    const char *inbuf, size_t inbuflen,
+//	    char **outbuf, size_t *outbuflen,
+//	    char **outs, size_t *outslen);
 func (mount *MountInfo) mdsCommand(mdsSpec string, args [][]byte, inputBuffer []byte) (buffer []byte, info string, err error) {
 	spec := C.CString(mdsSpec)
 	defer C.free(unsafe.Pointer(spec))

--- a/cephfs/conn_nautilus.go
+++ b/cephfs/conn_nautilus.go
@@ -15,10 +15,12 @@ import "C"
 // will be returned.
 //
 // Note:
-//  Only supported in Ceph Nautilus and newer.
+//
+//	Only supported in Ceph Nautilus and newer.
 //
 // Implements:
-//  int64_t ceph_get_fs_cid(struct ceph_mount_info *cmount);
+//
+//	int64_t ceph_get_fs_cid(struct ceph_mount_info *cmount);
 func (mount *MountInfo) GetFsCid() (int64, error) {
 	ret := C.ceph_get_fs_cid(mount.mount)
 	if ret < 0 {

--- a/cephfs/directory.go
+++ b/cephfs/directory.go
@@ -22,7 +22,8 @@ type Directory struct {
 // OpenDir returns a new Directory handle open for I/O.
 //
 // Implements:
-//  int ceph_opendir(struct ceph_mount_info *cmount, const char *name, struct ceph_dir_result **dirpp);
+//
+//	int ceph_opendir(struct ceph_mount_info *cmount, const char *name, struct ceph_dir_result **dirpp);
 func (mount *MountInfo) OpenDir(path string) (*Directory, error) {
 	var dir *C.struct_ceph_dir_result
 
@@ -43,7 +44,8 @@ func (mount *MountInfo) OpenDir(path string) (*Directory, error) {
 // Close the open directory handle.
 //
 // Implements:
-//  int ceph_closedir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
+//
+//	int ceph_closedir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
 func (dir *Directory) Close() error {
 	return getError(C.ceph_closedir(dir.mount.mount, dir.dir))
 }
@@ -136,7 +138,8 @@ func toDirEntryPlus(de *C.struct_dirent, s C.struct_ceph_statx) *DirEntryPlus {
 // exhausted.
 //
 // Implements:
-//  int ceph_readdir_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de);
+//
+//	int ceph_readdir_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de);
 func (dir *Directory) ReadDir() (*DirEntry, error) {
 	var de C.struct_dirent
 	ret := C.ceph_readdir_r(dir.mount.mount, dir.dir, &de)
@@ -156,8 +159,9 @@ func (dir *Directory) ReadDir() (*DirEntry, error) {
 // See Statx for a description of the wants and flags parameters.
 //
 // Implements:
-//  int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de,
-//                         struct ceph_statx *stx, unsigned want, unsigned flags, struct Inode **out);
+//
+//	int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de,
+//	                       struct ceph_statx *stx, unsigned want, unsigned flags, struct Inode **out);
 func (dir *Directory) ReadDirPlus(
 	want StatxMask, flags AtFlags) (*DirEntryPlus, error) {
 
@@ -186,7 +190,8 @@ func (dir *Directory) ReadDirPlus(
 // RewindDir sets the directory stream to the beginning of the directory.
 //
 // Implements:
-//  void ceph_rewinddir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
+//
+//	void ceph_rewinddir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
 func (dir *Directory) RewindDir() {
 	C.ceph_rewinddir(dir.mount.mount, dir.dir)
 }

--- a/cephfs/file.go
+++ b/cephfs/file.go
@@ -48,7 +48,8 @@ type File struct {
 // a local open call. Mode is the same mode bits as a local open call.
 //
 // Implements:
-//  int ceph_open(struct ceph_mount_info *cmount, const char *path, int flags, mode_t mode);
+//
+//	int ceph_open(struct ceph_mount_info *cmount, const char *path, int flags, mode_t mode);
 func (mount *MountInfo) Open(path string, flags int, mode uint32) (*File, error) {
 	if mount.mount == nil {
 		return nil, ErrNotConnected
@@ -72,7 +73,8 @@ func (f *File) validate() error {
 // Close the file.
 //
 // Implements:
-//  int ceph_close(struct ceph_mount_info *cmount, int fd);
+//
+//	int ceph_close(struct ceph_mount_info *cmount, int fd);
 func (f *File) Close() error {
 	if f.fd == -1 {
 		// already closed
@@ -93,7 +95,8 @@ func (f *File) Close() error {
 // wrappers for external callers of the library.
 //
 // Implements:
-//  int ceph_read(struct ceph_mount_info *cmount, int fd, char *buf, int64_t size, int64_t offset);
+//
+//	int ceph_read(struct ceph_mount_info *cmount, int fd, char *buf, int64_t size, int64_t offset);
 func (f *File) read(buf []byte, offset int64) (int, error) {
 	if err := f.validate(); err != nil {
 		return 0, err
@@ -137,8 +140,9 @@ func (f *File) ReadAt(buf []byte, offset int64) (int, error) {
 // 0, io.EOF.
 //
 // Implements:
-//  int ceph_preadv(struct ceph_mount_info *cmount, int fd, const struct iovec *iov, int iovcnt,
-//                  int64_t offset);
+//
+//	int ceph_preadv(struct ceph_mount_info *cmount, int fd, const struct iovec *iov, int iovcnt,
+//	                int64_t offset);
 func (f *File) Preadv(data [][]byte, offset int64) (int, error) {
 	if err := f.validate(); err != nil {
 		return 0, err
@@ -167,8 +171,9 @@ func (f *File) Preadv(data [][]byte, offset int64) (int, error) {
 // wrappers for external callers of the library.
 //
 // Implements:
-//  int ceph_write(struct ceph_mount_info *cmount, int fd, const char *buf,
-//                 int64_t size, int64_t offset);
+//
+//	int ceph_write(struct ceph_mount_info *cmount, int fd, const char *buf,
+//	               int64_t size, int64_t offset);
 func (f *File) write(buf []byte, offset int64) (int, error) {
 	if err := f.validate(); err != nil {
 		return 0, err
@@ -202,8 +207,9 @@ func (f *File) WriteAt(buf []byte, offset int64) (int, error) {
 // The number of bytes written is returned.
 //
 // Implements:
-//  int ceph_pwritev(struct ceph_mount_info *cmount, int fd, const struct iovec *iov, int iovcnt,
-//                   int64_t offset);
+//
+//	int ceph_pwritev(struct ceph_mount_info *cmount, int fd, const struct iovec *iov, int iovcnt,
+//	                 int64_t offset);
 func (f *File) Pwritev(data [][]byte, offset int64) (int, error) {
 	if err := f.validate(); err != nil {
 		return 0, err
@@ -226,7 +232,8 @@ func (f *File) Pwritev(data [][]byte, offset int64) (int, error) {
 // Seek will reposition the file stream based on the given offset.
 //
 // Implements:
-//  int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd, int64_t offset, int whence);
+//
+//	int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd, int64_t offset, int whence);
 func (f *File) Seek(offset int64, whence int) (int64, error) {
 	if err := f.validate(); err != nil {
 		return 0, err
@@ -250,7 +257,8 @@ func (f *File) Seek(offset int64, whence int) (int64, error) {
 // Fchmod changes the mode bits (permissions) of a file.
 //
 // Implements:
-//  int ceph_fchmod(struct ceph_mount_info *cmount, int fd, mode_t mode);
+//
+//	int ceph_fchmod(struct ceph_mount_info *cmount, int fd, mode_t mode);
 func (f *File) Fchmod(mode uint32) error {
 	if err := f.validate(); err != nil {
 		return err
@@ -263,7 +271,8 @@ func (f *File) Fchmod(mode uint32) error {
 // Fchown changes the ownership of a file.
 //
 // Implements:
-//  int ceph_fchown(struct ceph_mount_info *cmount, int fd, int uid, int gid);
+//
+//	int ceph_fchown(struct ceph_mount_info *cmount, int fd, int uid, int gid);
 func (f *File) Fchown(user uint32, group uint32) error {
 	if err := f.validate(); err != nil {
 		return err
@@ -276,8 +285,9 @@ func (f *File) Fchown(user uint32, group uint32) error {
 // Fstatx returns information about an open file.
 //
 // Implements:
-//  int ceph_fstatx(struct ceph_mount_info *cmount, int fd, struct ceph_statx *stx,
-//                  unsigned int want, unsigned int flags);
+//
+//	int ceph_fstatx(struct ceph_mount_info *cmount, int fd, struct ceph_statx *stx,
+//	                unsigned int want, unsigned int flags);
 func (f *File) Fstatx(want StatxMask, flags AtFlags) (*CephStatx, error) {
 	if err := f.validate(); err != nil {
 		return nil, err
@@ -317,6 +327,7 @@ const (
 // on the given range.
 //
 // Implements:
+//
 //	int ceph_fallocate(struct ceph_mount_info *cmount, int fd, int mode,
 //								  int64_t offset, int64_t length);
 func (f *File) Fallocate(mode FallocFlags, offset, length int64) error {
@@ -348,7 +359,8 @@ const (
 // lock, must be an arbitrary integer.
 //
 // Implements:
-//  int ceph_flock(struct ceph_mount_info *cmount, int fd, int operation, uint64_t owner);
+//
+//	int ceph_flock(struct ceph_mount_info *cmount, int fd, int operation, uint64_t owner);
 func (f *File) Flock(operation LockOp, owner uint64) error {
 	if err := f.validate(); err != nil {
 		return err
@@ -372,7 +384,8 @@ func (f *File) Flock(operation LockOp, owner uint64) error {
 // Pass SyncDataOnly to have this call behave more like fdatasync (on linux).
 //
 // Implements:
-//  int ceph_fsync(struct ceph_mount_info *cmount, int fd, int syncdataonly);
+//
+//	int ceph_fsync(struct ceph_mount_info *cmount, int fd, int syncdataonly);
 func (f *File) Fsync(sync SyncChoice) error {
 	if err := f.validate(); err != nil {
 		return err
@@ -401,7 +414,8 @@ func (f *File) Sync() error {
 // https://tracker.ceph.com/issues/48202
 //
 // Implements:
-//  int ceph_ftruncate(struct ceph_mount_info *cmount, int fd, int64_t size);
+//
+//	int ceph_ftruncate(struct ceph_mount_info *cmount, int fd, int64_t size);
 func (f *File) Truncate(size int64) error {
 	if err := f.validate(); err != nil {
 		return err

--- a/cephfs/file_xattr.go
+++ b/cephfs/file_xattr.go
@@ -39,8 +39,9 @@ const (
 // Please refer to https://tracker.ceph.com/issues/46084
 //
 // Implements:
-//  int ceph_fsetxattr(struct ceph_mount_info *cmount, int fd, const char *name,
-//                     const void *value, size_t size, int flags);
+//
+//	int ceph_fsetxattr(struct ceph_mount_info *cmount, int fd, const char *name,
+//	                   const void *value, size_t size, int flags);
 func (f *File) SetXattr(name string, value []byte, flags XattrFlags) error {
 	if err := f.validate(); err != nil {
 		return err
@@ -68,8 +69,9 @@ func (f *File) SetXattr(name string, value []byte, flags XattrFlags) error {
 // GetXattr gets an extended attribute from the open file.
 //
 // Implements:
-//  int ceph_fgetxattr(struct ceph_mount_info *cmount, int fd, const char *name,
-//                     void *value, size_t size);
+//
+//	int ceph_fgetxattr(struct ceph_mount_info *cmount, int fd, const char *name,
+//	                   void *value, size_t size);
 func (f *File) GetXattr(name string) ([]byte, error) {
 	if err := f.validate(); err != nil {
 		return nil, err
@@ -107,7 +109,8 @@ func (f *File) GetXattr(name string) ([]byte, error) {
 // on the file.
 //
 // Implements:
-//  int ceph_flistxattr(struct ceph_mount_info *cmount, int fd, char *list, size_t size);
+//
+//	int ceph_flistxattr(struct ceph_mount_info *cmount, int fd, char *list, size_t size);
 func (f *File) ListXattr() ([]string, error) {
 	if err := f.validate(); err != nil {
 		return nil, err
@@ -140,7 +143,8 @@ func (f *File) ListXattr() ([]string, error) {
 // RemoveXattr removes the named xattr from the open file.
 //
 // Implements:
-//  int ceph_fremovexattr(struct ceph_mount_info *cmount, int fd, const char *name);
+//
+//	int ceph_fremovexattr(struct ceph_mount_info *cmount, int fd, const char *name);
 func (f *File) RemoveXattr(name string) error {
 	if err := f.validate(); err != nil {
 		return err

--- a/cephfs/makedirs.go
+++ b/cephfs/makedirs.go
@@ -18,6 +18,7 @@ import (
 // MakeDirs creates multiple directories at once.
 //
 // Implements:
+//
 //	int ceph_mkdirs(struct ceph_mount_info *cmount, const char *path, mode_t mode);
 func (mount *MountInfo) MakeDirs(path string, mode uint32) error {
 	if err := mount.validate(); err != nil {

--- a/cephfs/mount_perms_mimic.go
+++ b/cephfs/mount_perms_mimic.go
@@ -15,7 +15,8 @@ import "C"
 // This function must be called after Init but before Mount.
 //
 // Implements:
-//  int ceph_mount_perms_set(struct ceph_mount_info *cmount, UserPerm *perm);
+//
+//	int ceph_mount_perms_set(struct ceph_mount_info *cmount, UserPerm *perm);
 func (mount *MountInfo) SetMountPerms(perm *UserPerm) error {
 	return getError(C.ceph_mount_perms_set(mount.mount, perm.userPerm))
 }

--- a/cephfs/path.go
+++ b/cephfs/path.go
@@ -60,7 +60,8 @@ func (mount *MountInfo) RemoveDir(path string) error {
 // Unlink removes a file.
 //
 // Implements:
-//  int ceph_unlink(struct ceph_mount_info *cmount, const char *path);
+//
+//	int ceph_unlink(struct ceph_mount_info *cmount, const char *path);
 func (mount *MountInfo) Unlink(path string) error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -75,7 +76,8 @@ func (mount *MountInfo) Unlink(path string) error {
 // Link creates a new link to an existing file.
 //
 // Implements:
-//  int ceph_link (struct ceph_mount_info *cmount, const char *existing, const char *newname);
+//
+//	int ceph_link (struct ceph_mount_info *cmount, const char *existing, const char *newname);
 func (mount *MountInfo) Link(oldname, newname string) error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -93,7 +95,8 @@ func (mount *MountInfo) Link(oldname, newname string) error {
 // Symlink creates a symbolic link to an existing path.
 //
 // Implements:
-//  int ceph_symlink(struct ceph_mount_info *cmount, const char *existing, const char *newname);
+//
+//	int ceph_symlink(struct ceph_mount_info *cmount, const char *existing, const char *newname);
 func (mount *MountInfo) Symlink(existing, newname string) error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -111,7 +114,8 @@ func (mount *MountInfo) Symlink(existing, newname string) error {
 // Readlink returns the value of a symbolic link.
 //
 // Implements:
-//  int ceph_readlink(struct ceph_mount_info *cmount, const char *path, char *buf, int64_t size);
+//
+//	int ceph_readlink(struct ceph_mount_info *cmount, const char *path, char *buf, int64_t size);
 func (mount *MountInfo) Readlink(path string) (string, error) {
 	if err := mount.validate(); err != nil {
 		return "", err
@@ -134,8 +138,9 @@ func (mount *MountInfo) Readlink(path string) (string, error) {
 // Statx returns information about a file/directory.
 //
 // Implements:
-//  int ceph_statx(struct ceph_mount_info *cmount, const char *path, struct ceph_statx *stx,
-//                 unsigned int want, unsigned int flags);
+//
+//	int ceph_statx(struct ceph_mount_info *cmount, const char *path, struct ceph_statx *stx,
+//	               unsigned int want, unsigned int flags);
 func (mount *MountInfo) Statx(path string, want StatxMask, flags AtFlags) (*CephStatx, error) {
 	if err := mount.validate(); err != nil {
 		return nil, err
@@ -160,7 +165,8 @@ func (mount *MountInfo) Statx(path string, want StatxMask, flags AtFlags) (*Ceph
 // Rename a file or directory.
 //
 // Implements:
-//  int ceph_rename(struct ceph_mount_info *cmount, const char *from, const char *to);
+//
+//	int ceph_rename(struct ceph_mount_info *cmount, const char *from, const char *to);
 func (mount *MountInfo) Rename(from, to string) error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -177,7 +183,8 @@ func (mount *MountInfo) Rename(from, to string) error {
 // Truncate sets the size of the specified file.
 //
 // Implements:
-//  int ceph_truncate(struct ceph_mount_info *cmount, const char *path, int64_t size);
+//
+//	int ceph_truncate(struct ceph_mount_info *cmount, const char *path, int64_t size);
 func (mount *MountInfo) Truncate(path string, size int64) error {
 	if err := mount.validate(); err != nil {
 		return err

--- a/cephfs/path_xattr.go
+++ b/cephfs/path_xattr.go
@@ -22,8 +22,9 @@ import (
 // the xattr to be unset. Please refer to https://tracker.ceph.com/issues/46084
 //
 // Implements:
-//  int ceph_setxattr(struct ceph_mount_info *cmount, const char *path, const char *name,
-//                    const void *value, size_t size, int flags);
+//
+//	int ceph_setxattr(struct ceph_mount_info *cmount, const char *path, const char *name,
+//	                  const void *value, size_t size, int flags);
 func (mount *MountInfo) SetXattr(path, name string, value []byte, flags XattrFlags) error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -53,8 +54,9 @@ func (mount *MountInfo) SetXattr(path, name string, value []byte, flags XattrFla
 // GetXattr gets an extended attribute from the file at the supplied path.
 //
 // Implements:
-//  int ceph_getxattr(struct ceph_mount_info *cmount, const char *path, const char *name,
-//                    void *value, size_t size);
+//
+//	int ceph_getxattr(struct ceph_mount_info *cmount, const char *path, const char *name,
+//	                  void *value, size_t size);
 func (mount *MountInfo) GetXattr(path, name string) ([]byte, error) {
 	if err := mount.validate(); err != nil {
 		return nil, err
@@ -94,7 +96,8 @@ func (mount *MountInfo) GetXattr(path, name string) ([]byte, error) {
 // on the file at the supplied path.
 //
 // Implements:
-//  int ceph_listxattr(struct ceph_mount_info *cmount, const char *path, char *list, size_t size);
+//
+//	int ceph_listxattr(struct ceph_mount_info *cmount, const char *path, char *list, size_t size);
 func (mount *MountInfo) ListXattr(path string) ([]string, error) {
 	if err := mount.validate(); err != nil {
 		return nil, err
@@ -129,7 +132,8 @@ func (mount *MountInfo) ListXattr(path string) ([]string, error) {
 // RemoveXattr removes the named xattr from the open file.
 //
 // Implements:
-//  int ceph_removexattr(struct ceph_mount_info *cmount, const char *path, const char *name);
+//
+//	int ceph_removexattr(struct ceph_mount_info *cmount, const char *path, const char *name);
 func (mount *MountInfo) RemoveXattr(path, name string) error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -155,8 +159,9 @@ func (mount *MountInfo) RemoveXattr(path, name string) error {
 // the xattr to be unset. Please refer to https://tracker.ceph.com/issues/46084
 //
 // Implements:
-//  int ceph_lsetxattr(struct ceph_mount_info *cmount, const char *path, const char *name,
-//                    const void *value, size_t size, int flags);
+//
+//	int ceph_lsetxattr(struct ceph_mount_info *cmount, const char *path, const char *name,
+//	                  const void *value, size_t size, int flags);
 func (mount *MountInfo) LsetXattr(path, name string, value []byte, flags XattrFlags) error {
 	if err := mount.validate(); err != nil {
 		return err
@@ -186,8 +191,9 @@ func (mount *MountInfo) LsetXattr(path, name string, value []byte, flags XattrFl
 // LgetXattr gets an extended attribute from the file at the supplied path.
 //
 // Implements:
-//  int ceph_lgetxattr(struct ceph_mount_info *cmount, const char *path, const char *name,
-//                    void *value, size_t size);
+//
+//	int ceph_lgetxattr(struct ceph_mount_info *cmount, const char *path, const char *name,
+//	                  void *value, size_t size);
 func (mount *MountInfo) LgetXattr(path, name string) ([]byte, error) {
 	if err := mount.validate(); err != nil {
 		return nil, err
@@ -227,7 +233,8 @@ func (mount *MountInfo) LgetXattr(path, name string) ([]byte, error) {
 // on the file at the supplied path.
 //
 // Implements:
-//  int ceph_llistxattr(struct ceph_mount_info *cmount, const char *path, char *list, size_t size);
+//
+//	int ceph_llistxattr(struct ceph_mount_info *cmount, const char *path, char *list, size_t size);
 func (mount *MountInfo) LlistXattr(path string) ([]string, error) {
 	if err := mount.validate(); err != nil {
 		return nil, err
@@ -262,7 +269,8 @@ func (mount *MountInfo) LlistXattr(path string) ([]string, error) {
 // LremoveXattr removes the named xattr from the open file.
 //
 // Implements:
-//  int ceph_lremovexattr(struct ceph_mount_info *cmount, const char *path, const char *name);
+//
+//	int ceph_lremovexattr(struct ceph_mount_info *cmount, const char *path, const char *name);
 func (mount *MountInfo) LremoveXattr(path, name string) error {
 	if err := mount.validate(); err != nil {
 		return err

--- a/cephfs/select_fs.go
+++ b/cephfs/select_fs.go
@@ -23,7 +23,8 @@ import (
 // valid then only the subsequent mount call will fail.
 //
 // Implements:
-//  int ceph_select_filesystem(struct ceph_mount_info *cmount, const char *fs_name);
+//
+//	int ceph_select_filesystem(struct ceph_mount_info *cmount, const char *fs_name);
 func (mount *MountInfo) SelectFilesystem(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))

--- a/cephfs/statfs.go
+++ b/cephfs/statfs.go
@@ -44,7 +44,8 @@ type CephStatVFS struct {
 // useful values.
 //
 // Implements:
-//  int ceph_statfs(struct ceph_mount_info *cmount, const char *path, struct statvfs *stbuf);
+//
+//	int ceph_statfs(struct ceph_mount_info *cmount, const char *path, struct statvfs *stbuf);
 func (mount *MountInfo) StatFS(path string) (*CephStatVFS, error) {
 	if err := mount.validate(); err != nil {
 		return nil, err

--- a/cephfs/userperm.go
+++ b/cephfs/userperm.go
@@ -29,7 +29,8 @@ type UserPerm struct {
 // NewUserPerm creates a UserPerm pointer and the underlying ceph resources.
 //
 // Implements:
-//  UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids, gid_t *gidlist);
+//
+//	UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids, gid_t *gidlist);
 func NewUserPerm(uid, gid int, gidlist []int) *UserPerm {
 	// the C code does not copy the content of the gid list so we keep the
 	// inputs stashed in the go type. For completeness we stash everything.
@@ -59,7 +60,8 @@ func NewUserPerm(uid, gid int, gidlist []int) *UserPerm {
 // Destroy will explicitly free ceph resources associated with the UserPerm.
 //
 // Implements:
-//  void ceph_userperm_destroy(UserPerm *perm);
+//
+//	void ceph_userperm_destroy(UserPerm *perm);
 func (p *UserPerm) Destroy() {
 	if p.userPerm == nil || !p.managed {
 		return

--- a/common/admin/manager/module.go
+++ b/common/admin/manager/module.go
@@ -7,7 +7,8 @@ import (
 // EnableModule will enable the specified manager module.
 //
 // Similar To:
-//  ceph mgr module enable <module> [--force]
+//
+//	ceph mgr module enable <module> [--force]
 func (fsa *MgrAdmin) EnableModule(module string, force bool) error {
 	m := map[string]string{
 		"prefix": "mgr module enable",
@@ -25,7 +26,8 @@ func (fsa *MgrAdmin) EnableModule(module string, force bool) error {
 // DisableModule will disable the specified manager module.
 //
 // Similar To:
-//  ceph mgr module disable <module>
+//
+//	ceph mgr module disable <module>
 func (fsa *MgrAdmin) DisableModule(module string) error {
 	m := map[string]string{
 		"prefix": "mgr module disable",

--- a/common/admin/nfs/export.go
+++ b/common/admin/nfs/export.go
@@ -135,7 +135,8 @@ func parseExportInfo(res commands.Response) (ExportInfo, error) {
 // CreateCephFSExport will create a new NFS export for a CephFS file system.
 //
 // Similar To:
-//  ceph nfs export create cephfs
+//
+//	ceph nfs export create cephfs
 func (nfsa *Admin) CreateCephFSExport(spec CephFSExportSpec) (
 	*ExportResult, error) {
 	// ---
@@ -152,7 +153,8 @@ const delSucc = "Successfully deleted export"
 // RemoveExport will remove an NFS export based on the pseudo-path of the export.
 //
 // Similar To:
-//  ceph nfs export rm
+//
+//	ceph nfs export rm
 func (nfsa *Admin) RemoveExport(clusterID, pseudoPath string) error {
 	m := map[string]string{
 		"prefix":      "nfs export rm",
@@ -167,7 +169,8 @@ func (nfsa *Admin) RemoveExport(clusterID, pseudoPath string) error {
 // ListDetailedExports will return a list of exports with details.
 //
 // Similar To:
-//  ceph nfs export ls --detailed
+//
+//	ceph nfs export ls --detailed
 func (nfsa *Admin) ListDetailedExports(clusterID string) ([]ExportInfo, error) {
 	/*
 		NOTE: there is no simple list because based on a quick reading of the code
@@ -190,7 +193,8 @@ func (nfsa *Admin) ListDetailedExports(clusterID string) ([]ExportInfo, error) {
 // pseudo-path.
 //
 // Similar To:
-//  ceph nfs export info
+//
+//	ceph nfs export info
 func (nfsa *Admin) ExportInfo(clusterID, pseudoPath string) (ExportInfo, error) {
 	m := map[string]string{
 		"prefix":      "nfs export info",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,7 @@ CEPH_CONF=/tmp/ceph/ceph.conf
 MIRROR_STATE=/dev/null
 PKG_PREFIX=github.com/ceph/go-ceph
 ALT_FS="@/tmp/ceph/altfs.txt"
+GOFLAGS="-buildvcs=false ${GOFLAGS}"
 
 # Default env vars that are not currently changed by this script
 # but can be used to change the test behavior:
@@ -311,6 +312,7 @@ test_go_ceph() {
         show "${MICRO_OSD_PATH}" /tmp/ceph
     fi
     export CEPH_CONF
+    export GOFLAGS
 
     if [[ ${TEST_RUN} == NONE ]]; then
         echo "skipping test execution"

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/ceph/go-ceph
 
-go 1.17
+go 1.19
 
 require (
-	github.com/aws/aws-sdk-go v1.44.192
+	github.com/aws/aws-sdk-go v1.44.197
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/stretchr/testify v1.8.1
-	golang.org/x/sys v0.4.0
+	golang.org/x/sys v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go v1.44.192 h1:KL54vCxRd5v5XBGjnF3FelzXXwl+aWHDmDTihFmRNgM=
-github.com/aws/aws-sdk-go v1.44.192/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.197 h1:pkg/NZsov9v/CawQWy+qWVzJMIZRQypCtYjUBXFomF8=
+github.com/aws/aws-sdk-go v1.44.197/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -36,8 +36,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
-golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/rados/command.go
+++ b/rados/command.go
@@ -44,11 +44,12 @@ func (c *Conn) MonCommandWithInputBuffer(args, inputBuffer []byte) ([]byte, stri
 // PGCommand sends a command to one of the PGs
 //
 // Implements:
-//  int rados_pg_command(rados_t cluster, const char *pgstr,
-//                       const char **cmd, size_t cmdlen,
-//                       const char *inbuf, size_t inbuflen,
-//                       char **outbuf, size_t *outbuflen,
-//                       char **outs, size_t *outslen);
+//
+//	int rados_pg_command(rados_t cluster, const char *pgstr,
+//	                     const char **cmd, size_t cmdlen,
+//	                     const char *inbuf, size_t inbuflen,
+//	                     char **outbuf, size_t *outbuflen,
+//	                     char **outs, size_t *outslen);
 func (c *Conn) PGCommand(pgid []byte, args [][]byte) ([]byte, string, error) {
 	return c.PGCommandWithInputBuffer(pgid, args, nil)
 }
@@ -56,11 +57,12 @@ func (c *Conn) PGCommand(pgid []byte, args [][]byte) ([]byte, string, error) {
 // PGCommandWithInputBuffer sends a command to one of the PGs, with an input buffer
 //
 // Implements:
-//  int rados_pg_command(rados_t cluster, const char *pgstr,
-//                       const char **cmd, size_t cmdlen,
-//                       const char *inbuf, size_t inbuflen,
-//                       char **outbuf, size_t *outbuflen,
-//                       char **outs, size_t *outslen);
+//
+//	int rados_pg_command(rados_t cluster, const char *pgstr,
+//	                     const char **cmd, size_t cmdlen,
+//	                     const char *inbuf, size_t inbuflen,
+//	                     char **outbuf, size_t *outbuflen,
+//	                     char **outs, size_t *outslen);
 func (c *Conn) PGCommandWithInputBuffer(pgid []byte, args [][]byte, inputBuffer []byte) ([]byte, string, error) {
 	name := C.CString(string(pgid))
 	defer C.free(unsafe.Pointer(name))
@@ -92,11 +94,12 @@ func (c *Conn) MgrCommand(args [][]byte) ([]byte, string, error) {
 // MgrCommandWithInputBuffer sends a command, with an input buffer, to a ceph-mgr.
 //
 // Implements:
-//  int rados_mgr_command(rados_t cluster, const char **cmd,
-//                         size_t cmdlen, const char *inbuf,
-//                         size_t inbuflen, char **outbuf,
-//                         size_t *outbuflen, char **outs,
-//                          size_t *outslen);
+//
+//	int rados_mgr_command(rados_t cluster, const char **cmd,
+//	                       size_t cmdlen, const char *inbuf,
+//	                       size_t inbuflen, char **outbuf,
+//	                       size_t *outbuflen, char **outs,
+//	                        size_t *outslen);
 func (c *Conn) MgrCommandWithInputBuffer(args [][]byte, inputBuffer []byte) ([]byte, string, error) {
 	ci := cutil.NewCommandInput(args, inputBuffer)
 	defer ci.Free()
@@ -126,11 +129,12 @@ func (c *Conn) OsdCommand(osd int, args [][]byte) ([]byte, string, error) {
 // specified ceph OSD.
 //
 // Implements:
-//  int rados_osd_command(rados_t cluster, int osdid,
-//                                       const char **cmd, size_t cmdlen,
-//                                       const char *inbuf, size_t inbuflen,
-//                                       char **outbuf, size_t *outbuflen,
-//                                       char **outs, size_t *outslen);
+//
+//	int rados_osd_command(rados_t cluster, int osdid,
+//	                                     const char **cmd, size_t cmdlen,
+//	                                     const char *inbuf, size_t inbuflen,
+//	                                     char **outbuf, size_t *outbuflen,
+//	                                     char **outs, size_t *outslen);
 func (c *Conn) OsdCommandWithInputBuffer(
 	osd int, args [][]byte, inputBuffer []byte) ([]byte, string, error) {
 
@@ -162,11 +166,12 @@ func (c *Conn) MonCommandTarget(name string, args [][]byte) ([]byte, string, err
 // MonCommandTargetWithInputBuffer sends a command, with an input buffer, to a specified monitor.
 //
 // Implements:
-//  int rados_mon_command_target(rados_t cluster, const char *name,
-//                               const char **cmd, size_t cmdlen,
-//                               const char *inbuf, size_t inbuflen,
-//                               char **outbuf, size_t *outbuflen,
-//                               char **outs, size_t *outslen);
+//
+//	int rados_mon_command_target(rados_t cluster, const char *name,
+//	                             const char **cmd, size_t cmdlen,
+//	                             const char *inbuf, size_t inbuflen,
+//	                             char **outbuf, size_t *outbuflen,
+//	                             char **outs, size_t *outslen);
 func (c *Conn) MonCommandTargetWithInputBuffer(
 	name string, args [][]byte, inputBuffer []byte) ([]byte, string, error) {
 

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -95,8 +95,9 @@ func (c *Conn) ReadDefaultConfigFile() error {
 // OpenIOContext creates and returns a new IOContext for the given pool.
 //
 // Implements:
-//  int rados_ioctx_create(rados_t cluster, const char *pool_name,
-//                         rados_ioctx_t *ioctx);
+//
+//	int rados_ioctx_create(rados_t cluster, const char *pool_name,
+//	                       rados_ioctx_t *ioctx);
 func (c *Conn) OpenIOContext(pool string) (*IOContext, error) {
 	cPool := C.CString(pool)
 	defer C.free(unsafe.Pointer(cPool))
@@ -200,8 +201,9 @@ func (c *Conn) GetClusterStats() (stat ClusterStat, err error) {
 // argument vector.
 //
 // Implements:
-//  int rados_conf_parse_argv(rados_t cluster, int argc,
-//                            const char **argv);
+//
+//	int rados_conf_parse_argv(rados_t cluster, int argc,
+//	                          const char **argv);
 func (c *Conn) ParseConfigArgv(argv []string) error {
 	if c.cluster == nil {
 		return ErrNotConnected

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -125,8 +125,9 @@ func (ioctx *IOContext) Pointer() unsafe.Pointer {
 // Setting namespace to a empty or zero length string sets the pool to the default namespace.
 //
 // Implements:
-//  void rados_ioctx_set_namespace(rados_ioctx_t io,
-//                                 const char *nspace);
+//
+//	void rados_ioctx_set_namespace(rados_ioctx_t io,
+//	                               const char *nspace);
 func (ioctx *IOContext) SetNamespace(namespace string) {
 	var cns *C.char
 	if len(namespace) > 0 {
@@ -139,8 +140,9 @@ func (ioctx *IOContext) SetNamespace(namespace string) {
 // Create a new object with key oid.
 //
 // Implements:
-//  void rados_write_op_create(rados_write_op_t write_op, int exclusive,
-//                             const char* category)
+//
+//	void rados_write_op_create(rados_write_op_t write_op, int exclusive,
+//	                           const char* category)
 func (ioctx *IOContext) Create(oid string, exclusive CreateOption) error {
 	op := CreateWriteOp()
 	defer op.Release()
@@ -247,8 +249,9 @@ func (ioctx *IOContext) Destroy() {
 // context.
 //
 // Implements:
-//  int rados_ioctx_pool_stat(rados_ioctx_t io,
-//                            struct rados_pool_stat_t *stats);
+//
+//	int rados_ioctx_pool_stat(rados_ioctx_t io,
+//	                          struct rados_pool_stat_t *stats);
 func (ioctx *IOContext) GetPoolStats() (stat PoolStat, err error) {
 	cStat := C.struct_rados_pool_stat_t{}
 	ret := C.rados_ioctx_pool_stat(ioctx.ioctx, &cStat)
@@ -274,7 +277,8 @@ func (ioctx *IOContext) GetPoolStats() (stat PoolStat, err error) {
 // GetPoolID returns the pool ID associated with the I/O context.
 //
 // Implements:
-//  int64_t rados_ioctx_get_id(rados_ioctx_t io)
+//
+//	int64_t rados_ioctx_get_id(rados_ioctx_t io)
 func (ioctx *IOContext) GetPoolID() int64 {
 	ret := C.rados_ioctx_get_id(ioctx.ioctx)
 	return int64(ret)
@@ -678,7 +682,8 @@ func (ioctx *IOContext) BreakLock(oid, name, client, cookie string) (int, error)
 // written to.
 //
 // Implements:
-//  uint64_t rados_get_last_version(rados_ioctx_t io);
+//
+//	uint64_t rados_get_last_version(rados_ioctx_t io);
 func (ioctx *IOContext) GetLastVersion() (uint64, error) {
 	if err := ioctx.validate(); err != nil {
 		return 0, err
@@ -690,8 +695,9 @@ func (ioctx *IOContext) GetLastVersion() (uint64, error) {
 // GetNamespace gets the namespace used for objects within this IO context.
 //
 // Implements:
-//  int rados_ioctx_get_namespace(rados_ioctx_t io, char *buf,
-//                                unsigned maxlen);
+//
+//	int rados_ioctx_get_namespace(rados_ioctx_t io, char *buf,
+//	                              unsigned maxlen);
 func (ioctx *IOContext) GetNamespace() (string, error) {
 	if err := ioctx.validate(); err != nil {
 		return "", err

--- a/rados/ioctx_nautilus.go
+++ b/rados/ioctx_nautilus.go
@@ -13,7 +13,8 @@ import "C"
 // or return EDQUOT or ENOSPC.
 //
 // Implements:
-//  void rados_set_osdmap_full_try(rados_ioctx_t io);
+//
+//	void rados_set_osdmap_full_try(rados_ioctx_t io);
 func (ioctx *IOContext) SetPoolFullTry() error {
 	if err := ioctx.validate(); err != nil {
 		return err
@@ -25,7 +26,8 @@ func (ioctx *IOContext) SetPoolFullTry() error {
 // UnsetPoolFullTry unsets the flag set by SetPoolFullTry()
 //
 // Implements:
-//  void rados_unset_osdmap_full_try(rados_ioctx_t io);
+//
+//	void rados_unset_osdmap_full_try(rados_ioctx_t io);
 func (ioctx *IOContext) UnsetPoolFullTry() error {
 	if err := ioctx.validate(); err != nil {
 		return err

--- a/rados/ioctx_octopus.go
+++ b/rados/ioctx_octopus.go
@@ -16,7 +16,8 @@ import "C"
 // or return EDQUOT or ENOSPC.
 //
 // Implements:
-//  void rados_set_pool_full_try(rados_ioctx_t io);
+//
+//	void rados_set_pool_full_try(rados_ioctx_t io);
 func (ioctx *IOContext) SetPoolFullTry() error {
 	if err := ioctx.validate(); err != nil {
 		return err
@@ -28,7 +29,8 @@ func (ioctx *IOContext) SetPoolFullTry() error {
 // UnsetPoolFullTry unsets the flag set by SetPoolFullTry()
 //
 // Implements:
-//  void rados_unset_pool_full_try(rados_ioctx_t io);
+//
+//	void rados_unset_pool_full_try(rados_ioctx_t io);
 func (ioctx *IOContext) UnsetPoolFullTry() error {
 	if err := ioctx.validate(); err != nil {
 		return err

--- a/rados/ioctx_pool_alignment.go
+++ b/rados/ioctx_pool_alignment.go
@@ -11,7 +11,8 @@ import "C"
 // alignment or not, use RequiresAlignment.
 //
 // Implements:
-//  int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t *alignment)
+//
+//	int rados_ioctx_pool_required_alignment2(rados_ioctx_t io, uint64_t *alignment)
 func (ioctx *IOContext) Alignment() (uint64, error) {
 	var alignSizeBytes C.uint64_t
 	ret := C.rados_ioctx_pool_required_alignment2(

--- a/rados/ioctx_pool_requires_alignment.go
+++ b/rados/ioctx_pool_requires_alignment.go
@@ -11,7 +11,8 @@ import "C"
 // Alignment to know how to get the stripe size for pools requiring it.
 //
 // Implements:
-//  int rados_ioctx_pool_requires_alignment2(rados_ioctx_t io, int *req)
+//
+//	int rados_ioctx_pool_requires_alignment2(rados_ioctx_t io, int *req)
 func (ioctx *IOContext) RequiresAlignment() (bool, error) {
 	var alignRequired C.int
 	ret := C.rados_ioctx_pool_requires_alignment2(

--- a/rados/ioctx_set_alloc_hint.go
+++ b/rados/ioctx_set_alloc_hint.go
@@ -16,11 +16,12 @@ import (
 // the backend.
 //
 // Implements:
-//  int rados_set_alloc_hint2(rados_ioctx_t io,
-//                            const char *o,
-//                            uint64_t expected_object_size,
-//                            uint64_t expected_write_size,
-//                            uint32_t flags);
+//
+//	int rados_set_alloc_hint2(rados_ioctx_t io,
+//	                          const char *o,
+//	                          uint64_t expected_object_size,
+//	                          uint64_t expected_write_size,
+//	                          uint32_t flags);
 func (ioctx *IOContext) SetAllocationHint(oid string, expectedObjectSize uint64, expectedWriteSize uint64, flags AllocHintFlags) error {
 	coid := C.CString(oid)
 	defer C.free(unsafe.Pointer(coid))

--- a/rados/object_iter.go
+++ b/rados/object_iter.go
@@ -42,13 +42,13 @@ func (iter *Iter) Seek(token IterToken) {
 // end of the iterator was reached, or the iterator received an error.
 //
 // Example:
+//
 //	iter := pool.Iter()
 //	defer iter.Close()
 //	for iter.Next() {
 //		fmt.Printf("%v\n", iter.Value())
 //	}
 //	return iter.Err()
-//
 func (iter *Iter) Next() bool {
 	var cEntry *C.char
 	var cNamespace *C.char

--- a/rados/rados_read_op_assert_version.go
+++ b/rados/rados_read_op_assert_version.go
@@ -11,8 +11,9 @@ import "C"
 // previously obtained with IOContext.GetLastVersion().
 //
 // Implements:
-//  void rados_read_op_assert_version(rados_read_op_t read_op,
-//                                    uint64_t ver)
+//
+//	void rados_read_op_assert_version(rados_read_op_t read_op,
+//	                                  uint64_t ver)
 func (r *ReadOp) AssertVersion(ver uint64) {
 	C.rados_read_op_assert_version(r.op, C.uint64_t(ver))
 }

--- a/rados/rados_set_locator.go
+++ b/rados/rados_set_locator.go
@@ -15,7 +15,8 @@ import (
 // To reset the locator, an empty string must be set.
 //
 // Implements:
-//  void rados_ioctx_locator_set_key(rados_ioctx_t io, const char *key);
+//
+//	void rados_ioctx_locator_set_key(rados_ioctx_t io, const char *key);
 func (ioctx *IOContext) SetLocator(locator string) {
 	if locator == "" {
 		C.rados_ioctx_locator_set_key(ioctx.ioctx, nil)

--- a/rados/rados_write_op_assert_version.go
+++ b/rados/rados_write_op_assert_version.go
@@ -11,8 +11,9 @@ import "C"
 // previously obtained with IOContext.GetLastVersion().
 //
 // Implements:
-//  void rados_read_op_assert_version(rados_read_op_t read_op,
-//                                    uint64_t ver)
+//
+//	void rados_read_op_assert_version(rados_read_op_t read_op,
+//	                                  uint64_t ver)
 func (w *WriteOp) AssertVersion(ver uint64) {
 	C.rados_write_op_assert_version(w.op, C.uint64_t(ver))
 }

--- a/rados/rados_write_op_remove.go
+++ b/rados/rados_write_op_remove.go
@@ -9,7 +9,8 @@ import "C"
 // Remove object.
 //
 // Implements:
-//  void rados_write_op_remove(rados_write_op_t write_op)
+//
+//	void rados_write_op_remove(rados_write_op_t write_op)
 func (w *WriteOp) Remove() {
 	C.rados_write_op_remove(w.op)
 }

--- a/rados/rados_write_op_setxattr.go
+++ b/rados/rados_write_op_setxattr.go
@@ -13,10 +13,11 @@ import (
 // SetXattr sets an xattr.
 //
 // Implements:
-//  void rados_write_op_setxattr(rados_write_op_t write_op,
-//                               const char * name,
-//                               const char * value,
-//                               size_t value_len)
+//
+//	void rados_write_op_setxattr(rados_write_op_t write_op,
+//	                             const char * name,
+//	                             const char * value,
+//	                             size_t value_len)
 func (w *WriteOp) SetXattr(name string, value []byte) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))

--- a/rados/read_op.go
+++ b/rados/read_op.go
@@ -59,7 +59,8 @@ func (r *ReadOp) operateCompat(ioctx *IOContext, oid string) error {
 // AssertExists assures the object targeted by the read op exists.
 //
 // Implements:
-//  void rados_read_op_assert_exists(rados_read_op_t read_op);
+//
+//	void rados_read_op_assert_exists(rados_read_op_t read_op);
 func (r *ReadOp) AssertExists() {
 	C.rados_read_op_assert_exists(r.op)
 }

--- a/rados/read_op_omap_get_vals_by_keys.go
+++ b/rados/read_op_omap_get_vals_by_keys.go
@@ -86,12 +86,13 @@ func (s *ReadOpOmapGetValsByKeysStep) Next() (*OmapKeyValue, error) {
 // GetOmapValuesByKeys starts iterating over specific key/value pairs.
 //
 // Implements:
-//  void rados_read_op_omap_get_vals_by_keys2(rados_read_op_t read_op,
-//                                            char const * const * keys,
-//                                            size_t num_keys,
-//                                            const size_t * key_lens,
-//                                            rados_omap_iter_t * iter,
-//                                            int * prval)
+//
+//	void rados_read_op_omap_get_vals_by_keys2(rados_read_op_t read_op,
+//	                                          char const * const * keys,
+//	                                          size_t num_keys,
+//	                                          const size_t * key_lens,
+//	                                          rados_omap_iter_t * iter,
+//	                                          int * prval)
 func (r *ReadOp) GetOmapValuesByKeys(keys []string) *ReadOpOmapGetValsByKeysStep {
 	s := newReadOpOmapGetValsByKeysStep()
 	r.steps = append(r.steps, s)

--- a/rados/read_op_read.go
+++ b/rados/read_op_read.go
@@ -48,12 +48,13 @@ func newReadOpReadStep() *ReadOpReadStep {
 // buffer[:ReadOpReadStep.BytesRead] then contains object data.
 //
 // Implements:
-//  void rados_read_op_read(rados_read_op_t read_op,
-//                          uint64_t offset,
-//                          size_t len,
-//                          char * buffer,
-//                          size_t * bytes_read,
-//                          int * prval)
+//
+//	void rados_read_op_read(rados_read_op_t read_op,
+//	                        uint64_t offset,
+//	                        size_t len,
+//	                        char * buffer,
+//	                        size_t * bytes_read,
+//	                        int * prval)
 func (r *ReadOp) Read(offset uint64, buffer []byte) *ReadOpReadStep {
 	oe := newReadStep(buffer, offset)
 	readStep := newReadOpReadStep()

--- a/rados/snapshot.go
+++ b/rados/snapshot.go
@@ -31,7 +31,8 @@ func (ioctx *IOContext) CreateSnap(snapName string) error {
 // RemoveSnap deletes the pool snapshot.
 //
 // Implements:
-//  int rados_ioctx_snap_remove(rados_ioctx_t io, const char *snapname)
+//
+//	int rados_ioctx_snap_remove(rados_ioctx_t io, const char *snapname)
 func (ioctx *IOContext) RemoveSnap(snapName string) error {
 	if err := ioctx.validate(); err != nil {
 		return err
@@ -50,7 +51,8 @@ type SnapID C.rados_snap_t
 // LookupSnap returns the ID of a pool snapshot.
 //
 // Implements:
-//  int rados_ioctx_snap_lookup(rados_ioctx_t io, const char *name, rados_snap_t *id)
+//
+//	int rados_ioctx_snap_lookup(rados_ioctx_t io, const char *name, rados_snap_t *id)
 func (ioctx *IOContext) LookupSnap(snapName string) (SnapID, error) {
 	var snapID SnapID
 
@@ -71,7 +73,8 @@ func (ioctx *IOContext) LookupSnap(snapName string) (SnapID, error) {
 // GetSnapName returns the name of a pool snapshot with the given snapshot ID.
 //
 // Implements:
-//  int rados_ioctx_snap_get_name(rados_ioctx_t io, rados_snap_t id, char *name, int maxlen)
+//
+//	int rados_ioctx_snap_get_name(rados_ioctx_t io, rados_snap_t id, char *name, int maxlen)
 func (ioctx *IOContext) GetSnapName(snapID SnapID) (string, error) {
 	if err := ioctx.validate(); err != nil {
 		return "", err
@@ -103,7 +106,8 @@ func (ioctx *IOContext) GetSnapName(snapID SnapID) (string, error) {
 // GetSnapStamp returns the time of the pool snapshot creation.
 //
 // Implements:
-//  int rados_ioctx_snap_get_stamp(rados_ioctx_t io, rados_snap_t id, time_t *t)
+//
+//	int rados_ioctx_snap_get_stamp(rados_ioctx_t io, rados_snap_t id, time_t *t)
 func (ioctx *IOContext) GetSnapStamp(snapID SnapID) (time.Time, error) {
 	var cTime C.time_t
 
@@ -121,7 +125,8 @@ func (ioctx *IOContext) GetSnapStamp(snapID SnapID) (time.Time, error) {
 // ListSnaps returns a slice containing the SnapIDs of existing pool snapshots.
 //
 // Implements:
-//  int rados_ioctx_snap_list(rados_ioctx_t io, rados_snap_t *snaps, int maxlen)
+//
+//	int rados_ioctx_snap_list(rados_ioctx_t io, rados_snap_t *snaps, int maxlen)
 func (ioctx *IOContext) ListSnaps() ([]SnapID, error) {
 	if err := ioctx.validate(); err != nil {
 		return nil, err
@@ -154,7 +159,8 @@ func (ioctx *IOContext) ListSnaps() ([]SnapID, error) {
 // The contents of the object will be the same as when the snapshot was taken.
 //
 // Implements:
-//  int rados_ioctx_snap_rollback(rados_ioctx_t io, const char *oid, const char *snapname);
+//
+//	int rados_ioctx_snap_rollback(rados_ioctx_t io, const char *oid, const char *snapname);
 func (ioctx *IOContext) RollbackSnap(oid, snapName string) error {
 	if err := ioctx.validate(); err != nil {
 		return err
@@ -178,7 +184,8 @@ const SnapHead = SnapID(C.LIBRADOS_SNAP_HEAD)
 // Pass SnapHead for no snapshot (i.e. normal operation).
 //
 // Implements:
-//  void rados_ioctx_snap_set_read(rados_ioctx_t io, rados_snap_t snap);
+//
+//	void rados_ioctx_snap_set_read(rados_ioctx_t io, rados_snap_t snap);
 func (ioctx *IOContext) SetReadSnap(snapID SnapID) error {
 	if err := ioctx.validate(); err != nil {
 		return err

--- a/rados/watcher.go
+++ b/rados/watcher.go
@@ -72,27 +72,28 @@ var (
 // the NotifyEvents and Errors() receives all occuring errors. A typical code
 // creating a Watcher could look like this:
 //
-//  watcher, err := ioctx.Watch(oid)
-//  go func() { // event handler
-//    for ne := range watcher.Events() {
-//      ...
-//      ne.Ack([]byte("response data..."))
-//      ...
-//    }
-//  }()
-//  go func() { // error handler
-//    for err := range watcher.Errors() {
-//      ... handle err ...
-//    }
-//  }()
+//	watcher, err := ioctx.Watch(oid)
+//	go func() { // event handler
+//	  for ne := range watcher.Events() {
+//	    ...
+//	    ne.Ack([]byte("response data..."))
+//	    ...
+//	  }
+//	}()
+//	go func() { // error handler
+//	  for err := range watcher.Errors() {
+//	    ... handle err ...
+//	  }
+//	}()
 //
 // CAUTION: the Watcher references the IOContext in which it has been created.
 // Therefore all watchers must be deleted with the Delete() method before the
 // IOContext is being destroyed.
 //
 // Implements:
-//  int rados_watch2(rados_ioctx_t io, const char* o, uint64_t* cookie,
-//    rados_watchcb2_t watchcb, rados_watcherrcb_t watcherrcb, void* arg)
+//
+//	int rados_watch2(rados_ioctx_t io, const char* o, uint64_t* cookie,
+//	  rados_watchcb2_t watchcb, rados_watcherrcb_t watcherrcb, void* arg)
 func (ioctx *IOContext) Watch(obj string) (*Watcher, error) {
 	return ioctx.WatchWithTimeout(obj, 0)
 }
@@ -101,9 +102,10 @@ func (ioctx *IOContext) Watch(obj string) (*Watcher, error) {
 // different timeout than the default can be specified.
 //
 // Implements:
-//  int rados_watch3(rados_ioctx_t io, const char *o, uint64_t *cookie,
-// 	  rados_watchcb2_t watchcb, rados_watcherrcb_t watcherrcb, uint32_t timeout,
-// 	  void *arg);
+//
+//	 int rados_watch3(rados_ioctx_t io, const char *o, uint64_t *cookie,
+//		  rados_watchcb2_t watchcb, rados_watcherrcb_t watcherrcb, uint32_t timeout,
+//		  void *arg);
 func (ioctx *IOContext) WatchWithTimeout(oid string, timeout time.Duration) (*Watcher, error) {
 	cObj := C.CString(oid)
 	defer C.free(unsafe.Pointer(cObj))
@@ -158,7 +160,8 @@ func (w *Watcher) Errors() <-chan error {
 // Watcher is no longer valid, and should be destroyed with the Delete() method.
 //
 // Implements:
-//  int rados_watch_check(rados_ioctx_t io, uint64_t cookie)
+//
+//	int rados_watch_check(rados_ioctx_t io, uint64_t cookie)
 func (w *Watcher) Check() (time.Duration, error) {
 	ret := C.rados_watch_check(w.ioctx.ioctx, C.uint64_t(w.id))
 	if ret < 0 {
@@ -170,7 +173,8 @@ func (w *Watcher) Check() (time.Duration, error) {
 // Delete the watcher. This closes both the event and error channel.
 //
 // Implements:
-//  int rados_unwatch2(rados_ioctx_t io, uint64_t cookie)
+//
+//	int rados_unwatch2(rados_ioctx_t io, uint64_t cookie)
 func (w *Watcher) Delete() error {
 	watchersMtx.Lock()
 	_, ok := watchers[w.id]
@@ -204,8 +208,9 @@ func (ioctx *IOContext) Notify(obj string, data []byte) ([]NotifyAck, []NotifyTi
 // default.
 //
 // Implements:
-//  int rados_notify2(rados_ioctx_t io, const char* o, const char* buf, int buf_len,
-//    uint64_t timeout_ms, char** reply_buffer, size_t* reply_buffer_len)
+//
+//	int rados_notify2(rados_ioctx_t io, const char* o, const char* buf, int buf_len,
+//	  uint64_t timeout_ms, char** reply_buffer, size_t* reply_buffer_len)
 func (ioctx *IOContext) NotifyWithTimeout(obj string, data []byte, timeout time.Duration) ([]NotifyAck,
 	[]NotifyTimeout, error) {
 	cObj := C.CString(obj)
@@ -236,8 +241,9 @@ func (ioctx *IOContext) NotifyWithTimeout(obj string, data []byte, timeout time.
 // blocks and eventiually times out.
 //
 // Implements:
-//  int rados_notify_ack(rados_ioctx_t io, const char *o, uint64_t notify_id,
-//    uint64_t cookie, const char *buf, int buf_len)
+//
+//	int rados_notify_ack(rados_ioctx_t io, const char *o, uint64_t notify_id,
+//	  uint64_t cookie, const char *buf, int buf_len)
 func (ne *NotifyEvent) Ack(response []byte) error {
 	watchersMtx.RLock()
 	w, ok := watchers[ne.WatcherID]
@@ -265,7 +271,8 @@ func (ne *NotifyEvent) Ack(response []byte) error {
 // WatcherFlush flushes all pending notifications of the cluster.
 //
 // Implements:
-//  int rados_watch_flush(rados_t cluster)
+//
+//	int rados_watch_flush(rados_t cluster)
 func (c *Conn) WatcherFlush() error {
 	if !c.connected {
 		return ErrNotConnected
@@ -275,18 +282,19 @@ func (c *Conn) WatcherFlush() error {
 }
 
 // decoder for this notify response format:
-//    le32 num_acks
-//    {
-//      le64 gid     global id for the client (for client.1234 that's 1234)
-//      le64 cookie  cookie for the client
-//      le32 buflen  length of reply message buffer
-//      u8 buflen  payload
-//    } num_acks
-//    le32 num_timeouts
-//    {
-//      le64 gid     global id for the client
-//      le64 cookie  cookie for the client
-//    } num_timeouts
+//
+//	le32 num_acks
+//	{
+//	  le64 gid     global id for the client (for client.1234 that's 1234)
+//	  le64 cookie  cookie for the client
+//	  le32 buflen  length of reply message buffer
+//	  u8 buflen  payload
+//	} num_acks
+//	le32 num_timeouts
+//	{
+//	  le64 gid     global id for the client
+//	  le64 cookie  cookie for the client
+//	} num_timeouts
 //
 // NOTE: starting with pacific this is implemented as a C function and this can
 // be replaced later

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -136,7 +136,8 @@ func (w *WriteOp) CleanOmap() {
 // AssertExists assures the object targeted by the write op exists.
 //
 // Implements:
-//  void rados_write_op_assert_exists(rados_write_op_t write_op);
+//
+//	void rados_write_op_assert_exists(rados_write_op_t write_op);
 func (w *WriteOp) AssertExists() {
 	C.rados_write_op_assert_exists(w.op)
 }
@@ -144,10 +145,11 @@ func (w *WriteOp) AssertExists() {
 // Write a given byte slice at the supplied offset.
 //
 // Implements:
-//  void rados_write_op_write(rados_write_op_t write_op,
-//                                       const char *buffer,
-//                                       size_t len,
-//                                       uint64_t offset);
+//
+//	void rados_write_op_write(rados_write_op_t write_op,
+//	                                     const char *buffer,
+//	                                     size_t len,
+//	                                     uint64_t offset);
 func (w *WriteOp) Write(b []byte, offset uint64) {
 	oe := newWriteStep(b, 0, offset)
 	w.steps = append(w.steps, oe)
@@ -162,9 +164,10 @@ func (w *WriteOp) Write(b []byte, offset uint64) {
 // atomically replacing it.
 //
 // Implements:
-//  void rados_write_op_write_full(rados_write_op_t write_op,
-//                                 const char *buffer,
-//                                 size_t len);
+//
+//	void rados_write_op_write_full(rados_write_op_t write_op,
+//	                               const char *buffer,
+//	                               size_t len);
 func (w *WriteOp) WriteFull(b []byte) {
 	oe := newWriteStep(b, 0, 0)
 	w.steps = append(w.steps, oe)
@@ -178,11 +181,12 @@ func (w *WriteOp) WriteFull(b []byte) {
 // writeLen is satisfied.
 //
 // Implements:
-//  void rados_write_op_writesame(rados_write_op_t write_op,
-//                                const char *buffer,
-//                                size_t data_len,
-//                                size_t write_len,
-//                                uint64_t offset);
+//
+//	void rados_write_op_writesame(rados_write_op_t write_op,
+//	                              const char *buffer,
+//	                              size_t data_len,
+//	                              size_t write_len,
+//	                              uint64_t offset);
 func (w *WriteOp) WriteSame(b []byte, writeLen, offset uint64) {
 	oe := newWriteStep(b, writeLen, offset)
 	w.steps = append(w.steps, oe)

--- a/rados/write_op_cmpext.go
+++ b/rados/write_op_cmpext.go
@@ -39,11 +39,12 @@ func newWriteOpCmpExtStep() *WriteOpCmpExtStep {
 // CmpExt ensures that given object range (extent) satisfies comparison.
 //
 // Implements:
-//  void rados_write_op_cmpext(rados_write_op_t write_op,
-//                             const char * cmp_buf,
-//                             size_t cmp_len,
-//                             uint64_t off,
-//                             int * prval);
+//
+//	void rados_write_op_cmpext(rados_write_op_t write_op,
+//	                           const char * cmp_buf,
+//	                           size_t cmp_len,
+//	                           uint64_t off,
+//	                           int * prval);
 func (w *WriteOp) CmpExt(b []byte, offset uint64) *WriteOpCmpExtStep {
 	oe := newWriteStep(b, 0, offset)
 	cmpExtStep := newWriteOpCmpExtStep()

--- a/rados/write_op_set_alloc_hint.go
+++ b/rados/write_op_set_alloc_hint.go
@@ -12,10 +12,11 @@ import "C"
 // the backend.
 //
 // Implements:
-//  void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,
-//                                      uint64_t expected_object_size,
-//                                      uint64_t expected_write_size,
-//                                      uint32_t flags);
+//
+//	void rados_write_op_set_alloc_hint2(rados_write_op_t write_op,
+//	                                    uint64_t expected_object_size,
+//	                                    uint64_t expected_write_size,
+//	                                    uint32_t flags);
 func (w *WriteOp) SetAllocationHint(expectedObjectSize uint64, expectedWriteSize uint64, flags AllocHintFlags) {
 	C.rados_write_op_set_alloc_hint2(
 		w.op,

--- a/rbd/admin/msschedule.go
+++ b/rbd/admin/msschedule.go
@@ -40,7 +40,8 @@ func (ra *RBDAdmin) MirrorSnashotSchedule() *MirrorSnashotScheduleAdmin {
 // level spec.
 //
 // Similar To:
-//  rbd mirror snapshot schedule add <level_spec> <interval> <start_time>
+//
+//	rbd mirror snapshot schedule add <level_spec> <interval> <start_time>
 func (mss *MirrorSnashotScheduleAdmin) Add(l LevelSpec, i Interval, s StartTime) error {
 	m := map[string]string{
 		"prefix":     "rbd mirror snapshot schedule add",
@@ -59,7 +60,8 @@ func (mss *MirrorSnashotScheduleAdmin) Add(l LevelSpec, i Interval, s StartTime)
 // List the snapshot schedules based on the supplied level spec.
 //
 // Similar To:
-//  rbd mirror snapshot schedule list <level_spec>
+//
+//	rbd mirror snapshot schedule list <level_spec>
 func (mss *MirrorSnashotScheduleAdmin) List(l LevelSpec) ([]SnapshotSchedule, error) {
 	m := map[string]string{
 		"prefix":     "rbd mirror snapshot schedule list",
@@ -114,7 +116,8 @@ func parseMirrorSnapshotScheduleList(res commands.Response) (
 // Remove a snapshot schedule matching the supplied arguments.
 //
 // Similar To:
-//  rbd mirror snapshot schedule remove <level_spec> <interval> <start_time>
+//
+//	rbd mirror snapshot schedule remove <level_spec> <interval> <start_time>
 func (mss *MirrorSnashotScheduleAdmin) Remove(
 	l LevelSpec, i Interval, s StartTime) error {
 
@@ -136,7 +139,8 @@ func (mss *MirrorSnashotScheduleAdmin) Remove(
 // matching the supplied level spec.
 //
 // Similar To:
-//  rbd mirror snapshot schedule status <level_spec>
+//
+//	rbd mirror snapshot schedule status <level_spec>
 func (mss *MirrorSnashotScheduleAdmin) Status(l LevelSpec) ([]ScheduledImage, error) {
 	m := map[string]string{
 		"prefix":     "rbd mirror snapshot schedule status",

--- a/rbd/admin/task.go
+++ b/rbd/admin/task.go
@@ -56,7 +56,8 @@ func parseTaskResponseList(res commands.Response) ([]TaskResponse, error) {
 // supplied image spec.
 //
 // Similar To:
-//  rbd task add flatten <image_spec>
+//
+//	rbd task add flatten <image_spec>
 func (ta *TaskAdmin) AddFlatten(img ImageSpec) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":     "rbd task add flatten",
@@ -70,7 +71,8 @@ func (ta *TaskAdmin) AddFlatten(img ImageSpec) (TaskResponse, error) {
 // image spec.
 //
 // Similar To:
-//  rbd task add remove <image_spec>
+//
+//	rbd task add remove <image_spec>
 func (ta *TaskAdmin) AddRemove(img ImageSpec) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":     "rbd task add remove",
@@ -84,7 +86,8 @@ func (ta *TaskAdmin) AddRemove(img ImageSpec) (TaskResponse, error) {
 // on the supplied image id spec.
 //
 // Similar To:
-//  rbd task add trash remove <image_id_spec>
+//
+//	rbd task add trash remove <image_id_spec>
 func (ta *TaskAdmin) AddTrashRemove(img ImageSpec) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":        "rbd task add trash remove",
@@ -97,7 +100,8 @@ func (ta *TaskAdmin) AddTrashRemove(img ImageSpec) (TaskResponse, error) {
 // List pending or running asynchronous tasks.
 //
 // Similar To:
-//  rbd task list
+//
+//	rbd task list
 func (ta *TaskAdmin) List() ([]TaskResponse, error) {
 	m := map[string]string{
 		"prefix": "rbd task list",
@@ -109,7 +113,8 @@ func (ta *TaskAdmin) List() ([]TaskResponse, error) {
 // GetTaskByID returns pending or running asynchronous task using id.
 //
 // Similar To:
-//  rbd task list <task_id>
+//
+//	rbd task list <task_id>
 func (ta *TaskAdmin) GetTaskByID(taskID string) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":  "rbd task list",
@@ -122,7 +127,8 @@ func (ta *TaskAdmin) GetTaskByID(taskID string) (TaskResponse, error) {
 // Cancel a pending or running asynchronous task.
 //
 // Similar To:
-//  rbd task cancel <task_id>
+//
+//	rbd task cancel <task_id>
 func (ta *TaskAdmin) Cancel(taskID string) (TaskResponse, error) {
 	m := map[string]string{
 		"prefix":  "rbd task cancel",

--- a/rbd/diff_iterate.go
+++ b/rbd/diff_iterate.go
@@ -84,12 +84,13 @@ const (
 // arguments to the callback and the return behavior.
 //
 // Implements:
-//  int rbd_diff_iterate2(rbd_image_t image,
-//                        const char *fromsnapname,
-//                        uint64_t ofs, uint64_t len,
-//                        uint8_t include_parent, uint8_t whole_object,
-//                        int (*cb)(uint64_t, size_t, int, void *),
-//                        void *arg);
+//
+//	int rbd_diff_iterate2(rbd_image_t image,
+//	                      const char *fromsnapname,
+//	                      uint64_t ofs, uint64_t len,
+//	                      uint8_t include_parent, uint8_t whole_object,
+//	                      int (*cb)(uint64_t, size_t, int, void *),
+//	                      void *arg);
 func (image *Image) DiffIterate(config DiffIterateConfig) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err

--- a/rbd/encryption.go
+++ b/rbd/encryption.go
@@ -91,10 +91,11 @@ func (opts EncryptionOptionsLUKS2) allocateEncryptionOptions() cEncryptionData {
 // EncryptionFormat creates an encryption format header
 //
 // Implements:
-//  int rbd_encryption_format(rbd_image_t image,
-//                            rbd_encryption_format_t format,
-//                            rbd_encryption_options_t opts,
-//                            size_t opts_size);
+//
+//	int rbd_encryption_format(rbd_image_t image,
+//	                          rbd_encryption_format_t format,
+//	                          rbd_encryption_options_t opts,
+//	                          size_t opts_size);
 //
 // To issue an IO against the image, you need to mount the image
 // with libvirt/qemu using the LUKS format, or make a call to
@@ -119,10 +120,11 @@ func (image *Image) EncryptionFormat(opts EncryptionOptions) error {
 // EncryptionLoad enables IO on an open encrypted image
 //
 // Implements:
-//  int rbd_encryption_load(rbd_image_t image,
-//                          rbd_encryption_format_t format,
-//                          rbd_encryption_options_t opts,
-//                          size_t opts_size);
+//
+//	int rbd_encryption_load(rbd_image_t image,
+//	                        rbd_encryption_format_t format,
+//	                        rbd_encryption_options_t opts,
+//	                        size_t opts_size);
 func (image *Image) EncryptionLoad(opts EncryptionOptions) error {
 	if image.image == nil {
 		return ErrImageNotOpen

--- a/rbd/features.go
+++ b/rbd/features.go
@@ -154,7 +154,8 @@ func (fs *FeatureSet) Names() []string {
 // GetFeatures returns the features bitmask for the rbd image.
 //
 // Implements:
-//  int rbd_get_features(rbd_image_t image, uint64_t *features);
+//
+//	int rbd_get_features(rbd_image_t image, uint64_t *features);
 func (image *Image) GetFeatures() (features uint64, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -170,8 +171,9 @@ func (image *Image) GetFeatures() (features uint64, err error) {
 // UpdateFeatures updates the features on the Image.
 //
 // Implements:
-//   int rbd_update_features(rbd_image_t image, uint64_t features,
-//                           uint8_t enabled);
+//
+//	int rbd_update_features(rbd_image_t image, uint64_t features,
+//	                        uint8_t enabled);
 func (image *Image) UpdateFeatures(features uint64, enabled bool) error {
 	if image.image == nil {
 		return RbdErrorImageNotOpen

--- a/rbd/group.go
+++ b/rbd/group.go
@@ -18,7 +18,8 @@ import (
 // GroupCreate is used to create an image group.
 //
 // Implements:
-//  int rbd_group_create(rados_ioctx_t p, const char *name);
+//
+//	int rbd_group_create(rados_ioctx_t p, const char *name);
 func GroupCreate(ioctx *rados.IOContext, name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -30,7 +31,8 @@ func GroupCreate(ioctx *rados.IOContext, name string) error {
 // GroupRemove is used to remove an image group.
 //
 // Implements:
-//  int rbd_group_remove(rados_ioctx_t p, const char *name);
+//
+//	int rbd_group_remove(rados_ioctx_t p, const char *name);
 func GroupRemove(ioctx *rados.IOContext, name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -42,8 +44,9 @@ func GroupRemove(ioctx *rados.IOContext, name string) error {
 // GroupRename will rename an existing image group.
 //
 // Implements:
-//  int rbd_group_rename(rados_ioctx_t p, const char *src_name,
-//                       const char *dest_name);
+//
+//	int rbd_group_rename(rados_ioctx_t p, const char *src_name,
+//	                     const char *dest_name);
 func GroupRename(ioctx *rados.IOContext, src, dest string) error {
 	cSrc := C.CString(src)
 	defer C.free(unsafe.Pointer(cSrc))
@@ -57,7 +60,8 @@ func GroupRename(ioctx *rados.IOContext, src, dest string) error {
 // GroupList returns a slice of image group names.
 //
 // Implements:
-//  int rbd_group_list(rados_ioctx_t p, char *names, size_t *size);
+//
+//	int rbd_group_list(rados_ioctx_t p, char *names, size_t *size);
 func GroupList(ioctx *rados.IOContext) ([]string, error) {
 	var (
 		buf []byte
@@ -89,10 +93,11 @@ func GroupList(ioctx *rados.IOContext) ([]string, error) {
 // An io context must be supplied for both the group and image.
 //
 // Implements:
-//  int rbd_group_image_add(rados_ioctx_t group_p,
-//                          const char *group_name,
-//                          rados_ioctx_t image_p,
-//                          const char *image_name);
+//
+//	int rbd_group_image_add(rados_ioctx_t group_p,
+//	                        const char *group_name,
+//	                        rados_ioctx_t image_p,
+//	                        const char *image_name);
 func GroupImageAdd(groupIoctx *rados.IOContext, groupName string,
 	imageIoctx *rados.IOContext, imageName string) error {
 
@@ -113,10 +118,11 @@ func GroupImageAdd(groupIoctx *rados.IOContext, groupName string,
 // An io context must be supplied for both the group and image.
 //
 // Implements:
-//  int rbd_group_image_remove(rados_ioctx_t group_p,
-//                             const char *group_name,
-//                             rados_ioctx_t image_p,
-//                             const char *image_name);
+//
+//	int rbd_group_image_remove(rados_ioctx_t group_p,
+//	                           const char *group_name,
+//	                           rados_ioctx_t image_p,
+//	                           const char *image_name);
 func GroupImageRemove(groupIoctx *rados.IOContext, groupName string,
 	imageIoctx *rados.IOContext, imageName string) error {
 
@@ -137,10 +143,11 @@ func GroupImageRemove(groupIoctx *rados.IOContext, groupName string,
 // An io context must be supplied for both the group and image.
 //
 // Implements:
-//  CEPH_RBD_API int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
-//                                               const char *group_name,
-//                                               rados_ioctx_t image_p,
-//                                               const char *image_id);
+//
+//	CEPH_RBD_API int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
+//	                                             const char *group_name,
+//	                                             rados_ioctx_t image_p,
+//	                                             const char *image_id);
 func GroupImageRemoveByID(groupIoctx *rados.IOContext, groupName string,
 	imageIoctx *rados.IOContext, imageID string) error {
 
@@ -178,11 +185,12 @@ type GroupImageInfo struct {
 // images that are part of the named group.
 //
 // Implements:
-//  int rbd_group_image_list(rados_ioctx_t group_p,
-//                           const char *group_name,
-//                           rbd_group_image_info_t *images,
-//                           size_t group_image_info_size,
-//                           size_t *num_entries);
+//
+//	int rbd_group_image_list(rados_ioctx_t group_p,
+//	                         const char *group_name,
+//	                         rbd_group_image_info_t *images,
+//	                         size_t group_image_info_size,
+//	                         size_t *num_entries);
 func GroupImageList(ioctx *rados.IOContext, name string) ([]GroupImageInfo, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -233,8 +241,9 @@ type GroupInfo struct {
 // GetGroup returns group info for the group this image is part of.
 //
 // Implements:
-//  int rbd_get_group(rbd_image_t image, rbd_group_info_t *group_info,
-//                    size_t group_info_size);
+//
+//	int rbd_get_group(rbd_image_t image, rbd_group_info_t *group_info,
+//	                  size_t group_info_size);
 func (image *Image) GetGroup() (GroupInfo, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return GroupInfo{}, err

--- a/rbd/group_snap.go
+++ b/rbd/group_snap.go
@@ -29,9 +29,10 @@ import (
 // GroupSnapCreate will create a group snapshot.
 //
 // Implements:
-//  int rbd_group_snap_create(rados_ioctx_t group_p,
-//                            const char *group_name,
-//                            const char *snap_name);
+//
+//	int rbd_group_snap_create(rados_ioctx_t group_p,
+//	                          const char *group_name,
+//	                          const char *snap_name);
 func GroupSnapCreate(ioctx *rados.IOContext, group, snap string) error {
 	cGroupName := C.CString(group)
 	defer C.free(unsafe.Pointer(cGroupName))
@@ -45,9 +46,10 @@ func GroupSnapCreate(ioctx *rados.IOContext, group, snap string) error {
 // GroupSnapRemove removes an existing group snapshot.
 //
 // Implements:
-//  int rbd_group_snap_remove(rados_ioctx_t group_p,
-//                            const char *group_name,
-//                            const char *snap_name);
+//
+//	int rbd_group_snap_remove(rados_ioctx_t group_p,
+//	                          const char *group_name,
+//	                          const char *snap_name);
 func GroupSnapRemove(ioctx *rados.IOContext, group, snap string) error {
 	cGroupName := C.CString(group)
 	defer C.free(unsafe.Pointer(cGroupName))
@@ -61,10 +63,11 @@ func GroupSnapRemove(ioctx *rados.IOContext, group, snap string) error {
 // GroupSnapRename will rename an existing group snapshot.
 //
 // Implements:
-//  int rbd_group_snap_rename(rados_ioctx_t group_p,
-//                            const char *group_name,
-//                            const char *old_snap_name,
-//                            const char *new_snap_name);
+//
+//	int rbd_group_snap_rename(rados_ioctx_t group_p,
+//	                          const char *group_name,
+//	                          const char *old_snap_name,
+//	                          const char *new_snap_name);
 func GroupSnapRename(ioctx *rados.IOContext, group, src, dest string) error {
 	cGroupName := C.CString(group)
 	defer C.free(unsafe.Pointer(cGroupName))
@@ -98,11 +101,12 @@ type GroupSnapInfo struct {
 // GroupSnapList returns a slice of snapshots in a group.
 //
 // Implements:
-//  int rbd_group_snap_list(rados_ioctx_t group_p,
-//                          const char *group_name,
-//                          rbd_group_snap_info_t *snaps,
-//                          size_t group_snap_info_size,
-//                          size_t *num_entries);
+//
+//	int rbd_group_snap_list(rados_ioctx_t group_p,
+//	                        const char *group_name,
+//	                        rbd_group_snap_info_t *snaps,
+//	                        size_t group_snap_info_size,
+//	                        size_t *num_entries);
 func GroupSnapList(ioctx *rados.IOContext, group string) ([]GroupSnapInfo, error) {
 	cGroupName := C.CString(group)
 	defer C.free(unsafe.Pointer(cGroupName))
@@ -147,9 +151,10 @@ func GroupSnapList(ioctx *rados.IOContext, group string) ([]GroupSnapInfo, error
 // given snapshot.
 //
 // Implements:
-//  int rbd_group_snap_rollback(rados_ioctx_t group_p,
-//                              const char *group_name,
-//                              const char *snap_name);
+//
+//	int rbd_group_snap_rollback(rados_ioctx_t group_p,
+//	                            const char *group_name,
+//	                            const char *snap_name);
 func GroupSnapRollback(ioctx *rados.IOContext, group, snap string) error {
 	cGroupName := C.CString(group)
 	defer C.free(unsafe.Pointer(cGroupName))
@@ -174,11 +179,12 @@ var groupSnapRollbackCallbacks = callbacks.New()
 // to report on the progress of the snapshot rollback.
 //
 // Implements:
-//  int rbd_group_snap_rollback_with_progress(rados_ioctx_t group_p,
-//                                            const char *group_name,
-//                                            const char *snap_name,
-//                                            librbd_progress_fn_t cb,
-//                                            void *cbdata);
+//
+//	int rbd_group_snap_rollback_with_progress(rados_ioctx_t group_p,
+//	                                          const char *group_name,
+//	                                          const char *snap_name,
+//	                                          librbd_progress_fn_t cb,
+//	                                          void *cbdata);
 func GroupSnapRollbackWithProgress(
 	ioctx *rados.IOContext, group, snap string,
 	cb GroupSnapRollbackCallback, data interface{}) error {

--- a/rbd/metadata.go
+++ b/rbd/metadata.go
@@ -15,7 +15,8 @@ import (
 // GetMetadata returns the metadata string associated with the given key.
 //
 // Implements:
-//  int rbd_metadata_get(rbd_image_t image, const char *key, char *value, size_t *vallen)
+//
+//	int rbd_metadata_get(rbd_image_t image, const char *key, char *value, size_t *vallen)
 func (image *Image) GetMetadata(key string) (string, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return "", err
@@ -47,7 +48,8 @@ func (image *Image) GetMetadata(key string) (string, error) {
 // SetMetadata updates the metadata string associated with the given key.
 //
 // Implements:
-//  int rbd_metadata_set(rbd_image_t image, const char *key, const char *value)
+//
+//	int rbd_metadata_set(rbd_image_t image, const char *key, const char *value)
 func (image *Image) SetMetadata(key string, value string) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -69,7 +71,8 @@ func (image *Image) SetMetadata(key string, value string) error {
 // RemoveMetadata clears the metadata associated with the given key.
 //
 // Implements:
-//  int rbd_metadata_remove(rbd_image_t image, const char *key)
+//
+//	int rbd_metadata_remove(rbd_image_t image, const char *key)
 func (image *Image) RemoveMetadata(key string) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -89,8 +92,9 @@ func (image *Image) RemoveMetadata(key string) error {
 // ListMetadata returns a map containing all metadata assigned to the RBD image.
 //
 // Implements:
-//  int rbd_metadata_list(rbd_image_t image, const char *start, uint64_t max,
-//                        char *keys, size_t *key_len, char *values, size_t *vals_len);
+//
+//	int rbd_metadata_list(rbd_image_t image, const char *start, uint64_t max,
+//	                      char *keys, size_t *key_len, char *values, size_t *vals_len);
 func (image *Image) ListMetadata() (map[string]string, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err

--- a/rbd/migration.go
+++ b/rbd/migration.go
@@ -62,12 +62,12 @@ type MigrationImageStatus struct {
 // to source and making source read-only.
 //
 // Implements:
-//  int rbd_migration_prepare(rados_ioctx_t ioctx,
-//                            const char *image_name,
-//                            rados_ioctx_t dest_ioctx,
-//                            const char *dest_image_name,
-//                            rbd_image_options_t opts);
 //
+//	int rbd_migration_prepare(rados_ioctx_t ioctx,
+//	                          const char *image_name,
+//	                          rados_ioctx_t dest_ioctx,
+//	                          const char *dest_image_name,
+//	                          rbd_image_options_t opts);
 func MigrationPrepare(ioctx *rados.IOContext, sourceImageName string, destIoctx *rados.IOContext, destImageName string, rio *ImageOptions) error {
 	cSourceImageName := C.CString(sourceImageName)
 	cDestImageName := C.CString(destImageName)
@@ -90,11 +90,11 @@ func MigrationPrepare(ioctx *rados.IOContext, sourceImageName string, destIoctx 
 // from a specified source to a new target image.
 //
 // Implements:
-//  int rbd_migration_prepare_import(const char *source_spec,
-//                                   rados_ioctx_t dest_ioctx,
-//                                   const char *dest_image_name,
-//                                   rbd_image_options_t opts);
 //
+//	int rbd_migration_prepare_import(const char *source_spec,
+//	                                 rados_ioctx_t dest_ioctx,
+//	                                 const char *dest_image_name,
+//	                                 rbd_image_options_t opts);
 func MigrationPrepareImport(sourceSpec string, ioctx *rados.IOContext, destImageName string, rio *ImageOptions) error {
 	cSourceSpec := C.CString(sourceSpec)
 	cDestImageName := C.CString(destImageName)
@@ -116,9 +116,9 @@ func MigrationPrepareImport(sourceSpec string, ioctx *rados.IOContext, destImage
 // from the source image to the target image.
 //
 // Implements:
-//  int rbd_migration_execute(rados_ioctx_t ioctx,
-//                            const char *image_name);
 //
+//	int rbd_migration_execute(rados_ioctx_t ioctx,
+//	                          const char *image_name);
 func MigrationExecute(ioctx *rados.IOContext, name string) error {
 	cName := C.CString(name)
 
@@ -136,9 +136,9 @@ func MigrationExecute(ioctx *rados.IOContext, name string) error {
 // breaking the relationship of image to the source.
 //
 // Implements:
-//  int rbd_migration_commit(rados_ioctx_t ioctx,
-//                           const char *image_name);
 //
+//	int rbd_migration_commit(rados_ioctx_t ioctx,
+//	                         const char *image_name);
 func MigrationCommit(ioctx *rados.IOContext, name string) error {
 	cName := C.CString(name)
 
@@ -156,9 +156,9 @@ func MigrationCommit(ioctx *rados.IOContext, name string) error {
 // breaking the relationship of image to the source.
 //
 // Implements:
-//  int rbd_migration_abort(rados_ioctx_t ioctx,
-//                          const char *image_name);
 //
+//	int rbd_migration_abort(rados_ioctx_t ioctx,
+//	                        const char *image_name);
 func MigrationAbort(ioctx *rados.IOContext, name string) error {
 	cName := C.CString(name)
 
@@ -176,11 +176,11 @@ func MigrationAbort(ioctx *rados.IOContext, name string) error {
 // for the specified image.
 //
 // Implements:
-//  int rbd_migration_status(rados_ioctx_t ioctx,
-//                           const char *image_name,
-//                           rbd_image_migration_status_t *status,
-//                           size_t status_size);
 //
+//	int rbd_migration_status(rados_ioctx_t ioctx,
+//	                         const char *image_name,
+//	                         rbd_image_migration_status_t *status,
+//	                         size_t status_size);
 func MigrationStatus(ioctx *rados.IOContext, name string) (*MigrationImageStatus, error) {
 	cName := C.CString(name)
 

--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -81,8 +81,9 @@ func (imm ImageMirrorMode) String() string {
 // associated with the ioctx.
 //
 // Implements:
-//  int rbd_mirror_uuid_get(rados_ioctx_t io_ctx, char *uuid, size_t
-//                          *max_len);
+//
+//	int rbd_mirror_uuid_get(rados_ioctx_t io_ctx, char *uuid, size_t
+//	                        *max_len);
 func GetMirrorUUID(ioctx *rados.IOContext) (string, error) {
 	var (
 		err   error
@@ -109,8 +110,9 @@ func GetMirrorUUID(ioctx *rados.IOContext) (string, error) {
 // an automatic or per-image behavior.
 //
 // Implements:
-//  int rbd_mirror_mode_set(rados_ioctx_t io_ctx,
-//                          rbd_mirror_mode_t mirror_mode);
+//
+//	int rbd_mirror_mode_set(rados_ioctx_t io_ctx,
+//	                        rbd_mirror_mode_t mirror_mode);
 func SetMirrorMode(ioctx *rados.IOContext, mode MirrorMode) error {
 	ret := C.rbd_mirror_mode_set(
 		cephIoctx(ioctx),
@@ -121,8 +123,9 @@ func SetMirrorMode(ioctx *rados.IOContext, mode MirrorMode) error {
 // GetMirrorMode is used to fetch the current mirroring mode for a pool.
 //
 // Implements:
-//  int rbd_mirror_mode_get(rados_ioctx_t io_ctx,
-//                          rbd_mirror_mode_t *mirror_mode);
+//
+//	int rbd_mirror_mode_get(rados_ioctx_t io_ctx,
+//	                        rbd_mirror_mode_t *mirror_mode);
 func GetMirrorMode(ioctx *rados.IOContext) (MirrorMode, error) {
 	var mode C.rbd_mirror_mode_t
 
@@ -138,8 +141,9 @@ func GetMirrorMode(ioctx *rados.IOContext) (MirrorMode, error) {
 // MirrorEnable will enable mirroring for an image using the specified mode.
 //
 // Implements:
-//  int rbd_mirror_image_enable2(rbd_image_t image,
-//                               rbd_mirror_image_mode_t mode);
+//
+//	int rbd_mirror_image_enable2(rbd_image_t image,
+//	                             rbd_mirror_image_mode_t mode);
 func (image *Image) MirrorEnable(mode ImageMirrorMode) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -151,7 +155,8 @@ func (image *Image) MirrorEnable(mode ImageMirrorMode) error {
 // MirrorDisable will disable mirroring for the image.
 //
 // Implements:
-//  int rbd_mirror_image_disable(rbd_image_t image, bool force);
+//
+//	int rbd_mirror_image_disable(rbd_image_t image, bool force);
 func (image *Image) MirrorDisable(force bool) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -163,7 +168,8 @@ func (image *Image) MirrorDisable(force bool) error {
 // MirrorPromote will promote the image to primary status.
 //
 // Implements:
-//  int rbd_mirror_image_promote(rbd_image_t image, bool force);
+//
+//	int rbd_mirror_image_promote(rbd_image_t image, bool force);
 func (image *Image) MirrorPromote(force bool) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -175,7 +181,8 @@ func (image *Image) MirrorPromote(force bool) error {
 // MirrorDemote will demote the image to secondary status.
 //
 // Implements:
-//  int rbd_mirror_image_demote(rbd_image_t image);
+//
+//	int rbd_mirror_image_demote(rbd_image_t image);
 func (image *Image) MirrorDemote() error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -188,7 +195,8 @@ func (image *Image) MirrorDemote() error {
 // resynchronization.
 //
 // Implements:
-//  int rbd_mirror_image_resync(rbd_image_t image);
+//
+//	int rbd_mirror_image_resync(rbd_image_t image);
 func (image *Image) MirrorResync() error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -200,9 +208,10 @@ func (image *Image) MirrorResync() error {
 // MirrorInstanceID returns a string naming the instance id for the image.
 //
 // Implements:
-//  int rbd_mirror_image_get_instance_id(rbd_image_t image,
-//                                       char *instance_id,
-//                                       size_t *id_max_length);
+//
+//	int rbd_mirror_image_get_instance_id(rbd_image_t image,
+//	                                     char *instance_id,
+//	                                     size_t *id_max_length);
 func (image *Image) MirrorInstanceID() (string, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return "", err
@@ -275,9 +284,10 @@ func convertMirrorImageInfo(cInfo *C.rbd_mirror_image_info_t) MirrorImageInfo {
 // GetMirrorImageInfo fetches the mirroring status information of a RBD image.
 //
 // Implements:
-//  int rbd_mirror_image_get_info(rbd_image_t image,
-//                                rbd_mirror_image_info_t *mirror_image_info,
-//                                size_t info_size)
+//
+//	int rbd_mirror_image_get_info(rbd_image_t image,
+//	                              rbd_mirror_image_info_t *mirror_image_info,
+//	                              size_t info_size)
 func (image *Image) GetMirrorImageInfo() (*MirrorImageInfo, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err
@@ -303,7 +313,8 @@ func (image *Image) GetMirrorImageInfo() (*MirrorImageInfo, error) {
 // GetImageMirrorMode fetches the mirroring approach for an RBD image.
 //
 // Implements:
-//  int rbd_mirror_image_get_mode(rbd_image_t image, rbd_mirror_image_mode_t *mode);
+//
+//	int rbd_mirror_image_get_mode(rbd_image_t image, rbd_mirror_image_mode_t *mode);
 func (image *Image) GetImageMirrorMode() (ImageMirrorMode, error) {
 	var mode C.rbd_mirror_image_mode_t
 	if err := image.validate(imageIsOpen); err != nil {
@@ -404,10 +415,11 @@ type siteArray [cutil.MaxIdx]C.rbd_mirror_image_site_status_t
 // of the images's mirroring.
 //
 // Implements:
-//   int rbd_mirror_image_get_global_status(
-//     rbd_image_t image,
-//     rbd_mirror_image_global_status_t *mirror_image_global_status,
-//     size_t status_size);
+//
+//	int rbd_mirror_image_get_global_status(
+//	  rbd_image_t image,
+//	  rbd_mirror_image_global_status_t *mirror_image_global_status,
+//	  size_t status_size);
 func (image *Image) GetGlobalMirrorStatus() (GlobalMirrorImageStatus, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return GlobalMirrorImageStatus{}, err
@@ -453,8 +465,9 @@ func newGlobalMirrorImageStatus(
 // CreateMirrorSnapshot creates a snapshot for image propagation to mirrors.
 //
 // Implements:
-//  int rbd_mirror_image_create_snapshot(rbd_image_t image,
-//                                       uint64_t *snap_id);
+//
+//	int rbd_mirror_image_create_snapshot(rbd_image_t image,
+//	                                     uint64_t *snap_id);
 func (image *Image) CreateMirrorSnapshot() (uint64, error) {
 	var snapID C.uint64_t
 	ret := C.rbd_mirror_image_create_snapshot(
@@ -467,9 +480,10 @@ func (image *Image) CreateMirrorSnapshot() (uint64, error) {
 // of images with said status.
 //
 // Implements:
-//  int rbd_mirror_image_status_summary(
-//    rados_ioctx_t io_ctx, rbd_mirror_image_status_state_t *states, int *counts,
-//    size_t *maxlen);
+//
+//	int rbd_mirror_image_status_summary(
+//	  rados_ioctx_t io_ctx, rbd_mirror_image_status_state_t *states, int *counts,
+//	  size_t *maxlen);
 func MirrorImageStatusSummary(
 	ioctx *rados.IOContext) (map[MirrorImageStatusState]uint, error) {
 	// ideally, we already know the size of the arrays - they should be
@@ -513,8 +527,9 @@ func MirrorImageStatusSummary(
 // cluster associated with the provided rados connection.
 //
 // Implements:
-//  int rbd_mirror_site_name_set(rados_t cluster,
-//                               const char *name);
+//
+//	int rbd_mirror_site_name_set(rados_t cluster,
+//	                             const char *name);
 func SetMirrorSiteName(conn *rados.Conn, name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -530,7 +545,8 @@ func SetMirrorSiteName(conn *rados.Conn, name string) error {
 //
 // Implements:
 // int rbd_mirror_site_name_get(rados_t cluster,
-//                              char *name, size_t *max_len);
+//
+//	char *name, size_t *max_len);
 func GetMirrorSiteName(conn *rados.Conn) (string, error) {
 
 	var (
@@ -562,8 +578,9 @@ func GetMirrorSiteName(conn *rados.Conn) (string, error) {
 // pools.
 //
 // Implements:
-//  int rbd_mirror_peer_bootstrap_create(
-//    rados_ioctx_t io_ctx, char *token, size_t *max_len);
+//
+//	int rbd_mirror_peer_bootstrap_create(
+//	  rados_ioctx_t io_ctx, char *token, size_t *max_len);
 func CreateMirrorPeerBootstrapToken(ioctx *rados.IOContext) (string, error) {
 	var (
 		cioctx = cephIoctx(ioctx)
@@ -606,9 +623,10 @@ const (
 // source, destination, or both.
 //
 // Implements:
-//  int rbd_mirror_peer_bootstrap_import(
-//    rados_ioctx_t io_ctx, rbd_mirror_peer_direction_t direction,
-//    const char *token);
+//
+//	int rbd_mirror_peer_bootstrap_import(
+//	  rados_ioctx_t io_ctx, rbd_mirror_peer_direction_t direction,
+//	  const char *token);
 func ImportMirrorPeerBootstrapToken(
 	ioctx *rados.IOContext, direction MirrorPeerDirection, token string) error {
 	// instead of taking a length, rbd_mirror_peer_bootstrap_import assumes a
@@ -644,8 +662,9 @@ var iterBufSize = 64
 //
 // Implements:
 // int rbd_mirror_image_status_list(rados_ioctx_t p,
-//     const char *start_id, size_t max, char **image_ids,
-//     rbd_mirror_image_status_t *images, size_t *len)
+//
+//	const char *start_id, size_t max, char **image_ids,
+//	rbd_mirror_image_status_t *images, size_t *len)
 func MirrorImageGlobalStatusList(
 	ioctx *rados.IOContext, start string, max int) ([]GlobalMirrorImageIDAndStatus, error) {
 	var (
@@ -781,10 +800,11 @@ type MirrorImageInfoItem struct {
 //
 // Implements:
 // int rbd_mirror_image_info_list(
-//     rados_ioctx_t p, rbd_mirror_image_mode_t *mode_filter,
-//     const char *start_id, size_t max, char **image_ids,
-//     rbd_mirror_image_mode_t *mode_entries,
-//     rbd_mirror_image_info_t *info_entries, size_t *num_entries)
+//
+//	rados_ioctx_t p, rbd_mirror_image_mode_t *mode_filter,
+//	const char *start_id, size_t max, char **image_ids,
+//	rbd_mirror_image_mode_t *mode_entries,
+//	rbd_mirror_image_info_t *info_entries, size_t *num_entries)
 func MirrorImageInfoList(
 	ioctx *rados.IOContext, modeFilter ImageMirrorModeFilter, start string,
 	max int) ([]MirrorImageInfoItem, error) {
@@ -921,11 +941,12 @@ type MirrorImageInstanceIDItem struct {
 //
 // Implements:
 // int rbd_mirror_image_instance_id_list(
-// 	 	rados_ioctx_t io_ctx,
-// 	 	const char *start_id,
-// 	 	size_t max, char **image_ids,
-// 	 	char **instance_ids,
-// 	 	size_t *len)
+//
+//	rados_ioctx_t io_ctx,
+//	const char *start_id,
+//	size_t max, char **image_ids,
+//	char **instance_ids,
+//	size_t *len)
 func MirrorImageInstanceIDList(
 	ioctx *rados.IOContext, start string,
 	max int) ([]MirrorImageInstanceIDItem, error) {

--- a/rbd/mirror_nautilus.go
+++ b/rbd/mirror_nautilus.go
@@ -35,7 +35,8 @@ const (
 // tag.
 //
 // Implements:
-//  int rbd_mirror_mode_get(rados_ioctx_t p, rbd_mirror_mode_t *mirror_mode)
+//
+//	int rbd_mirror_mode_get(rados_ioctx_t p, rbd_mirror_mode_t *mirror_mode)
 func MirrorModeGet(ioctx *rados.IOContext) (MirrorMode, error) {
 	var rmm C.rbd_mirror_mode_t
 
@@ -53,7 +54,8 @@ func MirrorModeGet(ioctx *rados.IOContext) (MirrorMode, error) {
 // tag.
 //
 // Implements:
-//  rbd_mirror_mode_set(rados_ioctx_t p, rbd_mirror_mode_t mirror_mode)
+//
+//	rbd_mirror_mode_set(rados_ioctx_t p, rbd_mirror_mode_t mirror_mode)
 func MirrorModeSet(ioctx *rados.IOContext, mode MirrorMode) error {
 	cMode := C.rbd_mirror_mode_t(mode)
 
@@ -70,10 +72,11 @@ func MirrorModeSet(ioctx *rados.IOContext, mode MirrorMode) error {
 // tag.
 //
 // Implements:
-//  int rbd_mirror_peer_add(rados_ioctx_t p, char *uuid,
-//  												size_t uuid_max_length,
-// 													const char *cluster_name,
-//													const char *client_name)
+//
+//	 int rbd_mirror_peer_add(rados_ioctx_t p, char *uuid,
+//	 												size_t uuid_max_length,
+//														const char *cluster_name,
+//														const char *client_name)
 func MirrorPeerAdd(ioctx *rados.IOContext, clusterName, clientName string) (string, error) {
 	// librbd uses 36-byte UUIDs with a trailing null. rbd_mirror_add_peer will
 	// return -E2BIG if we pass a UUID buffer smaller than 37 bytes.
@@ -98,7 +101,8 @@ func MirrorPeerAdd(ioctx *rados.IOContext, clusterName, clientName string) (stri
 // tag.
 //
 // Implements:
-//  int rbd_mirror_peer_remove(rados_ioctx_t io_ctx, const char *uuid)
+//
+//	int rbd_mirror_peer_remove(rados_ioctx_t io_ctx, const char *uuid)
 func MirrorPeerRemove(ioctx *rados.IOContext, uuid string) error {
 	cUUID := C.CString(uuid)
 	defer C.free(unsafe.Pointer(cUUID))
@@ -121,9 +125,10 @@ type MirrorPeerInfo struct {
 // tag.
 //
 // Implements:
-//  int rbd_mirror_peer_list(rados_ioctx_t io_ctx,
-//  												 rbd_mirror_peer_list_t *peers,
-// 										 			 int *max_peers);
+//
+//	 int rbd_mirror_peer_list(rados_ioctx_t io_ctx,
+//	 												 rbd_mirror_peer_list_t *peers,
+//											 			 int *max_peers);
 func MirrorPeerList(ioctx *rados.IOContext) ([]*MirrorPeerInfo, error) {
 	var mpi []*MirrorPeerInfo
 	cMaxPeers := C.int(5)
@@ -218,9 +223,10 @@ type MirrorImageInfo struct {
 // tag.
 //
 // Implements:
-//  rbd_mirror_image_get_info(rbd_image_t image,
-//                            rbd_mirror_image_info_t *mirror_image_info,
-//                            size_t info_size)
+//
+//	rbd_mirror_image_get_info(rbd_image_t image,
+//	                          rbd_mirror_image_info_t *mirror_image_info,
+//	                          size_t info_size)
 func (image *Image) MirrorGetImage() (*MirrorImageInfo, error) {
 	err := image.validate(imageIsOpen)
 	if err != nil {
@@ -250,11 +256,12 @@ func (image *Image) MirrorGetImage() (*MirrorImageInfo, error) {
 // tag.
 //
 // Implements:
-//  int rbd_mirror_image_status_list(rados_ioctx_t io_ctx,
-//  				      									 const char *start_id, size_t max,
-//  				      									 char **image_ids,
-//  				      									 rbd_mirror_image_status_t *images,
-//  				      									 size_t *len)
+//
+//	int rbd_mirror_image_status_list(rados_ioctx_t io_ctx,
+//					      									 const char *start_id, size_t max,
+//					      									 char **image_ids,
+//					      									 rbd_mirror_image_status_t *images,
+//					      									 size_t *len)
 func MirrorImageList(ioctx *rados.IOContext) ([]*MirrorImageInfo, error) {
 	imageInfos := make([]*MirrorImageInfo, 0)
 	const cMaxIter C.size_t = 100
@@ -327,7 +334,8 @@ func iterateImageList(ioctx *rados.IOContext, imageInfos *[]*MirrorImageInfo, st
 // tag.
 //
 // Implements:
-//  int rbd_mirror_image_enable(rbd_image_t image)
+//
+//	int rbd_mirror_image_enable(rbd_image_t image)
 func (image *Image) MirrorEnable() error {
 	err := image.validate(imageIsOpen)
 	if err != nil {
@@ -344,7 +352,8 @@ func (image *Image) MirrorEnable() error {
 // tag.
 //
 // Implements:
-//  int rbd_mirror_image_disable(rbd_image_t image, bool force)
+//
+//	int rbd_mirror_image_disable(rbd_image_t image, bool force)
 func (image *Image) MirrorDisable(force bool) error {
 	err := image.validate(imageIsOpen)
 	if err != nil {
@@ -361,7 +370,8 @@ func (image *Image) MirrorDisable(force bool) error {
 // tag.
 //
 // Implements:
-//  int rbd_mirror_image_promote(rbd_image_t image, bool force)
+//
+//	int rbd_mirror_image_promote(rbd_image_t image, bool force)
 func (image *Image) MirrorPromote(force bool) error {
 	err := image.validate(imageIsOpen)
 	if err != nil {
@@ -378,7 +388,8 @@ func (image *Image) MirrorPromote(force bool) error {
 // tag.
 //
 // Implements:
-//  int rbd_mirror_image_demote(rbd_image_t image)
+//
+//	int rbd_mirror_image_demote(rbd_image_t image)
 func (image *Image) MirrorDemote() error {
 	err := image.validate(imageIsOpen)
 	if err != nil {
@@ -396,7 +407,8 @@ func (image *Image) MirrorDemote() error {
 // tag.
 //
 // Implements:
-//  int rbd_mirror_image_resync(rbd_image_t image)
+//
+//	int rbd_mirror_image_resync(rbd_image_t image)
 func (image *Image) MirrorResync() error {
 	err := image.validate(imageIsOpen)
 	if err != nil {

--- a/rbd/namespace_nautilus.go
+++ b/rbd/namespace_nautilus.go
@@ -22,7 +22,8 @@ import (
 // NamespaceCreate creates the namespace for a given Rados IOContext.
 //
 // Implements:
-//  int rbd_namespace_create(rados_ioctx_t io, const char *namespace_name);
+//
+//	int rbd_namespace_create(rados_ioctx_t io, const char *namespace_name);
 func NamespaceCreate(ioctx *rados.IOContext, namespaceName string) error {
 	if ioctx == nil {
 		return ErrNoIOContext
@@ -40,7 +41,8 @@ func NamespaceCreate(ioctx *rados.IOContext, namespaceName string) error {
 // NamespaceRemove removes a given namespace.
 //
 // Implements:
-//  int rbd_namespace_remove(rados_ioctx_t io, const char *namespace_name);
+//
+//	int rbd_namespace_remove(rados_ioctx_t io, const char *namespace_name);
 func NamespaceRemove(ioctx *rados.IOContext, namespaceName string) error {
 	if ioctx == nil {
 		return ErrNoIOContext
@@ -58,7 +60,8 @@ func NamespaceRemove(ioctx *rados.IOContext, namespaceName string) error {
 // NamespaceExists checks whether a given namespace exists or not.
 //
 // Implements:
-//  int rbd_namespace_exists(rados_ioctx_t io, const char *namespace_name, bool *exists);
+//
+//	int rbd_namespace_exists(rados_ioctx_t io, const char *namespace_name, bool *exists);
 func NamespaceExists(ioctx *rados.IOContext, namespaceName string) (bool, error) {
 	if ioctx == nil {
 		return false, ErrNoIOContext
@@ -77,7 +80,8 @@ func NamespaceExists(ioctx *rados.IOContext, namespaceName string) (bool, error)
 // NamespaceList returns a slice containing the names of existing rbd namespaces.
 //
 // Implements:
-//  int rbd_namespace_list(rados_ioctx_t io, char *namespace_names, size_t *size);
+//
+//	int rbd_namespace_list(rados_ioctx_t io, char *namespace_names, size_t *size);
 func NamespaceList(ioctx *rados.IOContext) (names []string, err error) {
 	if ioctx == nil {
 		return nil, ErrNoIOContext

--- a/rbd/options.go
+++ b/rbd/options.go
@@ -99,7 +99,8 @@ type RbdImageOption = ImageOption
 // RbdImageOptions.Destroy() to free the resources.
 //
 // Implements:
-//  void rbd_image_options_create(rbd_image_options_t* opts)
+//
+//	void rbd_image_options_create(rbd_image_options_t* opts)
 func NewRbdImageOptions() *ImageOptions {
 	rio := &ImageOptions{}
 	C.rbd_image_options_create(&rio.options)
@@ -109,7 +110,8 @@ func NewRbdImageOptions() *ImageOptions {
 // Destroy a RbdImageOptions struct and free the associated resources.
 //
 // Implements:
-//  void rbd_image_options_destroy(rbd_image_options_t opts);
+//
+//	void rbd_image_options_destroy(rbd_image_options_t opts);
 func (rio *ImageOptions) Destroy() {
 	C.rbd_image_options_destroy(rio.options)
 }
@@ -117,8 +119,9 @@ func (rio *ImageOptions) Destroy() {
 // SetString sets the value of the RbdImageOption to the given string.
 //
 // Implements:
-//  int rbd_image_options_set_string(rbd_image_options_t opts, int optname,
-//          const char* optval);
+//
+//	int rbd_image_options_set_string(rbd_image_options_t opts, int optname,
+//	        const char* optval);
 func (rio *ImageOptions) SetString(option ImageOption, value string) error {
 	cValue := C.CString(value)
 	defer C.free(unsafe.Pointer(cValue))
@@ -135,8 +138,9 @@ func (rio *ImageOptions) SetString(option ImageOption, value string) error {
 // GetString returns the string value of the RbdImageOption.
 //
 // Implements:
-//  int rbd_image_options_get_string(rbd_image_options_t opts, int optname,
-//          char* optval, size_t maxlen);
+//
+//	int rbd_image_options_get_string(rbd_image_options_t opts, int optname,
+//	        char* optval, size_t maxlen);
 func (rio *ImageOptions) GetString(option ImageOption) (string, error) {
 	value := make([]byte, 4096)
 
@@ -153,8 +157,9 @@ func (rio *ImageOptions) GetString(option ImageOption) (string, error) {
 // SetUint64 sets the value of the RbdImageOption to the given uint64.
 //
 // Implements:
-//  int rbd_image_options_set_uint64(rbd_image_options_t opts, int optname,
-//          const uint64_t optval);
+//
+//	int rbd_image_options_set_uint64(rbd_image_options_t opts, int optname,
+//	        const uint64_t optval);
 func (rio *ImageOptions) SetUint64(option ImageOption, value uint64) error {
 	cValue := C.uint64_t(value)
 
@@ -170,8 +175,9 @@ func (rio *ImageOptions) SetUint64(option ImageOption, value uint64) error {
 // GetUint64 returns the uint64 value of the RbdImageOption.
 //
 // Implements:
-//  int rbd_image_options_get_uint64(rbd_image_options_t opts, int optname,
-//          uint64_t* optval);
+//
+//	int rbd_image_options_get_uint64(rbd_image_options_t opts, int optname,
+//	        uint64_t* optval);
 func (rio *ImageOptions) GetUint64(option ImageOption) (uint64, error) {
 	var cValue C.uint64_t
 
@@ -186,8 +192,9 @@ func (rio *ImageOptions) GetUint64(option ImageOption) (uint64, error) {
 // IsSet returns a true if the RbdImageOption is set, false otherwise.
 //
 // Implements:
-//  int rbd_image_options_is_set(rbd_image_options_t opts, int optname,
-//          bool* is_set);
+//
+//	int rbd_image_options_is_set(rbd_image_options_t opts, int optname,
+//	        bool* is_set);
 func (rio *ImageOptions) IsSet(option ImageOption) (bool, error) {
 	var cSet C.bool
 
@@ -202,7 +209,8 @@ func (rio *ImageOptions) IsSet(option ImageOption) (bool, error) {
 // Unset a given RbdImageOption.
 //
 // Implements:
-//  int rbd_image_options_unset(rbd_image_options_t opts, int optname)
+//
+//	int rbd_image_options_unset(rbd_image_options_t opts, int optname)
 func (rio *ImageOptions) Unset(option ImageOption) error {
 	ret := C.rbd_image_options_unset(rio.options, C.int(option))
 	if ret != 0 {
@@ -215,7 +223,8 @@ func (rio *ImageOptions) Unset(option ImageOption) error {
 // Clear all options in the RbdImageOptions.
 //
 // Implements:
-//  void rbd_image_options_clear(rbd_image_options_t opts)
+//
+//	void rbd_image_options_clear(rbd_image_options_t opts)
 func (rio *ImageOptions) Clear() {
 	C.rbd_image_options_clear(rio.options)
 }
@@ -224,7 +233,8 @@ func (rio *ImageOptions) Clear() {
 // false otherwise.
 //
 // Implements:
-//  int rbd_image_options_is_empty(rbd_image_options_t opts)
+//
+//	int rbd_image_options_is_empty(rbd_image_options_t opts)
 func (rio *ImageOptions) IsEmpty() bool {
 	ret := C.rbd_image_options_is_empty(rio.options)
 	return ret != 0

--- a/rbd/pool_nautilus.go
+++ b/rbd/pool_nautilus.go
@@ -20,7 +20,8 @@ import (
 // GetPoolMetadata returns pool metadata associated with the given key.
 //
 // Implements:
-//  int rbd_pool_metadata_get(rados_ioctx_t io_ctx, const char *key, char *value, size_t *val_len);
+//
+//	int rbd_pool_metadata_get(rados_ioctx_t io_ctx, const char *key, char *value, size_t *val_len);
 func GetPoolMetadata(ioctx *rados.IOContext, key string) (string, error) {
 	if ioctx == nil {
 		return "", ErrNoIOContext
@@ -53,7 +54,8 @@ func GetPoolMetadata(ioctx *rados.IOContext, key string) (string, error) {
 // SetPoolMetadata updates the pool metadata string associated with the given key.
 //
 // Implements:
-//  int rbd_pool_metadata_set(rados_ioctx_t io_ctx, const char *key, const char *value);
+//
+//	int rbd_pool_metadata_set(rados_ioctx_t io_ctx, const char *key, const char *value);
 func SetPoolMetadata(ioctx *rados.IOContext, key, value string) error {
 	if ioctx == nil {
 		return ErrNoIOContext
@@ -71,7 +73,8 @@ func SetPoolMetadata(ioctx *rados.IOContext, key, value string) error {
 // RemovePoolMetadata removes the pool metadata value for a given pool metadata key.
 //
 // Implements:
-//  int rbd_pool_metadata_remove(rados_ioctx_t io_ctx, const char *key)
+//
+//	int rbd_pool_metadata_remove(rados_ioctx_t io_ctx, const char *key)
 func RemovePoolMetadata(ioctx *rados.IOContext, key string) error {
 	if ioctx == nil {
 		return ErrNoIOContext
@@ -89,7 +92,8 @@ func RemovePoolMetadata(ioctx *rados.IOContext, key string) error {
 // to host rbd images.
 //
 // Implements:
-//  int rbd_pool_init(rados_ioctx_t io, bool force)
+//
+//	int rbd_pool_init(rados_ioctx_t io, bool force)
 func PoolInit(ioctx *rados.IOContext, force bool) error {
 	if ioctx == nil {
 		return ErrNoIOContext
@@ -107,7 +111,8 @@ type poolStats struct {
 // poolStatsCreate creates a new poolStats struct.
 //
 // Implements:
-//  void rbd_pool_stats_create(rbd_pool_stats_t *stats)
+//
+//	void rbd_pool_stats_create(rbd_pool_stats_t *stats)
 func poolStatsCreate() *poolStats {
 	poolstats := &poolStats{}
 	C.rbd_pool_stats_create(&poolstats.stats)
@@ -117,7 +122,8 @@ func poolStatsCreate() *poolStats {
 // destroy a poolStats struct and free the associated resources.
 //
 // Implements:
-//  void rbd_pool_stats_destroy(rbd_pool_stats_t stats)
+//
+//	void rbd_pool_stats_destroy(rbd_pool_stats_t stats)
 func (poolstats *poolStats) destroy() {
 	C.rbd_pool_stats_destroy(poolstats.stats)
 
@@ -159,7 +165,8 @@ const (
 // addPoolStatOption adds the given PoolStatOption to PoolStats.
 //
 // Implements:
-//  int rbd_pool_stats_option_add_uint64(rbd_pool_stats_t stats, int stat_option, uint64_t* stat_val)
+//
+//	int rbd_pool_stats_option_add_uint64(rbd_pool_stats_t stats, int stat_option, uint64_t* stat_val)
 func (poolstats *poolStats) addPoolStatOption(option PoolStatOption, val *uint64) error {
 	ret := C.rbd_pool_stats_option_add_uint64(
 		poolstats.stats,
@@ -171,7 +178,8 @@ func (poolstats *poolStats) addPoolStatOption(option PoolStatOption, val *uint64
 // GetAllPoolStats returns a map of all PoolStatOption(s) to their respective values.
 //
 // Implements:
-//  int rbd_pool_stats_get(rados_ioctx_t io, rbd_pool_stats_t stats);
+//
+//	int rbd_pool_stats_get(rados_ioctx_t io, rbd_pool_stats_t stats);
 func GetAllPoolStats(ioctx *rados.IOContext) (map[PoolStatOption]uint64, error) {
 	var omap = make(map[PoolStatOption]uint64)
 	if ioctx == nil {

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -145,14 +145,16 @@ func GetImage(ioctx *rados.IOContext, name string) *Image {
 // Create a new rbd image.
 //
 // Implements:
-//  int rbd_create(rados_ioctx_t io, const char *name, uint64_t size, int *order);
+//
+//	int rbd_create(rados_ioctx_t io, const char *name, uint64_t size, int *order);
 //
 // Also implements (for backward compatibility):
-//  int rbd_create2(rados_ioctx_t io, const char *name, uint64_t size,
-//          uint64_t features, int *order);
-//  int rbd_create3(rados_ioctx_t io, const char *name, uint64_t size,
-//        uint64_t features, int *order,
-//        uint64_t stripe_unit, uint64_t stripe_count);
+//
+//	int rbd_create2(rados_ioctx_t io, const char *name, uint64_t size,
+//	        uint64_t features, int *order);
+//	int rbd_create3(rados_ioctx_t io, const char *name, uint64_t size,
+//	      uint64_t features, int *order,
+//	      uint64_t stripe_unit, uint64_t stripe_count);
 func Create(ioctx *rados.IOContext, name string, size uint64, order int,
 	args ...uint64) (image *Image, err error) {
 	var ret C.int
@@ -188,8 +190,9 @@ func Create(ioctx *rados.IOContext, name string, size uint64, order int,
 // Create2 creates a new rbd image using provided features.
 //
 // Implements:
-//  int rbd_create2(rados_ioctx_t io, const char *name, uint64_t size,
-//          uint64_t features, int *order);
+//
+//	int rbd_create2(rados_ioctx_t io, const char *name, uint64_t size,
+//	        uint64_t features, int *order);
 func Create2(ioctx *rados.IOContext, name string, size uint64, features uint64,
 	order int) (image *Image, err error) {
 	var ret C.int
@@ -215,9 +218,10 @@ func Create2(ioctx *rados.IOContext, name string, size uint64, features uint64,
 // parameters.
 //
 // Implements:
-//  int rbd_create3(rados_ioctx_t io, const char *name, uint64_t size,
-//        uint64_t features, int *order,
-//        uint64_t stripe_unit, uint64_t stripe_count);
+//
+//	int rbd_create3(rados_ioctx_t io, const char *name, uint64_t size,
+//	      uint64_t features, int *order,
+//	      uint64_t stripe_unit, uint64_t stripe_count);
 func Create3(ioctx *rados.IOContext, name string, size uint64, features uint64,
 	order int, stripeUnit uint64, stripeCount uint64) (image *Image, err error) {
 	var ret C.int
@@ -243,9 +247,10 @@ func Create3(ioctx *rados.IOContext, name string, size uint64, features uint64,
 // Clone a new rbd image from a snapshot.
 //
 // Implements:
-//  int rbd_clone(rados_ioctx_t p_ioctx, const char *p_name,
-//           const char *p_snapname, rados_ioctx_t c_ioctx,
-//           const char *c_name, uint64_t features, int *c_order);
+//
+//	int rbd_clone(rados_ioctx_t p_ioctx, const char *p_name,
+//	         const char *p_snapname, rados_ioctx_t c_ioctx,
+//	         const char *c_name, uint64_t features, int *c_order);
 func (image *Image) Clone(snapname string, cIoctx *rados.IOContext, cName string, features uint64, order int) (*Image, error) {
 	if err := image.validate(imageNeedsIOContext); err != nil {
 		return nil, err
@@ -281,7 +286,8 @@ func (image *Image) Clone(snapname string, cIoctx *rados.IOContext, cName string
 // Remove the specified rbd image.
 //
 // Implements:
-//  int rbd_remove(rados_ioctx_t io, const char *name);
+//
+//	int rbd_remove(rados_ioctx_t io, const char *name);
 func (image *Image) Remove() error {
 	if err := image.validate(imageNeedsIOContext | imageNeedsName | imageIsNotOpen); err != nil {
 		return err
@@ -306,7 +312,8 @@ func (image *Image) Trash(delay time.Duration) error {
 // Rename an rbd image.
 //
 // Implements:
-//  int rbd_rename(rados_ioctx_t src_io_ctx, const char *srcname, const char *destname);
+//
+//	int rbd_rename(rados_ioctx_t src_io_ctx, const char *srcname, const char *destname);
 func (image *Image) Rename(destname string) error {
 	if err := image.validate(imageNeedsIOContext | imageNeedsName); err != nil {
 		return err
@@ -370,7 +377,8 @@ func (image *Image) Open(args ...interface{}) error {
 // Close an open rbd image.
 //
 // Implements:
-//  int rbd_close(rbd_image_t image);
+//
+//	int rbd_close(rbd_image_t image);
 func (image *Image) Close() error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -387,7 +395,8 @@ func (image *Image) Close() error {
 // Resize an rbd image.
 //
 // Implements:
-//  int rbd_resize(rbd_image_t image, uint64_t size);
+//
+//	int rbd_resize(rbd_image_t image, uint64_t size);
 func (image *Image) Resize(size uint64) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -399,7 +408,8 @@ func (image *Image) Resize(size uint64) error {
 // Stat an rbd image.
 //
 // Implements:
-//  int rbd_stat(rbd_image_t image, rbd_image_info_t *info, size_t infosize);
+//
+//	int rbd_stat(rbd_image_t image, rbd_image_info_t *info, size_t infosize);
 func (image *Image) Stat() (info *ImageInfo, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err
@@ -422,7 +432,8 @@ func (image *Image) Stat() (info *ImageInfo, err error) {
 // IsOldFormat returns true if the rbd image uses the old format.
 //
 // Implements:
-//  int rbd_get_old_format(rbd_image_t image, uint8_t *old);
+//
+//	int rbd_get_old_format(rbd_image_t image, uint8_t *old);
 func (image *Image) IsOldFormat() (bool, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return false, err
@@ -441,7 +452,8 @@ func (image *Image) IsOldFormat() (bool, error) {
 // GetSize returns the size of the rbd image.
 //
 // Implements:
-//  int rbd_size(rbd_image_t image, uint64_t *size);
+//
+//	int rbd_size(rbd_image_t image, uint64_t *size);
 func (image *Image) GetSize() (size uint64, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -457,7 +469,8 @@ func (image *Image) GetSize() (size uint64, err error) {
 // GetStripeUnit returns the stripe-unit value for the rbd image.
 //
 // Implements:
-//  int rbd_get_stripe_unit(rbd_image_t image, uint64_t *stripe_unit);
+//
+//	int rbd_get_stripe_unit(rbd_image_t image, uint64_t *stripe_unit);
 func (image *Image) GetStripeUnit() (uint64, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -474,7 +487,8 @@ func (image *Image) GetStripeUnit() (uint64, error) {
 // GetStripeCount returns the stripe-count value for the rbd image.
 //
 // Implements:
-//  int rbd_get_stripe_count(rbd_image_t image, uint64_t *stripe_count);
+//
+//	int rbd_get_stripe_count(rbd_image_t image, uint64_t *stripe_count);
 func (image *Image) GetStripeCount() (uint64, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -492,7 +506,8 @@ func (image *Image) GetStripeCount() (uint64, error) {
 // parent.
 //
 // Implements:
-//  int rbd_get_overlap(rbd_image_t image, uint64_t *overlap);
+//
+//	int rbd_get_overlap(rbd_image_t image, uint64_t *overlap);
 func (image *Image) GetOverlap() (overlap uint64, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -508,7 +523,8 @@ func (image *Image) GetOverlap() (overlap uint64, err error) {
 // Copy one rbd image to another.
 //
 // Implements:
-//  int rbd_copy(rbd_image_t image, rados_ioctx_t dest_io_ctx, const char *destname);
+//
+//	int rbd_copy(rbd_image_t image, rados_ioctx_t dest_io_ctx, const char *destname);
 func (image *Image) Copy(ioctx *rados.IOContext, destname string) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -528,7 +544,8 @@ func (image *Image) Copy(ioctx *rados.IOContext, destname string) error {
 // Copy2 copies one rbd image to another, using an image handle.
 //
 // Implements:
-//  int rbd_copy2(rbd_image_t src, rbd_image_t dest);
+//
+//	int rbd_copy2(rbd_image_t src, rbd_image_t dest);
 func (image *Image) Copy2(dest *Image) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -542,8 +559,9 @@ func (image *Image) Copy2(dest *Image) error {
 // DeepCopy an rbd image to a new image with specific options.
 //
 // Implements:
-//  int rbd_deep_copy(rbd_image_t src, rados_ioctx_t dest_io_ctx,
-//          const char *destname, rbd_image_options_t dest_opts);
+//
+//	int rbd_deep_copy(rbd_image_t src, rados_ioctx_t dest_io_ctx,
+//	        const char *destname, rbd_image_options_t dest_opts);
 func (image *Image) DeepCopy(ioctx *rados.IOContext, destname string, rio *ImageOptions) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -569,7 +587,8 @@ func (image *Image) DeepCopy(ioctx *rados.IOContext, destname string, rio *Image
 // Flatten removes snapshot references from the image.
 //
 // Implements:
-//  int rbd_flatten(rbd_image_t image);
+//
+//	int rbd_flatten(rbd_image_t image);
 func (image *Image) Flatten() error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -581,11 +600,12 @@ func (image *Image) Flatten() error {
 // ListLockers returns a list of clients that have locks on the image.
 //
 // Impelemnts:
-//  ssize_t rbd_list_lockers(rbd_image_t image, int *exclusive,
-//              char *tag, size_t *tag_len,
-//              char *clients, size_t *clients_len,
-//              char *cookies, size_t *cookies_len,
-//              char *addrs, size_t *addrs_len);
+//
+//	ssize_t rbd_list_lockers(rbd_image_t image, int *exclusive,
+//	            char *tag, size_t *tag_len,
+//	            char *clients, size_t *clients_len,
+//	            char *cookies, size_t *cookies_len,
+//	            char *addrs, size_t *addrs_len);
 func (image *Image) ListLockers() (tag string, lockers []Locker, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return "", nil, err
@@ -645,7 +665,8 @@ func (image *Image) ListLockers() (tag string, lockers []Locker, err error) {
 // LockExclusive acquires an exclusive lock on the rbd image.
 //
 // Implements:
-//  int rbd_lock_exclusive(rbd_image_t image, const char *cookie);
+//
+//	int rbd_lock_exclusive(rbd_image_t image, const char *cookie);
 func (image *Image) LockExclusive(cookie string) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -660,7 +681,8 @@ func (image *Image) LockExclusive(cookie string) error {
 // LockShared acquires a shared lock on the rbd image.
 //
 // Implements:
-//  int rbd_lock_shared(rbd_image_t image, const char *cookie, const char *tag);
+//
+//	int rbd_lock_shared(rbd_image_t image, const char *cookie, const char *tag);
 func (image *Image) LockShared(cookie string, tag string) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -677,7 +699,8 @@ func (image *Image) LockShared(cookie string, tag string) error {
 // Unlock releases a lock on the image.
 //
 // Implements:
-//  int rbd_lock_shared(rbd_image_t image, const char *cookie, const char *tag);
+//
+//	int rbd_lock_shared(rbd_image_t image, const char *cookie, const char *tag);
 func (image *Image) Unlock(cookie string) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -692,7 +715,8 @@ func (image *Image) Unlock(cookie string) error {
 // BreakLock forces the release of a lock held by another client.
 //
 // Implements:
-//  int rbd_break_lock(rbd_image_t image, const char *client, const char *cookie);
+//
+//	int rbd_break_lock(rbd_image_t image, const char *client, const char *cookie);
 func (image *Image) BreakLock(client string, cookie string) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -711,8 +735,9 @@ func (image *Image) BreakLock(client string, cookie string) error {
 // offset which is not safe in concurrent code. Prefer ReadAt when possible.
 //
 // Implements:
-//  ssize_t rbd_read(rbd_image_t image, uint64_t ofs, size_t len,
-//                   char *buf);
+//
+//	ssize_t rbd_read(rbd_image_t image, uint64_t ofs, size_t len,
+//	                 char *buf);
 func (image *Image) Read(data []byte) (int, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -745,8 +770,9 @@ func (image *Image) Read(data []byte) (int, error) {
 // offset which is not safe in concurrent code. Prefer WriteAt when possible.
 //
 // Implements:
-//  ssize_t rbd_write(rbd_image_t image, uint64_t ofs, size_t len,
-//                    const char *buf);
+//
+//	ssize_t rbd_write(rbd_image_t image, uint64_t ofs, size_t len,
+//	                  const char *buf);
 func (image *Image) Write(data []byte) (n int, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -790,7 +816,8 @@ func (image *Image) Seek(offset int64, whence int) (int64, error) {
 // space.
 //
 // Implements:
-//  int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
+//
+//	int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
 func (image *Image) Discard(ofs uint64, length uint64) (int, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return 0, err
@@ -855,8 +882,9 @@ func (image *Image) WriteAt(data []byte, off int64) (n int, err error) {
 // been written.
 //
 // Implements:
-//  ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
-//                        const char *buf, size_t data_len, int op_flags);
+//
+//	ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
+//	                      const char *buf, size_t data_len, int op_flags);
 func (image *Image) WriteSame(ofs, n uint64, data []byte, flags rados.OpFlags) (int64, error) {
 	var err error
 
@@ -884,7 +912,8 @@ func (image *Image) WriteSame(ofs, n uint64, data []byte, flags rados.OpFlags) (
 // Flush all cached writes to storage.
 //
 // Implements:
-//  int rbd_flush(rbd_image_t image);
+//
+//	int rbd_flush(rbd_image_t image);
 func (image *Image) Flush() error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -897,7 +926,8 @@ func (image *Image) Flush() error {
 // associated with the rbd image.
 //
 // Implements:
-//  int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps, int *max_snaps);
+//
+//	int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps, int *max_snaps);
 func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err
@@ -929,7 +959,8 @@ func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 // GetId returns the internal image ID string.
 //
 // Implements:
-//  int rbd_get_id(rbd_image_t image, char *id, size_t id_len);
+//
+//	int rbd_get_id(rbd_image_t image, char *id, size_t id_len);
 func (image *Image) GetId() (string, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return "", err
@@ -964,7 +995,8 @@ func (image *Image) GetName() string {
 // is the source of readable data.
 //
 // Implements:
-//  int rbd_snap_set(rbd_image_t image, const char *snapname);
+//
+//	int rbd_snap_set(rbd_image_t image, const char *snapname);
 func (image *Image) SetSnapshot(snapname string) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -1033,8 +1065,9 @@ func TrashRestore(ioctx *rados.IOContext, id, name string) error {
 // snapName to explicitly indicate that no snapshot name is being provided.
 //
 // Implements:
-//  int rbd_open(rados_ioctx_t io, const char *name,
-//               rbd_image_t *image, const char *snap_name);
+//
+//	int rbd_open(rados_ioctx_t io, const char *name,
+//	             rbd_image_t *image, const char *snap_name);
 func OpenImage(ioctx *rados.IOContext, name, snapName string) (*Image, error) {
 	if ioctx == nil {
 		return nil, ErrNoIOContext
@@ -1076,8 +1109,9 @@ func OpenImage(ioctx *rados.IOContext, name, snapName string) (*Image, error) {
 // provided.
 //
 // Implements:
-//  int rbd_open_read_only(rados_ioctx_t io, const char *name,
-//                         rbd_image_t *image, const char *snap_name);
+//
+//	int rbd_open_read_only(rados_ioctx_t io, const char *name,
+//	                       rbd_image_t *image, const char *snap_name);
 func OpenImageReadOnly(ioctx *rados.IOContext, name, snapName string) (*Image, error) {
 	if ioctx == nil {
 		return nil, ErrNoIOContext
@@ -1120,8 +1154,9 @@ func OpenImageReadOnly(ioctx *rados.IOContext, name, snapName string) (*Image, e
 // that fixes https://tracker.ceph.com/issues/43178
 //
 // Implements:
-//  int rbd_open_by_id(rados_ioctx_t io, const char *id,
-//                     rbd_image_t *image, const char *snap_name);
+//
+//	int rbd_open_by_id(rados_ioctx_t io, const char *id,
+//	                   rbd_image_t *image, const char *snap_name);
 func OpenImageById(ioctx *rados.IOContext, id, snapName string) (*Image, error) {
 	if ioctx == nil {
 		return nil, ErrNoIOContext
@@ -1164,8 +1199,9 @@ func OpenImageById(ioctx *rados.IOContext, id, snapName string) (*Image, error) 
 // that fixes https://tracker.ceph.com/issues/43178
 //
 // Implements:
-//  int rbd_open_by_id_read_only(rados_ioctx_t io, const char *id,
-//                               rbd_image_t *image, const char *snap_name);
+//
+//	int rbd_open_by_id_read_only(rados_ioctx_t io, const char *id,
+//	                             rbd_image_t *image, const char *snap_name);
 func OpenImageByIdReadOnly(ioctx *rados.IOContext, id, snapName string) (*Image, error) {
 	if ioctx == nil {
 		return nil, ErrNoIOContext
@@ -1203,8 +1239,9 @@ func OpenImageByIdReadOnly(ioctx *rados.IOContext, id, snapName string) (*Image,
 // CreateImage creates a new rbd image using provided image options.
 //
 // Implements:
-//  int rbd_create4(rados_ioctx_t io, const char *name, uint64_t size,
-//                 rbd_image_options_t opts);
+//
+//	int rbd_create4(rados_ioctx_t io, const char *name, uint64_t size,
+//	               rbd_image_options_t opts);
 func CreateImage(ioctx *rados.IOContext, name string, size uint64, rio *ImageOptions) error {
 	if ioctx == nil {
 		return ErrNoIOContext
@@ -1227,7 +1264,8 @@ func CreateImage(ioctx *rados.IOContext, name string, size uint64, rio *ImageOpt
 // RemoveImage removes the specified rbd image.
 //
 // Implements:
-//  int rbd_remove(rados_ioctx_t io, const char *name);
+//
+//	int rbd_remove(rados_ioctx_t io, const char *name);
 func RemoveImage(ioctx *rados.IOContext, name string) error {
 	if ioctx == nil {
 		return ErrNoIOContext
@@ -1245,9 +1283,10 @@ func RemoveImage(ioctx *rados.IOContext, name string) error {
 // provided io-context with the given name and image options.
 //
 // Implements:
-//   int rbd_clone3(rados_ioctx_t p_ioctx, const char *p_name,
-//                  const char *p_snapname, rados_ioctx_t c_ioctx,
-//                  const char *c_name, rbd_image_options_t c_opts);
+//
+//	int rbd_clone3(rados_ioctx_t p_ioctx, const char *p_name,
+//	               const char *p_snapname, rados_ioctx_t c_ioctx,
+//	               const char *c_name, rbd_image_options_t c_opts);
 func CloneImage(ioctx *rados.IOContext, parentName, snapName string,
 	destctx *rados.IOContext, name string, rio *ImageOptions) error {
 

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -48,7 +48,8 @@ func GetImageNames(ioctx *rados.IOContext) ([]string, error) {
 // GetCreateTimestamp returns the time the rbd image was created.
 //
 // Implements:
-//  int rbd_get_create_timestamp(rbd_image_t image, struct timespec *timestamp);
+//
+//	int rbd_get_create_timestamp(rbd_image_t image, struct timespec *timestamp);
 func (image *Image) GetCreateTimestamp() (Timespec, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return Timespec{}, err
@@ -66,7 +67,8 @@ func (image *Image) GetCreateTimestamp() (Timespec, error) {
 // GetAccessTimestamp returns the time the rbd image was last accessed.
 //
 // Implements:
-//  int rbd_get_access_timestamp(rbd_image_t image, struct timespec *timestamp);
+//
+//	int rbd_get_access_timestamp(rbd_image_t image, struct timespec *timestamp);
 func (image *Image) GetAccessTimestamp() (Timespec, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return Timespec{}, err
@@ -84,7 +86,8 @@ func (image *Image) GetAccessTimestamp() (Timespec, error) {
 // GetModifyTimestamp returns the time the rbd image was last modified.
 //
 // Implements:
-//  int rbd_get_modify_timestamp(rbd_image_t image, struct timespec *timestamp);
+//
+//	int rbd_get_modify_timestamp(rbd_image_t image, struct timespec *timestamp);
 func (image *Image) GetModifyTimestamp() (Timespec, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return Timespec{}, err
@@ -104,7 +107,8 @@ func (image *Image) GetModifyTimestamp() (Timespec, error) {
 // a power of two no less than 4096 and no larger than the image size.
 //
 // Implements:
-//  int rbd_sparsify(rbd_image_t image, size_t sparse_size);
+//
+//	int rbd_sparsify(rbd_image_t image, size_t sparse_size);
 func (image *Image) Sparsify(sparseSize uint) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -21,7 +21,8 @@ type Snapshot struct {
 // a snapshot of the rbd image.
 //
 // Implements:
-//  int rbd_snap_create(rbd_image_t image, const char *snapname);
+//
+//	int rbd_snap_create(rbd_image_t image, const char *snapname);
 func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err
@@ -66,7 +67,8 @@ func (image *Image) GetSnapshot(snapname string) *Snapshot {
 // Remove the snapshot from the connected rbd image.
 //
 // Implements:
-//  int rbd_snap_remove(rbd_image_t image, const char *snapname);
+//
+//	int rbd_snap_remove(rbd_image_t image, const char *snapname);
 func (snapshot *Snapshot) Remove() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -81,7 +83,8 @@ func (snapshot *Snapshot) Remove() error {
 // Rollback the image to the snapshot.
 //
 // Implements:
-//  int rbd_snap_rollback(rbd_image_t image, const char *snapname);
+//
+//	int rbd_snap_rollback(rbd_image_t image, const char *snapname);
 func (snapshot *Snapshot) Rollback() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -96,7 +99,8 @@ func (snapshot *Snapshot) Rollback() error {
 // Protect a snapshot from unwanted deletion.
 //
 // Implements:
-//  int rbd_snap_protect(rbd_image_t image, const char *snap_name);
+//
+//	int rbd_snap_protect(rbd_image_t image, const char *snap_name);
 func (snapshot *Snapshot) Protect() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -111,7 +115,8 @@ func (snapshot *Snapshot) Protect() error {
 // Unprotect stops protecting the snapshot.
 //
 // Implements:
-//  int rbd_snap_unprotect(rbd_image_t image, const char *snap_name);
+//
+//	int rbd_snap_unprotect(rbd_image_t image, const char *snap_name);
 func (snapshot *Snapshot) Unprotect() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -126,8 +131,9 @@ func (snapshot *Snapshot) Unprotect() error {
 // IsProtected returns true if the snapshot is currently protected.
 //
 // Implements:
-//  int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
-//               int *is_protected);
+//
+//	int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
+//	             int *is_protected);
 func (snapshot *Snapshot) IsProtected() (bool, error) {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return false, err
@@ -153,7 +159,8 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 // Deprecated: use the SetSnapshot method of the Image type instead
 //
 // Implements:
-//  int rbd_snap_set(rbd_image_t image, const char *snapname);
+//
+//	int rbd_snap_set(rbd_image_t image, const char *snapname);
 func (snapshot *Snapshot) Set() error {
 	if err := snapshot.validate(snapshotNeedsName | imageIsOpen); err != nil {
 		return err
@@ -168,7 +175,8 @@ func (snapshot *Snapshot) Set() error {
 // Check https://tracker.ceph.com/issues/47287 for details.
 //
 // Implements:
-//  int rbd_snap_get_timestamp(rbd_image_t image, uint64_t snap_id, struct timespec *timestamp)
+//
+//	int rbd_snap_get_timestamp(rbd_image_t image, uint64_t snap_id, struct timespec *timestamp)
 func (image *Image) GetSnapTimestamp(snapID uint64) (Timespec, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return Timespec{}, err

--- a/rbd/snapshot_namespace.go
+++ b/rbd/snapshot_namespace.go
@@ -32,7 +32,8 @@ const (
 // returns error on failure.
 //
 // Implements:
-//  int rbd_snap_get_namespace_type(rbd_image_t image, uint64_t snap_id, rbd_snap_namespace_type_t *namespace_type)
+//
+//	int rbd_snap_get_namespace_type(rbd_image_t image, uint64_t snap_id, rbd_snap_namespace_type_t *namespace_type)
 func (image *Image) GetSnapNamespaceType(snapID uint64) (SnapNamespaceType, error) {
 	var nsType SnapNamespaceType
 
@@ -51,7 +52,8 @@ func (image *Image) GetSnapNamespaceType(snapID uint64) (SnapNamespaceType, erro
 // function belongs to a snapshot already in the Trash.
 //
 // Implements:
-//  int rbd_snap_get_trash_namespace(rbd_image_t image, uint64_t snap_id, char *original_name, size_t max_length)
+//
+//	int rbd_snap_get_trash_namespace(rbd_image_t image, uint64_t snap_id, char *original_name, size_t max_length)
 func (image *Image) GetSnapTrashNamespace(snapID uint64) (string, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return "", err

--- a/rbd/snapshot_nautilus.go
+++ b/rbd/snapshot_nautilus.go
@@ -19,9 +19,10 @@ import (
 // and snapshot-name in the byte-arrays that are passed as arguments.
 //
 // Implements:
-//   int rbd_get_parent(rbd_image_t image,
-//                      rbd_linked_image_spec_t *parent_image,
-//                      rbd_snap_spec_t *parent_snap)
+//
+//	int rbd_get_parent(rbd_image_t image,
+//	                   rbd_linked_image_spec_t *parent_image,
+//	                   rbd_snap_spec_t *parent_snap)
 func (image *Image) GetParentInfo(pool, name, snapname []byte) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err
@@ -123,8 +124,9 @@ func (image *Image) GetParent() (*ParentInfo, error) {
 // used to link the two items together.
 //
 // Implements:
-//   int rbd_list_children3(rbd_image_t image, rbd_linked_image_spec_t *images,
-//                          size_t *max_images);
+//
+//	int rbd_list_children3(rbd_image_t image, rbd_linked_image_spec_t *images,
+//	                       size_t *max_images);
 func (image *Image) ListChildren() (pools []string, images []string, err error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, nil, err
@@ -162,7 +164,8 @@ func (image *Image) ListChildren() (pools []string, images []string, err error) 
 // is the source of readable data.
 //
 // Implements:
-//  int rbd_snap_set_by_id(rbd_image_t image, uint64_t snap_id);
+//
+//	int rbd_snap_set_by_id(rbd_image_t image, uint64_t snap_id);
 func (image *Image) SetSnapByID(snapID uint64) error {
 	if err := image.validate(imageIsOpen); err != nil {
 		return err

--- a/rbd/snapshot_octopus.go
+++ b/rbd/snapshot_octopus.go
@@ -17,7 +17,8 @@ import (
 // GetSnapID returns the snapshot ID for the given snapshot name.
 //
 // Implements:
-//  int rbd_snap_get_id(rbd_image_t image, const char *snapname, uint64_t *snap_id)
+//
+//	int rbd_snap_get_id(rbd_image_t image, const char *snapname, uint64_t *snap_id)
 func (image *Image) GetSnapID(snapName string) (uint64, error) {
 	var snapID C.uint64_t
 	if err := image.validate(imageIsOpen); err != nil {
@@ -37,7 +38,8 @@ func (image *Image) GetSnapID(snapName string) (uint64, error) {
 // GetSnapByID returns the snapshot name for the given snapshot ID.
 //
 // Implements:
-//  int rbd_snap_get_name(rbd_image_t image, uint64_t snap_id, char *snapname, size_t *name_len)
+//
+//	int rbd_snap_get_name(rbd_image_t image, uint64_t snap_id, char *snapname, size_t *name_len)
 func (image *Image) GetSnapByID(snapID uint64) (string, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return "", err

--- a/rbd/snapshot_rename.go
+++ b/rbd/snapshot_rename.go
@@ -12,7 +12,8 @@ import (
 // Rename a snapshot.
 //
 // Implements:
-// 	int rbd_snap_rename(rbd_image_t image, const char *snapname,
+//
+//	int rbd_snap_rename(rbd_image_t image, const char *snapname,
 //				 const char* dstsnapsname);
 func (snapshot *Snapshot) Rename(destName string) error {
 	if err := snapshot.validate(imageNeedsIOContext | imageIsOpen | imageNeedsName | snapshotNeedsName); err != nil {

--- a/rbd/watchers.go
+++ b/rbd/watchers.go
@@ -31,11 +31,13 @@ type ImageWatcher struct {
 // and an error are returned.
 //
 // Note:
-//   Only supported in Ceph Mimic and newer.
+//
+//	Only supported in Ceph Mimic and newer.
 //
 // Implements:
-//   int rbd_watchers_list(rbd_image_t image,
-//                         rbd_image_watcher_t *watchers, size_t *max_watchers)
+//
+//	int rbd_watchers_list(rbd_image_t image,
+//	                      rbd_image_watcher_t *watchers, size_t *max_watchers)
 func (image *Image) ListWatchers() ([]ImageWatcher, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err
@@ -91,8 +93,9 @@ type Watch struct {
 // image, returning a Watch object.
 //
 // Implements:
-//  int rbd_update_watch(rbd_image_t image, uint64_t *handle,
-//                       rbd_update_callback_t watch_cb, void *arg);
+//
+//	int rbd_update_watch(rbd_image_t image, uint64_t *handle,
+//	                     rbd_update_callback_t watch_cb, void *arg);
 func (image *Image) UpdateWatch(cb WatchCallback, data interface{}) (*Watch, error) {
 	if err := image.validate(imageIsOpen); err != nil {
 		return nil, err
@@ -120,7 +123,8 @@ func (image *Image) UpdateWatch(cb WatchCallback, data interface{}) (*Watch, err
 // Unwatch un-registers the image watch.
 //
 // Implements:
-//  int rbd_update_unwatch(rbd_image_t image, uint64_t handle);
+//
+//	int rbd_update_unwatch(rbd_image_t image, uint64_t handle);
 func (w *Watch) Unwatch() error {
 	if w.image == nil {
 		return ErrImageNotOpen

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -20,7 +20,7 @@ RUN true && \
     yum clean all && \
     true
 
-ARG GO_VERSION=1.17.9
+ARG GO_VERSION=1.19.5
 ENV GO_VERSION=${GO_VERSION}
 ARG GOARCH
 ENV GOARCH=${GOARCH}


### PR DESCRIPTION
This bumps the Go version of the test container to 1.19.5, which is the oldest supported Go version as of now.

The go.mod file (including an upgrade of its dependencies) and the revive environment is bumped to 1.19 as well.

Signed-off-by: Sven Anderson <sven@redhat.com>

Closes: #825 