### PR TITLE
workflows: Move actions/checkout before actions/setup-go

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,10 @@ jobs:
     needs: go-versions
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
         go-version: ${{ needs.go-versions.outputs.latest }}
-    - uses: actions/checkout@v3
     - name: Install revive
       run: go install github.com/mgechev/revive@latest
     - name: Run checks


### PR DESCRIPTION
By placing actions/checkout before actions/setup-go(as suggested in https://github.com/actions/setup-go/issues/281) we could avoid the following warning message:

> Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/go-ceph/go-ceph. Supported file pattern: go.sum

fixes #917 