### PR TITLE
github: remove deprecated and failing rebase_fallback attribute

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,6 @@ defaults:
     queue:
       name: default
       method: rebase
-      rebase_fallback: merge
       update_method: rebase
 
 # each test should be listed separately, do not use regular expressions:


### PR DESCRIPTION
As noted in the status on github:
```
The configuration uses the deprecated rebase_fallback attribute of the
queue action.
A brownout is planned on February 13th, 2023.
This option will be removed on March 13th, 2023.
For more information: https://docs.mergify.com/actions/queue/
```

Therefore we'll simply drop this attribute.


Internal/CI change.
