### PR TITLE
CI: enable and collect core dumps in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,11 +76,15 @@ jobs:
           go_version: ${{ needs.go-versions.outputs.unstable }}
     steps:
     - uses: actions/checkout@v4
+    - name: Set cores to get stored as "core"
+      run:  sudo bash -c 'echo "core" > /proc/sys/kernel/core_pattern'
     - name: Run tests
       run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "GO_VERSION=${{ matrix.go_version }}" "RESULTS_DIR=$PWD/_results"
     - name: Clean up test containers
+      if: always()
       run: make test-containers-clean "CEPH_VERSION=${{ matrix.ceph_version }}"
     - name: Archive test results
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: "go-ceph-results-${{ matrix.ceph_version }}-${{ matrix.go_version }}"
@@ -88,6 +92,7 @@ jobs:
           _results/
         retention-days: 30
     - name: Check API Versions and Aging
+      if: always()
       run: |
         if [ -f _results/implements.json ]; then
           ./contrib/apiage.py

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -16,7 +16,8 @@ RUN true && \
     yum install -y \
     git wget curl make \
     /usr/bin/cc /usr/bin/c++ \
-    "libcephfs-devel-${cv}" "librados-devel-${cv}" "librbd-devel-${cv}" && \
+    "libcephfs-devel-${cv}" "librados-devel-${cv}" "librbd-devel-${cv}" \
+    gdb libcephfs2-debuginfo librados2-debuginfo librbd1-debuginfo && \
     yum clean all && \
     true
 


### PR DESCRIPTION
This change enables core dumps. If a core dump is created, its backtrace is logged with gdb and it is put into the artifacts together with the test executable.

To see it in action, see #923, which creates a core dump and is based on this PR.