### PR TITLE
cephfs: made ENOENT a public error

### DIFF
--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -54,6 +54,8 @@ const (
 	// ErrNotConnected may be returned when client is not connected
 	// to a cluster.
 	ErrNotConnected = cephFSError(-C.ENOTCONN)
+	// ErrNotExist indicates a non-specific missing resource.
+	ErrNotExist = cephFSError(-C.ENOENT)
 )
 
 // Private errors:
@@ -61,6 +63,5 @@ const (
 const (
 	errInvalid     = cephFSError(-C.EINVAL)
 	errNameTooLong = cephFSError(-C.ENAMETOOLONG)
-	errNoEntry     = cephFSError(-C.ENOENT)
 	errRange       = cephFSError(-C.ERANGE)
 )

--- a/cephfs/path_test.go
+++ b/cephfs/path_test.go
@@ -53,7 +53,7 @@ func TestRemoveDir(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = mount.Statx(dirname, StatxBasicStats, 0)
-	assert.Equal(t, err, errNoEntry)
+	assert.Equal(t, err, ErrNotExist)
 }
 
 func TestLink(t *testing.T) {
@@ -367,7 +367,7 @@ func TestStatx(t *testing.T) {
 		st, err = mount.Statx(dirname, StatxBasicStats, 0)
 		assert.Error(t, err)
 		assert.Nil(t, st)
-		assert.Equal(t, errNoEntry, err)
+		assert.Equal(t, ErrNotExist, err)
 	})
 
 	t.Run("invalidMount", func(t *testing.T) {


### PR DESCRIPTION
this commit renames ErrNoEntry of cephfs
to ErrNotExist and making it public allowing
other projects to access this.

Signed-off-by: Riya Singhal <rsinghal@redhat.com>
 