### PR TITLE
RGW/admin: add tenant to bucket struct field

### DIFF
--- a/rgw/admin/bucket.go
+++ b/rgw/admin/bucket.go
@@ -11,6 +11,7 @@ import (
 type Bucket struct {
 	Bucket            string  `json:"bucket" url:"bucket"`
 	NumShards         *uint64 `json:"num_shards"`
+	Tenant            string  `json:"tenant"`
 	Zonegroup         string  `json:"zonegroup"`
 	PlacementRule     string  `json:"placement_rule"`
 	ExplicitPlacement struct {


### PR DESCRIPTION
RGW/admin: add tenant to bucket struct field

This change adds a new bucket struct field, so we can use rgw.admin.API.GetBucketInfo() to get a bucket's tenant.

```
$ radosgw-admin bucket stats --bucket "tenant0/qb001"
{
    "bucket": "qb001",
    "num_shards": 11,
    "tenant": "tenant0",
```


Signed-off-by: Dmitry Kvashnin <dm.kvashnin@gmail.com>