### PR TITLE
remove runtime.SetFinalizer

### DIFF
--- a/cephfs/userperm.go
+++ b/cephfs/userperm.go
@@ -8,7 +8,6 @@ package cephfs
 import "C"
 
 import (
-	"runtime"
 	"unsafe"
 
 	"github.com/ceph/go-ceph/internal/log"
@@ -49,11 +48,7 @@ func NewUserPerm(uid, gid int, gidlist []int) *UserPerm {
 	}
 	p.userPerm = C.ceph_userperm_new(
 		p.uid, p.gid, C.int(len(p.gidList)), cgids)
-	// if the go object is unreachable, we would like to free the c-memory
-	// since this has no other resources than memory associated with it.
-	// This is only valid for UserPerm objects created by new, and thus have
-	// the managed var set.
-	runtime.SetFinalizer(p, destroyUserPerm)
+
 	return p
 }
 

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -71,9 +71,6 @@ func (c *Conn) Connect() error {
 
 // Shutdown disconnects from the cluster.
 func (c *Conn) Shutdown() {
-	if err := c.ensureConnected(); err != nil {
-		return
-	}
 	freeConn(c)
 }
 

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -8,7 +8,6 @@ package rados
 import "C"
 
 import (
-	"runtime"
 	"unsafe"
 )
 
@@ -44,7 +43,7 @@ func newGetOmapStep() *GetOmapStep {
 		more: (*C.uchar)(C.malloc(C.sizeof_uchar)),
 		rval: (*C.int)(C.malloc(C.sizeof_int)),
 	}
-	runtime.SetFinalizer(gos, opStepFinalizer)
+
 	return gos
 }
 

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -7,7 +7,6 @@ package rados
 import "C"
 
 import (
-	"runtime"
 	"unsafe"
 
 	"github.com/ceph/go-ceph/internal/log"
@@ -74,7 +73,6 @@ func newConn(user *C.char) (*Conn, error) {
 		return nil, getError(ret)
 	}
 
-	runtime.SetFinalizer(conn, freeConn)
 	return conn, nil
 }
 
@@ -107,7 +105,6 @@ func NewConnWithClusterAndUser(clusterName string, userName string) (*Conn, erro
 		return nil, getError(ret)
 	}
 
-	runtime.SetFinalizer(conn, freeConn)
 	return conn, nil
 }
 


### PR DESCRIPTION
I believe this fixes https://github.com/ceph/go-ceph/issues/904

I did exact same tests in that issue (more actually) and memory usage is ~200MB, down from 1100MB.

I did some research on `runtime.SetFinalizer` and it should not be used for "large" objects, has no guarantees on being called, and if not done properly will not free memory properly, and is considered a "hack" for code that doesnt cleanup properly (closing connections, etc). It also has a significant performance hit when the GC runs, and tells the GC to keep track of the code, but that doesnt really make sense when there are destroy/shutdown/close functions right?

In the bug that I reported I had only done about 30 concurrent copies of a 2Gi image, this resulted in 1.1G of RSS; memory was never freed. I have done 90+ concurrent copies of a 2Gi image and memory usage stays around 210M RSS; so I believe this PR fixes.