### PR TITLE
go-ceph: update README.md for v0.21.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ go test -tags pacific ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.21.0         | pacific, quincy         | nautilus, octopus        |
 | v0.20.0         | pacific, quincy         | nautilus, octopus        |
 | v0.19.0         | pacific, quincy         | nautilus, octopus        |
 | v0.18.0         | octopus, pacific, quincy | nautilus                |


### PR DESCRIPTION
No changes to the supported ceph versions.



## Checklist
n/a

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
