### PR TITLE
internal: use runtime.Pinner in PtrGuard

### DIFF
--- a/internal/cutil/ptrguard_pinner.go
+++ b/internal/cutil/ptrguard_pinner.go
@@ -1,28 +1,26 @@
-//go:build !go1.21
-// +build !go1.21
-
-// This code assumes a non-moving garbage collector, which is the case until at
-// least go 1.20
+//go:build go1.21
+// +build go1.21
 
 package cutil
 
 import (
+	"runtime"
 	"unsafe"
 )
 
 // PtrGuard respresents a guarded Go pointer (pointing to memory allocated by Go
 // runtime) stored in C memory (allocated by C)
 type PtrGuard struct {
-	cPtr  CPtr
-	goPtr unsafe.Pointer
+	cPtr   CPtr
+	pinner runtime.Pinner
 }
 
 // NewPtrGuard writes the goPtr (pointing to Go memory) into C memory at the
 // position cPtr, and returns a PtrGuard object.
 func NewPtrGuard(cPtr CPtr, goPtr unsafe.Pointer) *PtrGuard {
 	var v PtrGuard
+	v.pinner.Pin(goPtr)
 	v.cPtr = cPtr
-	v.goPtr = goPtr
 	p := (*unsafe.Pointer)(unsafe.Pointer(cPtr))
 	*p = goPtr
 	return &v
@@ -33,5 +31,5 @@ func NewPtrGuard(cPtr CPtr, goPtr unsafe.Pointer) *PtrGuard {
 func (v *PtrGuard) Release() {
 	p := (*unsafe.Pointer)(unsafe.Pointer(v.cPtr))
 	*p = nil
-	v.goPtr = nil
+	v.pinner.Unpin()
 }

--- a/internal/cutil/ptrguard_test.go
+++ b/internal/cutil/ptrguard_test.go
@@ -36,15 +36,9 @@ func TestPtrGuard(t *testing.T) {
 		assert.Zero(t, *(*unsafe.Pointer)(cPtr))
 	})
 
-	t.Run("uintptrescapesTest", func(t *testing.T) {
-		// This test assures that the special //go:uintptrescapes comment before
-		// the storeUntilRelease() function works as intended, that is the
-		// garbage collector doesn't touch the object referenced by the uintptr
-		// until the function returns after Release() is called. The test will
-		// fail if the //go:uintptrescapes comment is disabled (removed) or
-		// stops working in future versions of go.
+	t.Run("keepsReachable", func(t *testing.T) {
 		var pgDone, uDone bool
-		var goPtr = func(b *bool) unsafe.Pointer {
+		goPtr := func(b *bool) unsafe.Pointer {
 			s := "ok"
 			runtime.SetFinalizer(&s, func(p *string) { *b = true })
 			return unsafe.Pointer(&s)


### PR DESCRIPTION
Since Go 1.21 there is a runtime.Pinner API that allows to safely pass structures with embedded Go pointers to C code.  In earlier Go version we know that the garbage collector is non-moving, so it is safe to pass Go pointers to C as well. This change adds two implementations of PtrGuard, one for pre 1.21 that is basically a no-op, and one for 1.21+ that uses runtime.Pinner.
