### PR TITLE
rbd: Remove redundant LastSeen property from MirrorPeerSite struct

### DIFF
--- a/rbd/mirror_peer_site.go
+++ b/rbd/mirror_peer_site.go
@@ -149,14 +149,15 @@ func SetAttributesMirrorPeerSite(ioctx *rados.IOContext, uuid string, attributes
 	return getError(ret)
 }
 
-// MirrorPeerSite contains information about a mirroring peer site.
+// MirrorPeerSite is go equivalent of rbd_mirror_peer_site_t struct and contains information
+// about a mirroring peer site. Here, we are ignoring the "last_seen" as this property is redundant
+// and not updated in the ceph API. Related Ceph issue: https://tracker.ceph.com/issues/59581
 type MirrorPeerSite struct {
 	UUID       string
 	Direction  MirrorPeerDirection
 	SiteName   string
 	MirrorUUID string
 	ClientName string
-	LastSeen   C.time_t
 }
 
 // ListMirrorPeerSite returns the list of peer sites


### PR DESCRIPTION
**Description:**
Removed the `LastSeen` property of MirrorPeerSite struct as it is not being set/updated anywhere by the ceph API.

Fixes: #870 

Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>