### PR TITLE
Dockerfile: Add missing GOPROXY build argument

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -24,6 +24,8 @@ ARG GO_VERSION=1.19.5
 ENV GO_VERSION=${GO_VERSION}
 ARG GOARCH
 ENV GOARCH=${GOARCH}
+ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 RUN true && \
     gotar=go${GO_VERSION}.linux-${GOARCH}.tar.gz && \
     gourl="https://dl.google.com/go/${gotar}" && \


### PR DESCRIPTION
Previously, commit 102616b15852dac174a071012f945d8522a05265 tried to expose GOPROXY env var from developer environment by specifying it as environment variable or build argument to container build process. But using _--build-arg_ to container build command would require the same to be referenced inside Dockerfile/Containerfile so that the following warning can be avoided:

```
[Warning] one or more build args were not consumed: [GOPROXY]
```
