### PR TITLE
cephfs: Add futime cephfs API

### DIFF
--- a/cephfs/file_ops.go
+++ b/cephfs/file_ops.go
@@ -32,3 +32,31 @@ func (mount *MountInfo) Mknod(path string, mode uint16, dev uint16) error {
 	ret := C.ceph_mknod(mount.mount, cPath, C.mode_t(mode), C.dev_t(dev))
 	return getError(ret)
 }
+
+// Utime struct is the equivalent of C.struct_utimbuf
+type Utime struct {
+	// AcTime  represents the file's access time in seconds since the Unix epoch.
+	AcTime int64
+	// ModTime represents the file's modification time in seconds since the Unix epoch.
+	ModTime int64
+}
+
+// Futime changes file/directory last access and modification times.
+//
+// Implements:
+//
+//	int ceph_futime(struct ceph_mount_info *cmount, int fd, struct utimbuf *buf);
+func (mount *MountInfo) Futime(fd int, times *Utime) error {
+	if err := mount.validate(); err != nil {
+		return err
+	}
+
+	cFd := C.int(fd)
+	uTimeBuf := &C.struct_utimbuf{
+		actime:  C.time_t(times.AcTime),
+		modtime: C.time_t(times.ModTime),
+	}
+
+	ret := C.ceph_futime(mount.mount, cFd, uTimeBuf)
+	return getError(ret)
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -331,6 +331,12 @@
         "comment": "Mknod creates a regular, block or character special file.\n\nImplements:\n\n\tint ceph_mknod(struct ceph_mount_info *cmount, const char *path, mode_t mode,\n\t\t\t\t   dev_t rdev);\n",
         "added_in_version": "$NEXT_RELEASE",
         "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MountInfo.Futime",
+        "comment": "Futime changes file/directory last access and modification times.\n\nImplements:\n\n\tint ceph_futime(struct ceph_mount_info *cmount, int fd, struct utimbuf *buf);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -11,6 +11,7 @@ Name | Added in Version | Expected Stable Version |
 MountInfo.SelectFilesystem | v0.20.0 | v0.22.0 | 
 MountInfo.MakeDirs | v0.21.0 | v0.23.0 | 
 MountInfo.Mknod | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+MountInfo.Futime | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: cephfs/admin
 


### PR DESCRIPTION
Added a new cephfs API named `ceph_futime`

Fixes: #252


## Checklist
- [X] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
- [X] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [X] Ran `make api-update` to record new APIs
