### PR TITLE
rados: free object list results after listing

### DIFF
--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -332,7 +332,8 @@ func (ioctx *IOContext) ListObjects(listFn ObjectListFunc) error {
 	defer C.rados_object_list_cursor_free(ioctx.ioctx, finish)
 
 	for {
-		ret := C.rados_object_list(ioctx.ioctx, next, finish, pageResults, nil, filterLen, (*C.rados_object_list_item)(unsafe.Pointer(&results[0])), &next)
+		res := (*C.rados_object_list_item)(unsafe.Pointer(&results[0]))
+		ret := C.rados_object_list(ioctx.ioctx, next, finish, pageResults, nil, filterLen, res, &next)
 		if ret < 0 {
 			return getError(ret)
 		}
@@ -342,6 +343,7 @@ func (ioctx *IOContext) ListObjects(listFn ObjectListFunc) error {
 			item := results[i]
 			listFn(C.GoStringN(item.oid, (C.int)(item.oid_length)))
 		}
+		C.rados_object_list_free(C.size_t(ret), res)
 
 		if C.rados_object_list_is_end(ioctx.ioctx, next) == listEndSentinel {
 			return nil


### PR DESCRIPTION
This fixes a memory leak that becomes substantial across large pools.


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
