### PR TITLE
go-ceph: add Ceph Reef CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,10 @@ jobs:
         - "octopus"
         - "pacific"
         - "quincy"
+        - "reef"
         - "pre-pacific"
         - "pre-quincy"
+        - "pre-reef"
         - "main"
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,6 @@ jobs:
         - "pacific"
         - "quincy"
         - "reef"
-        - "pre-pacific"
         - "pre-quincy"
         - "pre-reef"
         - "main"

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ endif
 ifeq ($(CEPH_VERSION),quincy)
 	CEPH_TAG := v17
 endif
+ifeq ($(CEPH_VERSION),reef)
+	CEPH_TAG := v18
+endif
 # pre-<codename> indicates we want to consume pre-release versions of ceph from
 # the ceph ci. This way we can start testing on ceph versions before they hit
 # quay.io/ceph/ceph
@@ -43,6 +46,12 @@ ifeq ($(CEPH_VERSION),pre-pacific)
 	CEPH_IMG := quay.ceph.io/ceph-ci/ceph
 	GO_CEPH_VERSION := pacific
 	BUILD_TAGS := pacific,ceph_pre_pacific
+endif
+ifeq ($(CEPH_VERSION),pre-reef)
+	CEPH_TAG := reef
+	CEPH_IMG := quay.ceph.io/ceph-ci/ceph
+	GO_CEPH_VERSION := reef
+	BUILD_TAGS := reef,ceph_pre_reef
 endif
 ifeq ($(CEPH_VERSION),main)
 	CEPH_TAG := main

--- a/cephfs/admin/fsadmin_test.go
+++ b/cephfs/admin/fsadmin_test.go
@@ -22,12 +22,13 @@ const (
 	cephOctopus  = "octopus"
 	cephPacfic   = "pacific"
 	cephQuincy   = "quincy"
+	cephReef     = "reef"
 	cephMain     = "main"
 )
 
 func init() {
 	switch vname := os.Getenv("CEPH_VERSION"); vname {
-	case cephNautilus, cephOctopus, cephPacfic, cephQuincy, cephMain:
+	case cephNautilus, cephOctopus, cephPacfic, cephQuincy, cephReef, cephMain:
 		serverVersion = vname
 	}
 }
@@ -43,7 +44,7 @@ func TestServerSentinel(t *testing.T) {
 	// server version it expects and force us to update the tests if a new
 	// version of ceph is added.
 	if serverVersion == "" {
-		t.Fatalf("server must be nautilus, octopus, pacific, or quincy (do the tests need updating?)")
+		t.Fatalf("server must be nautilus, octopus, pacific, quincy, or reef (do the tests need updating?)")
 	}
 }
 


### PR DESCRIPTION
With the Ceph Reef release imminent, we're a bit overdue to add it to our CI. However, the risk of being a little late is lowered by the fact that we have our tests regularly running against ceph main branch.

However, once the release is done the divergence between the two will increase over time and so I think it's good to get this done soon.