### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/cephfs/admin/workflow_test.go
+++ b/cephfs/admin/workflow_test.go
@@ -3,7 +3,7 @@ package admin
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	pathpkg "path"
 	"testing"
@@ -57,7 +57,7 @@ func readFile(t *testing.T, mount *cephfs.MountInfo, path string) []byte {
 	f1, err := mount.Open(path, os.O_RDONLY, 0)
 	require.NoError(t, err)
 	defer f1.Close()
-	b, err := ioutil.ReadAll(f1)
+	b, err := io.ReadAll(f1)
 	require.NoError(t, err)
 	return b
 }

--- a/cephfs/cephfs_test.go
+++ b/cephfs/cephfs_test.go
@@ -3,7 +3,6 @@ package cephfs
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -336,7 +335,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestReadConfigFile(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp", "cephfs.conf")
+	file, err := os.CreateTemp("/tmp", "cephfs.conf")
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, file.Close())

--- a/contrib/implements/internal/implements/gosrc.go
+++ b/contrib/implements/internal/implements/gosrc.go
@@ -8,7 +8,7 @@ import (
 	"go/build/constraint"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -218,7 +218,7 @@ func CephGoFunctions(source, packageName string, ii *Inspector) error {
 	}
 	for _, fname := range toCheck {
 		logger.Printf("Reading go file: %v\n", fname)
-		src, err := ioutil.ReadFile(path.Join(p.Dir, fname))
+		src, err := os.ReadFile(path.Join(p.Dir, fname))
 		if err != nil {
 			return err
 		}

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -3,7 +3,6 @@ package rados
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"sort"
@@ -216,7 +215,7 @@ func (suite *RadosTestSuite) TestReadConfigFile() {
 	assert.NoError(suite.T(), err)
 
 	// create conf file that changes log_file conf option
-	file, err := ioutil.TempFile("/tmp", "go-rados")
+	file, err := os.CreateTemp("/tmp", "go-rados")
 	require.NoError(suite.T(), err)
 	defer func() {
 		assert.NoError(suite.T(), file.Close())

--- a/rgw/admin/radosgw.go
+++ b/rgw/admin/radosgw.go
@@ -3,7 +3,7 @@ package admin
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -98,12 +98,12 @@ func (api *API) call(ctx context.Context, httpMethod, path string, args url.Valu
 	defer resp.Body.Close()
 
 	// Decode HTTP response
-	decodedResponse, err := ioutil.ReadAll(resp.Body)
+	decodedResponse, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(decodedResponse))
+	resp.Body = io.NopCloser(bytes.NewBuffer(decodedResponse))
 
 	// Handle error in response
 	if resp.StatusCode >= 300 {

--- a/rgw/admin/subuser_test.go
+++ b/rgw/admin/subuser_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -57,7 +57,7 @@ func TestCreateSubuserMockAPI(t *testing.T) {
 
 // mockClient is defined in user_test.go
 func returnMockClientCreateSubuser() *mockClient {
-	r := ioutil.NopCloser(bytes.NewReader([]byte("")))
+	r := io.NopCloser(bytes.NewReader([]byte("")))
 	return &mockClient{
 		mockDo: func(req *http.Request) (*http.Response, error) {
 			if req.Method == http.MethodPut && req.URL.Path == "127.0.0.1/admin/user" {

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -248,7 +248,7 @@ func TestGetUserMockAPI(t *testing.T) {
 }
 
 func returnMockClient() *mockClient {
-	r := ioutil.NopCloser(bytes.NewReader(fakeUserResponse))
+	r := io.NopCloser(bytes.NewReader(fakeUserResponse))
 	return &mockClient{
 		mockDo: func(req *http.Request) (*http.Response, error) {
 			if req.Method == http.MethodGet && req.URL.Path == "127.0.0.1/admin/user" {


### PR DESCRIPTION
<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
