### PR TITLE
docs: fix version numbers of recently added APIs

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1823,50 +1823,50 @@
       {
         "name": "AddMirrorPeerSite",
         "comment": "AddMirrorPeerSite adds a peer site to the list of existing sites.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "RemoveMirrorPeerSite",
         "comment": "RemoveMirrorPeerSite removes the site with the provided uuid.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "GetAttributesMirrorPeerSite",
         "comment": "GetAttributesMirrorPeerSite fetches the list of key,value pair of attributes of a peer site.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "SetAttributesMirrorPeerSite",
         "comment": "SetAttributesMirrorPeerSite sets the attributes for the site with the given uuid.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "ListMirrorPeerSite",
         "comment": "ListMirrorPeerSite returns the list of peer sites.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "SetMirrorPeerSiteClientName",
         "comment": "SetMirrorPeerSiteClientName sets the client name of a mirror peer site.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "SetMirrorPeerSiteName",
         "comment": "SetMirrorPeerSiteName sets the site name of a mirror peer site.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       },
       {
         "name": "SetMirrorPeerSiteDirection",
         "comment": "SetMirrorPeerSiteDirection sets the direction of a mirror peer site.\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.21.0",
+        "expected_stable_version": "v0.23.0"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -55,14 +55,14 @@ MigrationAbort | v0.20.0 | v0.22.0 |
 MigrationStatus | v0.20.0 | v0.22.0 | 
 SiteMirrorImageStatus.UnmarshalDescriptionJSON | v0.21.0 | v0.23.0 | 
 SiteMirrorImageStatus.DescriptionReplayStatus | v0.21.0 | v0.23.0 | 
-AddMirrorPeerSite | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-RemoveMirrorPeerSite | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-GetAttributesMirrorPeerSite | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-SetAttributesMirrorPeerSite | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-ListMirrorPeerSite | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-SetMirrorPeerSiteClientName | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-SetMirrorPeerSiteName | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-SetMirrorPeerSiteDirection | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+AddMirrorPeerSite | v0.21.0 | v0.23.0 | 
+RemoveMirrorPeerSite | v0.21.0 | v0.23.0 | 
+GetAttributesMirrorPeerSite | v0.21.0 | v0.23.0 | 
+SetAttributesMirrorPeerSite | v0.21.0 | v0.23.0 | 
+ListMirrorPeerSite | v0.21.0 | v0.23.0 | 
+SetMirrorPeerSiteClientName | v0.21.0 | v0.23.0 | 
+SetMirrorPeerSiteName | v0.21.0 | v0.23.0 | 
+SetMirrorPeerSiteDirection | v0.21.0 | v0.23.0 | 
 
 ### Deprecated APIs
 


### PR DESCRIPTION
Fix the version numbers of some recently added APIs. I hope to land at least one more PR prior to the release, but it's always nice to have small deltas so I can fix what we've already merged now, and then have a small followup fixing the last batch of apis closer to the reelase.
