### PR TITLE
rgw/admin: Add support for /info section

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1993,7 +1993,14 @@
     ]
   },
   "rgw/admin": {
-    "preview_api": [],
+    "preview_api": [
+      {
+        "name": "API.GetInfo",
+        "comment": "GetInfo - https://docs.ceph.com/en/latest/radosgw/adminops/#info\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ],
     "stable_api": [
       {
         "name": "API.ListBuckets",

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -30,7 +30,11 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rgw/admin
 
-No Preview/Deprecated APIs found. All APIs are considered stable.
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+API.GetInfo | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: common/admin/manager
 

--- a/micro-osd.sh
+++ b/micro-osd.sh
@@ -164,6 +164,10 @@ launch_radosgw() {
     radosgw-admin user create --uid admin --display-name "Admin User" --caps "buckets=*;users=*;usage=read;metadata=read" --access-key="$S3_ACCESS_KEY" --secret-key="$S3_SECRET_KEY"
 }
 
+launch_radosgw2() {
+    radosgw-admin caps add --uid=admin --caps="info=read"
+}
+
 selftest() {
     ceph --version
     ceph status
@@ -183,8 +187,11 @@ if [ -z "$FEATURESET" ] ; then
         nautilus|octopus)
             FEATURESET="mon osd mgr mds rbd-mirror rgw selftest"
         ;;
-        *)
+        pacific)
             FEATURESET="mon osd mgr mds mds2 rbd-mirror cephfs-mirror rgw selftest"
+        ;;
+        *)
+            FEATURESET="mon osd mgr mds mds2 rbd-mirror cephfs-mirror rgw rgw2 selftest"
         ;;
     esac
 fi
@@ -200,6 +207,7 @@ for fname in ${FEATURESET} ; do
         rbd-mirror) launch_rbd_mirror ;;
         cephfs-mirror) launch_cephfs_mirror ;;
         rgw|radosgw) launch_radosgw ;;
+        rgw2|radosgw2) launch_radosgw2 ;;
         selftest) selftest ;;
         *)
             echo "Invalid feature: ${fname}"

--- a/rgw/admin/info.go
+++ b/rgw/admin/info.go
@@ -1,0 +1,39 @@
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// StorageBackend struct
+type StorageBackend struct {
+	Name      string `json:"name"`
+	ClusterID string `json:"cluster_id"`
+}
+
+// Info struct
+type Info struct {
+	InfoSpec struct {
+		StorageBackends []StorageBackend `json:"storage_backends"`
+	} `json:"info"`
+}
+
+// GetInfo - https://docs.ceph.com/en/latest/radosgw/adminops/#info
+func (api *API) GetInfo(ctx context.Context) (Info, error) {
+	body, err := api.call(ctx, http.MethodGet, "/info", nil)
+	if err != nil {
+		return Info{}, err
+	}
+	i := Info{}
+	err = json.Unmarshal(body, &i)
+	if err != nil {
+		return Info{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+	}
+
+	return i, nil
+}

--- a/rgw/admin/info_test.go
+++ b/rgw/admin/info_test.go
@@ -1,0 +1,57 @@
+//go:build !(nautilus || octopus || pacific) && ceph_preview
+// +build !nautilus,!octopus,!pacific,ceph_preview
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/ceph/go-ceph/rados"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func radosConnect(t *testing.T) *rados.Conn {
+	conn, err := rados.NewConn()
+	require.NoError(t, err)
+	err = conn.ReadDefaultConfigFile()
+	require.NoError(t, err)
+	waitForRadosConn(t, conn)
+	return conn
+}
+
+func waitForRadosConn(t *testing.T, conn *rados.Conn) {
+	var err error
+	timeout := time.After(time.Second * 15)
+	ch := make(chan error)
+	go func(conn *rados.Conn) {
+		ch <- conn.Connect()
+	}(conn)
+	select {
+	case err = <-ch:
+	case <-timeout:
+		err = fmt.Errorf("timed out waiting for connect")
+	}
+	require.NoError(t, err)
+}
+
+func (suite *RadosGWTestSuite) TestGetInfo() {
+	suite.SetupConnection()
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
+	assert.NoError(suite.T(), err)
+
+	suite.T().Run("test get rgw cluster/endpoint information", func(t *testing.T) {
+		info, err := co.GetInfo(context.Background())
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), "rados", info.InfoSpec.StorageBackends[0].Name)
+		conn := radosConnect(suite.T())
+		fsid, err := conn.GetFSID()
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), fsid, info.InfoSpec.StorageBackends[0].ClusterID)
+		conn.Shutdown()
+	})
+}


### PR DESCRIPTION
## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

based on https://github.com/ceph/go-ceph/pull/616