### PR TITLE
rbd: Fix global image status listing

### DIFF
--- a/rbd/mirror.go
+++ b/rbd/mirror.go
@@ -717,7 +717,7 @@ func mirrorImageGlobalStatusList(
 	}
 	for i := 0; i < int(length); i++ {
 		results[i].ID = C.GoString(ids[i])
-		results[i].Status = newGlobalMirrorImageStatus(&images[0])
+		results[i].Status = newGlobalMirrorImageStatus(&images[i])
 	}
 	C.rbd_mirror_image_global_status_list_cleanup(
 		&ids[0],

--- a/rbd/mirror_test.go
+++ b/rbd/mirror_test.go
@@ -882,6 +882,7 @@ func TestMirrorImageLists(t *testing.T) {
 		assert.Len(t, lst, 10)
 		for i := 1; i < len(lst); i++ {
 			assert.NotEqual(t, lst[i-1].ID, lst[i].ID)
+			assert.NotEqual(t, lst[i-1].Status.Info.GlobalID, lst[i].Status.Info.GlobalID)
 		}
 		for i := 1; i <= iterBufSize; i++ {
 			lst, err := MirrorImageGlobalStatusList(ioctx, "", i)


### PR DESCRIPTION
Running `MirrorImageGlobalStatusList` returns a slice of `GlobalMirrorImageIDAndStatus`. The IDs are all different, however, the `GlobalMirrorImageStatus` is set to the 1st one for each image. This makes the status data inaccurate for every image after the 1st, including the image's name, GlobalID, and mirror status.