### PR TITLE
workflows: enable stale bot for PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,5 +13,8 @@ jobs:
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 14 days if no further activity occurs. Thank you for your contribution.'
         days-before-stale: 30
         days-before-close: 14
-        only-labels: 'question'
-
+        only-issue-labels: 'question'
+        stale-pr-message: 'This Pull Request has been automatically marked as stale because it has not had recent activity. It will be closed in 21 days if no further activity occurs. Remember, a closed PR can always be reopened. Thank you for your contribution.'
+        close-pr-message: 'This Pull Request has been automatically closed due to inactivity. In the future, if you resume working on this again, the PR can be reopened. Additionally, if you are proposing a feature or fix that you think someone else could take up - please say so - and if there is no existing issue already, file an issue for the topic. Thank you for your contribution.'
+        days-before-pr-stale: 60
+        days-before-pr-close: 21


### PR DESCRIPTION
Enable stale bot to mark PRs stale and eventually close stale PRs. I had tried to manually do this in the past with nice comments but I forget to do it and trying to be nice was unrewarding. I find a bunch of old PRs in the list a distraction and don't want to have to think about them or try to follow up on them. I want to be generous to PR authors so PRs can be inactive for 60 days and one has 3 weeks to unstale the PR.


Workflows only change.