### PR TITLE
feat(cephfs): implementation of mkdirs

### DIFF
--- a/cephfs/makedirs.go
+++ b/cephfs/makedirs.go
@@ -1,0 +1,31 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package cephfs
+
+/*
+#cgo LDFLAGS: -lcephfs
+#cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
+#include <stdlib.h>
+#include <cephfs/libcephfs.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// MakeDirs creates multiple directories at once.
+//
+// Implements:
+//	int ceph_mkdirs(struct ceph_mount_info *cmount, const char *path, mode_t mode);
+func (mount *MountInfo) MakeDirs(path string, mode uint32) error {
+	if err := mount.validate(); err != nil {
+		return err
+	}
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	ret := C.ceph_mkdirs(mount.mount, cPath, C.mode_t(mode))
+	return getError(ret)
+}

--- a/cephfs/makedirs_test.go
+++ b/cephfs/makedirs_test.go
@@ -1,0 +1,30 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package cephfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeDirs(t *testing.T) {
+	mount := fsConnect(t)
+	defer fsDisconnect(t, mount)
+
+	dir1 := "/base/sub/way"
+	err := mount.MakeDirs(dir1, 0755)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, mount.RemoveDir("/base/sub/way"))
+		assert.NoError(t, mount.RemoveDir("/base/sub"))
+		assert.NoError(t, mount.RemoveDir("/base"))
+	}()
+
+	dir, err := mount.OpenDir(dir1)
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+	err = dir.Close()
+	assert.NoError(t, err)
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -319,6 +319,12 @@
         "comment": "SelectFilesystem selects a file system to be mounted. If the ceph cluster\nsupports more than one cephfs this optional function selects which one to\nuse. Can only be called prior to calling Mount. The name of the file system\nis not validated by this call - if the supplied file system name is not\nvalid then only the subsequent mount call will fail.\n\nImplements:\n int ceph_select_filesystem(struct ceph_mount_info *cmount, const char *fs_name);\n",
         "added_in_version": "v0.20.0",
         "expected_stable_version": "v0.22.0"
+      },
+      {
+        "name": "MountInfo.MakeDirs",
+        "comment": "MakeDirs creates multiple directories at once.\n\nImplements:\n\n\tint ceph_mkdirs(struct ceph_mount_info *cmount, const char *path, mode_t mode);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -9,6 +9,7 @@
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 MountInfo.SelectFilesystem | v0.20.0 | v0.22.0 | 
+MountInfo.MakeDirs | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: cephfs/admin
 


### PR DESCRIPTION
Hello, this PR adds "ceph_mkdirs" implementation (to create path+subpath at once).

Signed-off-by: Damien DALY <maitredede@gmail.com>

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [&check;] Added tests for features and functional changes
- [&check;] Public functions and types are documented
- [&check;] Standard formatting is applied to Go code
- [&check;] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [&check;] Ran `make api-update` to record new APIs
