### PR TITLE
cephfs admin: deprecate the New function

### DIFF
--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -21,6 +21,9 @@ type FSAdmin struct {
 // configuration file. If more customization is needed, create a
 // *rados.Conn as you see fit and use NewFromConn to use that
 // connection with these administrative functions.
+//
+// Deprecated: Use NewFromConn instead of New. The New function does not expose
+// the rados connection and therefore can not be deterministically cleaned up.
 func New() (*FSAdmin, error) {
 	conn, err := rados.NewConn()
 	if err != nil {

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -346,10 +346,6 @@
         "comment": "CancelClone stops the background processes that populate a clone.\nCancelClone does not delete the clone.\n\nSimilar To:\n ceph fs clone cancel <volume> --group_name=<group> <clone>\n"
       },
       {
-        "name": "New",
-        "comment": "New creates an FSAdmin automatically based on the default ceph\nconfiguration file. If more customization is needed, create a\n*rados.Conn as you see fit and use NewFromConn to use that\nconnection with these administrative functions.\n"
-      },
-      {
         "name": "NewFromConn",
         "comment": "NewFromConn creates an FSAdmin management object from a preexisting\nrados connection. The existing connection can be rados.Conn or any\ntype implementing the RadosCommander interface. This may be useful\nif the calling layer needs to inject additional logging, error handling,\nfault injection, etc.\n"
       },
@@ -516,7 +512,14 @@
         "became_stable_version": "v0.18.0"
       }
     ],
-    "deprecated_api": [],
+    "deprecated_api": [
+      {
+        "name": "New",
+        "comment": "New creates an FSAdmin automatically based on the default ceph\nconfiguration file. If more customization is needed, create a\n*rados.Conn as you see fit and use NewFromConn to use that\nconnection with these administrative functions.\n\nDeprecated: Use NewFromConn instead of New. The New function does not expose\nthe rados connection and therefore can not be deterministically cleaned up.\n",
+        "deprecated_in_version": "v0.21.0",
+        "expected_remove_version": "v0.24.0"
+      }
+    ],
     "preview_api": [
       {
         "name": "FSAdmin.GetMetadata",

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -323,8 +323,8 @@
       {
         "name": "MountInfo.MakeDirs",
         "comment": "MakeDirs creates multiple directories at once.\n\nImplements:\n\n\tint ceph_mkdirs(struct ceph_mount_info *cmount, const char *path, mode_t mode);\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       }
     ]
   },
@@ -581,20 +581,20 @@
       {
         "name": "FSAdmin.PinSubVolume",
         "comment": "PinSubVolume pins subvolume to ranks according to policies. A valid pin\nsetting value depends on the type of pin as described in the docs from\nhttps://docs.ceph.com/en/latest/cephfs/multimds/#cephfs-pinning and\nhttps://docs.ceph.com/en/latest/cephfs/multimds/#setting-subtree-partitioning-policies\n\nSimilar To:\n\n\tceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting>\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "FSAdmin.PinSubVolumeGroup",
         "comment": "PinSubVolumeGroup pins subvolume to ranks according to policies. A valid pin\nsetting value depends on the type of pin as described in the docs from\nhttps://docs.ceph.com/en/latest/cephfs/multimds/#cephfs-pinning and\nhttps://docs.ceph.com/en/latest/cephfs/multimds/#setting-subtree-partitioning-policies\n\nSimilar To:\n\n\tceph fs subvolumegroup pin <vol_name> <group_name> <pin_type> <pin_setting>\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "FSAdmin.FetchVolumeInfo",
         "comment": "FetchVolumeInfo fetches the information of a CephFS volume.\n\nSimilar To:\n\n\tceph fs volume info <vol_name>\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       }
     ]
   },
@@ -1808,14 +1808,14 @@
       {
         "name": "SiteMirrorImageStatus.UnmarshalDescriptionJSON",
         "comment": "UnmarshalDescriptionJSON parses an embedded JSON string that may be found in\nthe description of the SiteMirrorImageStatus. It will store the result in\nthe value pointed to by v.  If no embedded JSON string is found an\nErrNotExist error is returned. An error may also be returned if the contents\ncan not be parsed.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "SiteMirrorImageStatus.DescriptionReplayStatus",
         "comment": "DescriptionReplayStatus parses a MirrorDescriptionReplayStatus result out of\nthe image status description field if available. If the embedded status JSON\nis not found or fails to parse and error will be returned.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "AddMirrorPeerSite",

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -9,7 +9,7 @@
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 MountInfo.SelectFilesystem | v0.20.0 | v0.22.0 | 
-MountInfo.MakeDirs | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+MountInfo.MakeDirs | v0.21.0 | v0.23.0 | 
 
 ## Package: cephfs/admin
 
@@ -27,9 +27,9 @@ FSAdmin.SetSnapshotMetadata | v0.20.0 | v0.22.0 |
 FSAdmin.RemoveSnapshotMetadata | v0.20.0 | v0.22.0 | 
 FSAdmin.ForceRemoveSnapshotMetadata | v0.20.0 | v0.22.0 | 
 FSAdmin.ListSnapshotMetadata | v0.20.0 | v0.22.0 | 
-FSAdmin.PinSubVolume | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-FSAdmin.PinSubVolumeGroup | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-FSAdmin.FetchVolumeInfo | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+FSAdmin.PinSubVolume | v0.21.0 | v0.23.0 | 
+FSAdmin.PinSubVolumeGroup | v0.21.0 | v0.23.0 | 
+FSAdmin.FetchVolumeInfo | v0.21.0 | v0.23.0 | 
 
 ## Package: rados
 
@@ -47,8 +47,8 @@ MigrationExecute | v0.20.0 | v0.22.0 |
 MigrationCommit | v0.20.0 | v0.22.0 | 
 MigrationAbort | v0.20.0 | v0.22.0 | 
 MigrationStatus | v0.20.0 | v0.22.0 | 
-SiteMirrorImageStatus.UnmarshalDescriptionJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-SiteMirrorImageStatus.DescriptionReplayStatus | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+SiteMirrorImageStatus.UnmarshalDescriptionJSON | v0.21.0 | v0.23.0 | 
+SiteMirrorImageStatus.DescriptionReplayStatus | v0.21.0 | v0.23.0 | 
 AddMirrorPeerSite | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 RemoveMirrorPeerSite | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 GetAttributesMirrorPeerSite | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -31,6 +31,12 @@ FSAdmin.PinSubVolume | v0.21.0 | v0.23.0 |
 FSAdmin.PinSubVolumeGroup | v0.21.0 | v0.23.0 | 
 FSAdmin.FetchVolumeInfo | v0.21.0 | v0.23.0 | 
 
+### Deprecated APIs
+
+Name | Deprecated in Version | Expected Removal Version | 
+---- | --------------------- | ------------------------ | 
+New | v0.21.0 | v0.24.0 | 
+
 ## Package: rados
 
 No Preview/Deprecated APIs found. All APIs are considered stable.


### PR DESCRIPTION
Fixes: #816 

First commit fixes the version numbers in api-status from our recent API additions. I did this before touching the api-status.* to deprecate the New function.

Second commit deprecates the New function.  The New function created a rados connection object but did not expose it via a public api, making it impossible to deterministically sever / clean up the connection. This commit assumes that the patch will be merged prior to the go-ceph v0.21 release so that we can plan to remove the function three versions later (v0.24).  I chose three versions so that it is one release longer than our typical stabilization period as this function has been around for a while.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
