### PR TITLE
Add Telemetry querying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.test
 /*.json
 /implements
+_results/
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,7 @@ test-binaries: \
 	cephfs/admin.test \
 	common/admin/manager.test \
 	common/admin/nfs.test \
+	common/admin/telemetry.test \
 	internal/callbacks.test \
 	internal/commands.test \
 	internal/cutil.test \

--- a/common/admin/telemetry/telemetry.go
+++ b/common/admin/telemetry/telemetry.go
@@ -1,0 +1,90 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package telemetry
+
+import (
+	"fmt"
+
+	ccom "github.com/ceph/go-ceph/common/commands"
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+// Admin is used to administer ceph nfs features.
+type Admin struct {
+	conn ccom.RadosCommander
+}
+
+// NewFromConn creates an new management object from a preexisting
+// rados connection. The existing connection can be rados.Conn or any
+// type implementing the RadosCommander interface.
+func NewFromConn(conn ccom.RadosCommander) *Admin {
+	return &Admin{conn}
+}
+
+// Status is the output of "ceph telemetry status"
+type Status struct {
+	ChannelBasic      bool   `json:"Channel_basic"`
+	ChannelCrash      bool   `json:"Channel_crash"`
+	ChannelDevice     bool   `json:"Channel_device"`
+	ChannelIdent      bool   `json:"Channel_ident"`
+	ChannelPerf       bool   `json:"Channel_perf"`
+	Contact           string `json:"Contact"`
+	Description       string `json:"Description"`
+	DeviceURL         string `json:"Device_url"`
+	Enabled           bool   `json:"Enabled"`
+	Interval          int    `json:"Interval"`
+	LastOptRevision   int    `json:"Last_opt_revision"`
+	LastUpload        string `json:"Last_upload"`
+	Leaderboard       bool   `json:"Leaderboard"`
+	LogLevel          string `json:"Log_level"`
+	LogToCluster      bool   `json:"Log_to_cluster"`
+	LogToClusterLevel string `json:"Log_to_cluster_level"`
+	LogToFile         bool   `json:"Log_to_file"`
+	Organization      string `json:"Organization"`
+	Proxy             string `json:"Proxy"`
+	URL               string `json:"Url"`
+}
+
+func parseStatus(res commands.Response) (*Status, error) {
+	m := &Status{}
+	if err := res.NoStatus().Unmarshal(m).End(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// Status returns the output of "ceph telemetry status"
+func (fsa *Admin) Status() (*Status, error) {
+	m := map[string]string{
+		"prefix": "telemetry status",
+		"format": "json",
+	}
+	return parseStatus(commands.MarshalMonCommand(fsa.conn, m))
+}
+
+// Data returns the output of the telemetry module
+// For this is either uses "preview-all" or "show-all"
+//
+//	depending if the module if activated or not
+func (fsa *Admin) Data() ([]byte, error) {
+	status, err := fsa.Status()
+	if err != nil {
+		return nil, err
+	}
+
+	commandArg := "preview"
+	if status.Enabled {
+		commandArg = "show"
+	}
+
+	m := map[string]string{
+		"prefix": fmt.Sprintf("telemetry %s-all", commandArg),
+		"format": "json",
+	}
+	resp := commands.MarshalMonCommand(fsa.conn, m)
+	if resp.Unwrap() != nil {
+		return nil, resp.Unwrap()
+	}
+	return resp.Body(), nil
+}

--- a/common/admin/telemetry/telemetry_test.go
+++ b/common/admin/telemetry/telemetry_test.go
@@ -1,0 +1,125 @@
+//go:build ceph_preview
+// +build ceph_preview
+
+package telemetry
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ceph/go-ceph/internal/admintest"
+)
+
+var radosConnector = admintest.NewConnector()
+
+type TelemetryReport struct {
+	DeviceReport json.RawMessage            `json:"device_report"`
+	Report       map[string]json.RawMessage `json:"report"`
+}
+
+func TestMgrAdmin_GetTelemetryStatus(t *testing.T) {
+	ra := radosConnector.Get(t)
+	admin := NewFromConn(ra)
+
+	tests := []struct {
+		name    string
+		want    *Status
+		wantErr bool
+	}{
+		{
+			name:    "happy Path",
+			want:    &Status{ChannelBasic: true, DeviceURL: "https://telemetry.ceph.com/device", Interval: 24},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := admin.Status()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MgrAdmin.GetTelemetryStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !(got.ChannelBasic == tt.want.ChannelBasic && got.DeviceURL == tt.want.DeviceURL && got.Interval == tt.want.Interval) {
+				// if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MgrAdmin.GetTelemetryStatus() = %+v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMgrAdmin_GetTelemetryData(t *testing.T) {
+	ra := radosConnector.Get(t)
+	admin := NewFromConn(ra)
+
+	// a map container to decode the JSON structure into
+	c := TelemetryReport{
+		DeviceReport: []byte(""),
+		Report:       make(map[string]json.RawMessage),
+	}
+	tests := []struct {
+		// creative name of the test
+		name string
+		// keys we expect in the report
+		wantKeys map[string]interface{}
+		// if we expect this test to error
+		wantErr bool
+	}{
+		{
+			name: "happy Path",
+			wantKeys: map[string]interface{}{
+				"balancer":              true,
+				"channels":              true,
+				"channels_available":    true,
+				"collections_available": true,
+				"collections_opted_in":  true,
+				"config":                true,
+				"crashes":               true,
+				"created":               true,
+				"crush":                 true,
+				"fs":                    true,
+				"hosts":                 true,
+				"leaderboard":           true,
+				"license":               true,
+				"metadata":              true,
+				"mon":                   true,
+				"osd":                   true,
+				"pools":                 true,
+				"rbd":                   true,
+				"report_id":             true,
+				"report_timestamp":      true,
+				"report_version":        true,
+				"rgw":                   true,
+				"rook":                  true,
+				"services":              true,
+				"usage":                 true,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := admin.Data()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MgrAdmin.GetTelemetryData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			e := json.Unmarshal(got, &c)
+			if (e != nil) != tt.wantErr {
+				t.Errorf("Issues when unmarsheling telemetry response into JSON")
+				return
+			} else if (e != nil) == tt.wantErr {
+				t.Logf("Error found as expected: %v", e)
+				return
+			}
+			keys := make(map[string]interface{}, len(c.Report))
+			for key := range c.Report {
+				keys[strings.TrimSpace(key)] = true
+			}
+			if !reflect.DeepEqual(keys, tt.wantKeys) {
+				t.Errorf("MgrAdmin.GetTelemetryData() = %v, want %v", keys, tt.wantKeys)
+			}
+		})
+	}
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2101,5 +2101,27 @@
         "became_stable_version": "v0.18.0"
       }
     ]
+  },
+  "common/admin/telemetry": {
+    "preview_api": [
+      {
+        "name": "NewFromConn",
+        "comment": "NewFromConn creates an new management object from a preexisting\nrados connection. The existing connection can be rados.Conn or any\ntype implementing the RadosCommander interface.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.Status",
+        "comment": "Status returns the output of \"ceph telemetry status\"\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.Data",
+        "comment": "Data returns the output of the telemetry module\nFor this is either uses \"preview-all\" or \"show-all\"\n\n\tdepending if the module if activated or not\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ]
   }
 }

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -82,3 +82,13 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 No Preview/Deprecated APIs found. All APIs are considered stable.
 
+## Package: common/admin/telemetry
+
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+NewFromConn | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.Status | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.Data | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+


### PR DESCRIPTION
  [topic]: Add Telemetry querying

  Adds functions to get the output of `ceph telemetry show-all` or `ceph telemetry preview-all` (depending on the module status)

  Signed-off-by: Chris Blum <cblum@ibm.com>



## Checklist
- [X] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
- [X] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [X] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
