### PR TITLE
rbd: include details for parent image in the trash

### DIFF
--- a/rbd/snapshot_nautilus.go
+++ b/rbd/snapshot_nautilus.go
@@ -67,8 +67,12 @@ func (image *Image) GetParentInfo(pool, name, snapname []byte) error {
 
 // ImageSpec represents the image information.
 type ImageSpec struct {
-	ImageName string
-	PoolName  string
+	ImageName     string
+	ImageID       string
+	PoolName      string
+	PoolNamespace string
+	PoolID        uint64
+	Trash         bool
 }
 
 // SnapSpec represents the snapshot infomation.
@@ -104,8 +108,12 @@ func (image *Image) GetParent() (*ParentInfo, error) {
 	defer C.rbd_snap_spec_cleanup(&parentSnap)
 
 	imageSpec := ImageSpec{
-		ImageName: C.GoString(parentImage.image_name),
-		PoolName:  C.GoString(parentImage.pool_name),
+		ImageName:     C.GoString(parentImage.image_name),
+		ImageID:       C.GoString(parentImage.image_id),
+		PoolName:      C.GoString(parentImage.pool_name),
+		PoolNamespace: C.GoString(parentImage.pool_namespace),
+		PoolID:        uint64(parentImage.pool_id),
+		Trash:         bool(parentImage.trash),
 	}
 
 	snapSpec := SnapSpec{


### PR DESCRIPTION
When a parent image has been removed, it will linger in the trash until all siblings are gone. The image is not accessible through it's name anymore, only through its ID.

The ImageSpec that is returned by Image.GetParent() now contains the Trash boolean and the ImageID to identify if the image is in the trash, and use OpenImageById() to access the removed parent image.

Related-to: ceph/ceph-csi#4013

## Checklist
- [x] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs
