### PR TITLE
cephfs: Add futimens cephfs API

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -337,6 +337,12 @@
         "comment": "Futime changes file/directory last access and modification times.\n\nImplements:\n\n\tint ceph_futime(struct ceph_mount_info *cmount, int fd, struct utimbuf *buf);\n",
         "added_in_version": "$NEXT_RELEASE",
         "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MountInfo.Futimens",
+        "comment": "Futimens changes file/directory last access and modification times, here times param\nis an array of Timespec struct having length 2, where times[0] represents the access time\nand times[1] represents the modification time.\n\nImplements:\n\n\tint ceph_futimens(struct ceph_mount_info *cmount, int fd, struct timespec times[2]);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -12,6 +12,7 @@ MountInfo.SelectFilesystem | v0.20.0 | v0.22.0 |
 MountInfo.MakeDirs | v0.21.0 | v0.23.0 | 
 MountInfo.Mknod | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 MountInfo.Futime | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+MountInfo.Futimens | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: cephfs/admin
 


### PR DESCRIPTION
Added a new cephfs API named `ceph_futimens`

Fixes: #253

Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>

## Checklist
- [X] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
- [X] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [X] Ran `make api-update` to record new APIs

