### PR TITLE
cephfs: Add futimes cephfs API

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -343,6 +343,12 @@
         "comment": "Futimens changes file/directory last access and modification times, here times param\nis an array of Timespec struct having length 2, where times[0] represents the access time\nand times[1] represents the modification time.\n\nImplements:\n\n\tint ceph_futimens(struct ceph_mount_info *cmount, int fd, struct timespec times[2]);\n",
         "added_in_version": "$NEXT_RELEASE",
         "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "MountInfo.Futimes",
+        "comment": "Futimes changes file/directory last access and modification times, here times param\nis an array of Timeval struct type having length 2, where times[0] represents the access time\nand times[1] represents the modification time.\n\nImplements:\n\n\tint ceph_futimes(struct ceph_mount_info *cmount, int fd, struct timeval times[2]);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -13,6 +13,7 @@ MountInfo.MakeDirs | v0.21.0 | v0.23.0 |
 MountInfo.Mknod | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 MountInfo.Futime | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 MountInfo.Futimens | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+MountInfo.Futimes | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: cephfs/admin
 


### PR DESCRIPTION
Added a new cephfs API named `ceph_futimes`

Fixes: #254

Signed-off-by: Nikhil-Ladha <nikhilladha1999@gmail.com>


## Checklist
- [X] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
- [X] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [X] Ran `make api-update` to record new APIs