### PR TITLE
containers: workaround for ganesha package error on reef

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -11,7 +11,7 @@ ENV GO_CEPH_VERSION=${GO_CEPH_VERSION:-$CEPH_VERSION}
 RUN true && \
     echo "Check: [ ${CEPH_VERSION} = ${GO_CEPH_VERSION} ]" && \
     [ "${CEPH_VERSION}" = "${GO_CEPH_VERSION}" ] && \
-    yum update -y && \
+    yum update -y --disablerepo=ganesha && \
     cv="$(rpm -q --queryformat '%{version}-%{release}' ceph-common)" && \
     yum install -y \
     git wget curl make \


### PR DESCRIPTION
Currently the tests on the released reef image fails due to an RPM transaction error when updating nfs-ganesha. Since go-ceph doesn't need ganesha packages to be up-to-date to ensure that lib{cephfs,rados,rbd}-devel are installed we _temporarily_ disable ganesha repo when running yum update.

See also, discussion in #910 

Testing infra only change.