### PR TITLE
build: propagation of GOPROXY env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ endif
 GO_CMD:=go
 GOFMT_CMD:=gofmt
 GOARCH:=$(shell $(GO_CMD) env GOARCH)
+GOPROXY:=$(shell $(GO_CMD) env GOPROXY)
 
 # the full name of the marker file including the ceph version
 BUILDFILE=.build.$(CEPH_VERSION)
@@ -78,6 +79,9 @@ else
 endif
 
 CONTAINER_OPTS += -e BUILD_TAGS=$(BUILD_TAGS)
+ifdef GOPROXY
+	CONTAINER_OPTS += --env GOPROXY=$(GOPROXY)
+endif
 
 ifneq ($(USE_CACHE),)
 	GOCACHE_VOLUME := -v test_ceph_go_cache:/go
@@ -110,6 +114,9 @@ ifdef GO_CEPH_VERSION
 	CONTAINER_BUILD_ARGS += --build-arg GO_CEPH_VERSION=$(GO_CEPH_VERSION)
 else
 	CONTAINER_BUILD_ARGS += --build-arg GO_CEPH_VERSION=$(CEPH_VERSION)
+endif
+ifdef GOPROXY
+	CONTAINER_BUILD_ARGS += --build-arg GOPROXY=$(GOPROXY)
 endif
 
 build:


### PR DESCRIPTION
Hello,

For dev containers, expose the GOPROXY env for faster tests.

Signed-off-by: Damien DALY <maitredede@gmail.com>

## Checklist
- [&check;] Added tests for features and functional changes (N/A: build scripts)
- [&check;] Public functions and types are documented (N/A: no new functions/types)
- [&check;] Standard formatting is applied to Go code (N/A: no new go code)
- [&check;] Is this a new API? Added a new file that begins with `//go:build ceph_preview` (N/A: no new go code)
- [&check;] Ran `make api-update` to record new APIs (N/A: no new api)
