### PR TITLE
rgw/admin: add creation time to bucket

### DIFF
--- a/rgw/admin/bucket.go
+++ b/rgw/admin/bucket.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 // Bucket describes an object store bucket
@@ -19,15 +20,16 @@ type Bucket struct {
 		DataExtraPool string `json:"data_extra_pool"`
 		IndexPool     string `json:"index_pool"`
 	} `json:"explicit_placement"`
-	ID        string `json:"id"`
-	Marker    string `json:"marker"`
-	IndexType string `json:"index_type"`
-	Owner     string `json:"owner"`
-	Ver       string `json:"ver"`
-	MasterVer string `json:"master_ver"`
-	Mtime     string `json:"mtime"`
-	MaxMarker string `json:"max_marker"`
-	Usage     struct {
+	ID           string     `json:"id"`
+	Marker       string     `json:"marker"`
+	IndexType    string     `json:"index_type"`
+	Owner        string     `json:"owner"`
+	Ver          string     `json:"ver"`
+	MasterVer    string     `json:"master_ver"`
+	Mtime        string     `json:"mtime"`
+	CreationTime *time.Time `json:"creation_time"`
+	MaxMarker    string     `json:"max_marker"`
+	Usage        struct {
 		RgwMain struct {
 			Size           *uint64 `json:"size"`
 			SizeActual     *uint64 `json:"size_actual"`


### PR DESCRIPTION
The API endpoint for bucket stats includes a `creation_time` field which is not included in the `admin.Bucket` struct. This simply adds the field.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
