### PR TITLE
rgw/admin: fix getbucketpolicy api

### DIFF
--- a/rgw/admin/bucket.go
+++ b/rgw/admin/bucket.go
@@ -113,13 +113,13 @@ func (api *API) GetBucketInfo(ctx context.Context, bucket Bucket) (Bucket, error
 	return ref, nil
 }
 
-// GetBucketPolicy - http://docs.ceph.com/docs/mimic/radosgw/adminops/#get-bucket-or-object-policy
+// GetBucketPolicy - https://docs.ceph.com/en/latest/radosgw/adminops/#get-bucket-or-object-policy
 func (api *API) GetBucketPolicy(ctx context.Context, bucket Bucket) (Policy, error) {
 	policy := true
 	bucket.Policy = &policy
 
 	// valid parameters not supported by go-ceph: object
-	body, err := api.call(ctx, http.MethodGet, "/bucket", valueToURLParams(bucket, []string{"bucket"}))
+	body, err := api.call(ctx, http.MethodGet, "/bucket?policy", valueToURLParams(bucket, []string{"bucket"}))
 	if err != nil {
 		return Policy{}, err
 	}

--- a/rgw/admin/bucket_test.go
+++ b/rgw/admin/bucket_test.go
@@ -38,6 +38,17 @@ func (suite *RadosGWTestSuite) TestBucket() {
 		assert.NoError(suite.T(), err)
 	})
 
+	suite.T().Run("get policy non-existing bucket", func(t *testing.T) {
+		_, err := co.GetBucketPolicy(context.Background(), Bucket{Bucket: "foo"})
+		assert.Error(suite.T(), err)
+		assert.True(suite.T(), errors.Is(err, ErrNoSuchKey), err)
+	})
+
+	suite.T().Run("get policy existing bucket", func(t *testing.T) {
+		_, err := co.GetBucketPolicy(context.Background(), Bucket{Bucket: suite.bucketTestName})
+		assert.NoError(suite.T(), err)
+	})
+
 	suite.T().Run("remove bucket", func(t *testing.T) {
 		err := co.RemoveBucket(context.Background(), Bucket{Bucket: suite.bucketTestName})
 		assert.NoError(suite.T(), err)


### PR DESCRIPTION
The request header in GetBucketPolicy(), was not passing policy in its
header, so the response received Bucket than the actual policy.

fixes #882 