### PR TITLE
docs: fix api versions for new ListBucketWithStat API

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1860,8 +1860,8 @@
       {
         "name": "API.ListBucketsWithStat",
         "comment": "ListBucketsWithStat will return the list of all buckets with stat (system admin API only)\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.20.0",
+        "expected_stable_version": "v0.22.0"
       }
     ],
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -62,7 +62,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-API.ListBucketsWithStat | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+API.ListBucketsWithStat | v0.20.0 | v0.22.0 | 
 
 ## Package: common/admin/manager
 


### PR DESCRIPTION
This change executes `make api-fix-versions` in order to convert the placeholder versions into real version numbers.