### PR TITLE
docs: update readme supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ go test -tags pacific ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.24.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.23.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.22.0         | pacific, quincy         | nautilus, octopus        |
 | v0.21.0         | pacific, quincy         | nautilus, octopus        |

--- a/README.md
+++ b/README.md
@@ -81,32 +81,13 @@ go test -tags pacific ....
 | v0.19.0         | pacific, quincy         | nautilus, octopus        |
 | v0.18.0         | octopus, pacific, quincy | nautilus                |
 | v0.17.0         | octopus, pacific, quincy | nautilus                |
-| v0.16.0         | octopus, pacific†       | nautilus                 |
-| v0.15.0         | octopus, pacific        | nautilus                 |
-| v0.14.0         | octopus, pacific        | nautilus                 |
-| v0.13.0         | octopus, pacific        | nautilus                 |
-| v0.12.0         | octopus, pacific        | nautilus                 |
-| v0.11.0         | nautilus, octopus, pacific  |                      |
-| v0.10.0         | nautilus, octopus, pacific  |                      |
-| v0.9.0          | nautilus, octopus       |                          |
-| v0.8.0          | nautilus, octopus       |                          |
-| v0.7.0          | nautilus, octopus       |                          |
-| v0.6.0          | nautilus, octopus       | mimic                    |
-| v0.5.0          | nautilus, octopus       | luminous, mimic          |
-| v0.4.0          | luminous, mimic, nautilus, octopus | |
-| v0.3.0          | luminous, mimic, nautilus, octopus | |
-| v0.2.0          | luminous, mimic, nautilus          | |
-| (pre release)   | luminous, mimic  (see note)        | |
 
-These tags affect what is supported at compile time. What version of the Ceph
+The tags affect what is supported at compile time. What version of the Ceph
 cluster the client libraries support, and vice versa, is determined entirely
 by what version of the Ceph C libraries go-ceph is compiled with.
 
-† Preliminary support for Ceph Quincy was available, but not fully tested, in
-this release.
-
-NOTE: Prior to 2020 the project did not make versioned releases. The ability to
-compile with a particular Ceph version before go-ceph v0.2.0 is not guaranteed.
+To see what older versions of go-ceph supported refer to the [older
+releases](./docs/older-releases.md) file in the documentation.
 
 
 ## Documentation

--- a/docs/older-releases.md
+++ b/docs/older-releases.md
@@ -1,0 +1,36 @@
+
+### Historical Supported Ceph Versions
+
+For recent releases, please refer to the [readme](../README.md).
+
+The following tables describes what versions of Ceph were supported for
+particular go-ceph releases. Note that prior to 2020 the project did not make
+versioned releases. The ability to compile with a particular Ceph version
+before go-ceph v0.2.0 is not guaranteed.
+
+| go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
+| --------------- | ------------------------| -------------------------|
+| v0.16.0         | octopus, pacific†       | nautilus                 |
+| v0.15.0         | octopus, pacific        | nautilus                 |
+| v0.14.0         | octopus, pacific        | nautilus                 |
+| v0.13.0         | octopus, pacific        | nautilus                 |
+| v0.12.0         | octopus, pacific        | nautilus                 |
+| v0.11.0         | nautilus, octopus, pacific  |                      |
+| v0.10.0         | nautilus, octopus, pacific  |                      |
+| v0.9.0          | nautilus, octopus       |                          |
+| v0.8.0          | nautilus, octopus       |                          |
+| v0.7.0          | nautilus, octopus       |                          |
+| v0.6.0          | nautilus, octopus       | mimic                    |
+| v0.5.0          | nautilus, octopus       | luminous, mimic          |
+| v0.4.0          | luminous, mimic, nautilus, octopus | |
+| v0.3.0          | luminous, mimic, nautilus, octopus | |
+| v0.2.0          | luminous, mimic, nautilus          | |
+| (pre release)   | luminous, mimic  (see note)        | |
+
+The tags affect what is supported at compile time. What version of the Ceph
+cluster the client libraries support, and vice versa, is determined entirely
+by what version of the Ceph C libraries go-ceph is compiled with.
+
+† Preliminary support for Ceph Quincy was available, but not fully tested, in
+this release.
+


### PR DESCRIPTION
In additition to updating the readme I decided to truncate the table and move the older items to a new historical doc. 
