### PR TITLE
rgw/admin: Add missing uid member to usage struct

### DIFF
--- a/rgw/admin/usage.go
+++ b/rgw/admin/usage.go
@@ -41,6 +41,7 @@ type Usage struct {
 			SuccessfulOps uint64 `json:"successful_ops"`
 		} `json:"total"`
 	} `json:"summary"`
+	UserID      string `url:"uid"`
 	Start       string `url:"start"` //Example:	2012-09-25 16:00:00
 	End         string `url:"end"`
 	ShowEntries *bool  `url:"show-entries"`


### PR DESCRIPTION
## Description
Added the uid member to the usage type.
We don't need to handle the uid here, as the ceph function handles it in the backend.

Fixes: #758

Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [X] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs
