### PR TITLE
API updates

### DIFF
--- a/cephfs/admin/fsadmin.go
+++ b/cephfs/admin/fsadmin.go
@@ -17,29 +17,6 @@ type FSAdmin struct {
 	conn RadosCommander
 }
 
-// New creates an FSAdmin automatically based on the default ceph
-// configuration file. If more customization is needed, create a
-// *rados.Conn as you see fit and use NewFromConn to use that
-// connection with these administrative functions.
-//
-// Deprecated: Use NewFromConn instead of New. The New function does not expose
-// the rados connection and therefore can not be deterministically cleaned up.
-func New() (*FSAdmin, error) {
-	conn, err := rados.NewConn()
-	if err != nil {
-		return nil, err
-	}
-	err = conn.ReadDefaultConfigFile()
-	if err != nil {
-		return nil, err
-	}
-	err = conn.Connect()
-	if err != nil {
-		return nil, err
-	}
-	return NewFromConn(conn), nil
-}
-
 // NewFromConn creates an FSAdmin management object from a preexisting
 // rados connection. The existing connection can be rados.Conn or any
 // type implementing the RadosCommander interface. This may be useful

--- a/cephfs/file_ops.go
+++ b/cephfs/file_ops.go
@@ -1,5 +1,5 @@
-//go:build !nautilus && ceph_preview
-// +build !nautilus,ceph_preview
+//go:build !nautilus
+// +build !nautilus
 
 package cephfs
 

--- a/cephfs/file_ops_test.go
+++ b/cephfs/file_ops_test.go
@@ -1,5 +1,5 @@
-//go:build !nautilus && ceph_preview
-// +build !nautilus,ceph_preview
+//go:build !nautilus
+// +build !nautilus
 
 package cephfs
 

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1894,40 +1894,39 @@
         "comment": "SparsifyWithProgress makes an image sparse by deallocating runs of zeros.\nThe sparseSize value will be used to find runs of zeros and must be\na power of two no less than 4096 and no larger than the image size.\nThe given progress callback will be called to report on the progress\nof sparse. The operation will be aborted if the progress callback returns\na non-zero value.\n\nImplements:\n\n\tint rbd_sparsify_with_progress(rbd_image_t image, size_t sparse_size,\n\t\t\t\t\t\t\t\t   librbd_progress_fn_t cb, void *cbdata);\n",
         "added_in_version": "v0.21.0",
         "became_stable_version": "v0.23.0"
-      }
-    ],
-    "preview_api": [
+      },
       {
         "name": "Image.LockAcquire",
         "comment": "LockAcquire takes a lock on the given image as per the provided lock_mode.\n\nImplements:\n\n\tint rbd_lock_acquire(rbd_image_t image, rbd_lock_mode_t lock_mode);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       },
       {
         "name": "Image.LockBreak",
         "comment": "LockBreak breaks the lock of lock_mode on the provided lock_owner.\n\nImplements:\n\n\tint rbd_lock_break(rbd_image_t image, rbd_lock_mode_t lock_mode,\n\t\t\t\t\t   const char *lock_owner);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       },
       {
         "name": "Image.LockGetOwners",
         "comment": "LockGetOwners fetches the list of lock owners.\n\nImplements:\n\n\tint rbd_lock_get_owners(rbd_image_t image, rbd_lock_mode_t *lock_mode,\n\t\t\t\t\t\t\tchar **lock_owners, size_t *max_lock_owners);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       },
       {
         "name": "Image.LockIsExclusiveOwner",
         "comment": "LockIsExclusiveOwner gets the status of the image exclusive lock.\n\nImplements:\n\n\tint rbd_is_exclusive_lock_owner(rbd_image_t image, int *is_owner);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       },
       {
         "name": "Image.LockRelease",
         "comment": "LockRelease releases a lock on the image.\n\nImplements:\n\n\tint rbd_lock_release(rbd_image_t image);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       }
-    ]
+    ],
+    "preview_api": []
   },
   "rbd/admin": {
     "stable_api": [

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -323,34 +323,33 @@
         "comment": "MakeDirs creates multiple directories at once.\n\nImplements:\n\n\tint ceph_mkdirs(struct ceph_mount_info *cmount, const char *path, mode_t mode);\n",
         "added_in_version": "v0.21.0",
         "became_stable_version": "v0.23.0"
-      }
-    ],
-    "preview_api": [
+      },
       {
         "name": "MountInfo.Mknod",
         "comment": "Mknod creates a regular, block or character special file.\n\nImplements:\n\n\tint ceph_mknod(struct ceph_mount_info *cmount, const char *path, mode_t mode,\n\t\t\t\t   dev_t rdev);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       },
       {
         "name": "MountInfo.Futime",
         "comment": "Futime changes file/directory last access and modification times.\n\nImplements:\n\n\tint ceph_futime(struct ceph_mount_info *cmount, int fd, struct utimbuf *buf);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       },
       {
         "name": "MountInfo.Futimens",
         "comment": "Futimens changes file/directory last access and modification times, here times param\nis an array of Timespec struct having length 2, where times[0] represents the access time\nand times[1] represents the modification time.\n\nImplements:\n\n\tint ceph_futimens(struct ceph_mount_info *cmount, int fd, struct timespec times[2]);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       },
       {
         "name": "MountInfo.Futimes",
         "comment": "Futimes changes file/directory last access and modification times, here times param\nis an array of Timeval struct type having length 2, where times[0] represents the access time\nand times[1] represents the modification time.\n\nImplements:\n\n\tint ceph_futimes(struct ceph_mount_info *cmount, int fd, struct timeval times[2]);\n",
         "added_in_version": "v0.22.0",
-        "expected_stable_version": "v0.24.0"
+        "became_stable_version": "v0.24.0"
       }
-    ]
+    ],
+    "preview_api": []
   },
   "cephfs/admin": {
     "stable_api": [

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -613,14 +613,7 @@
         "became_stable_version": "v0.23.0"
       }
     ],
-    "deprecated_api": [
-      {
-        "name": "New",
-        "comment": "New creates an FSAdmin automatically based on the default ceph\nconfiguration file. If more customization is needed, create a\n*rados.Conn as you see fit and use NewFromConn to use that\nconnection with these administrative functions.\n\nDeprecated: Use NewFromConn instead of New. The New function does not expose\nthe rados connection and therefore can not be deterministically cleaned up.\n",
-        "deprecated_in_version": "v0.21.0",
-        "expected_remove_version": "v0.24.0"
-      }
-    ],
+    "deprecated_api": [],
     "preview_api": []
   },
   "rados": {

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -27,16 +27,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rbd
 
-### Preview APIs
-
-Name | Added in Version | Expected Stable Version | 
----- | ---------------- | ----------------------- | 
-Image.LockAcquire | v0.22.0 | v0.24.0 | 
-Image.LockBreak | v0.22.0 | v0.24.0 | 
-Image.LockGetOwners | v0.22.0 | v0.24.0 | 
-Image.LockIsExclusiveOwner | v0.22.0 | v0.24.0 | 
-Image.LockRelease | v0.22.0 | v0.24.0 | 
-
 ### Deprecated APIs
 
 Name | Deprecated in Version | Expected Removal Version | 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -4,14 +4,7 @@
 
 ## Package: cephfs
 
-### Preview APIs
-
-Name | Added in Version | Expected Stable Version | 
----- | ---------------- | ----------------------- | 
-MountInfo.Mknod | v0.22.0 | v0.24.0 | 
-MountInfo.Futime | v0.22.0 | v0.24.0 | 
-MountInfo.Futimens | v0.22.0 | v0.24.0 | 
-MountInfo.Futimes | v0.22.0 | v0.24.0 | 
+No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: cephfs/admin
 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -8,11 +8,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: cephfs/admin
 
-### Deprecated APIs
-
-Name | Deprecated in Version | Expected Removal Version | 
----- | --------------------- | ------------------------ | 
-New | v0.21.0 | v0.24.0 | 
+No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rados
 

--- a/rbd/locks.go
+++ b/rbd/locks.go
@@ -1,5 +1,5 @@
-//go:build !nautilus && ceph_preview
-// +build !nautilus,ceph_preview
+//go:build !nautilus
+// +build !nautilus
 
 package rbd
 

--- a/rbd/locks_test.go
+++ b/rbd/locks_test.go
@@ -1,5 +1,5 @@
-//go:build !nautilus && ceph_preview
-// +build !nautilus,ceph_preview
+//go:build !nautilus
+// +build !nautilus
 
 package rbd
 


### PR DESCRIPTION
Fixes #928 

Prepare for the v0.24 release with a batch of API updates. This includes the removal of cephfs admin `New` method.