### PR TITLE
rgw/admin: Add support for user bucket quota

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2006,6 +2006,18 @@
         "comment": "GetInfo - https://docs.ceph.com/en/latest/radosgw/adminops/#info\n",
         "added_in_version": "v0.25.0",
         "expected_stable_version": "v0.27.0"
+      },
+      {
+        "name": "API.GetBucketQuota",
+        "comment": "GetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#get-bucket-quota\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "API.SetBucketQuota",
+        "comment": "SetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#set-bucket-quota\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ],
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -41,6 +41,8 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 API.GetInfo | v0.25.0 | v0.27.0 | 
+API.GetBucketQuota | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+API.SetBucketQuota | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: common/admin/manager
 

--- a/rgw/admin/user_bucket_quota.go
+++ b/rgw/admin/user_bucket_quota.go
@@ -1,0 +1,50 @@
+//go:build ceph_preview
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// GetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#get-bucket-quota
+func (api *API) GetBucketQuota(ctx context.Context, quota QuotaSpec) (QuotaSpec, error) {
+	// Always for bucket quota type
+	quota.QuotaType = "bucket"
+
+	if quota.UID == "" {
+		return QuotaSpec{}, errMissingUserID
+	}
+
+	body, err := api.call(ctx, http.MethodGet, "/user?quota", valueToURLParams(quota, []string{"uid", "quota-type"}))
+	if err != nil {
+		return QuotaSpec{}, err
+	}
+
+	ref := QuotaSpec{}
+	err = json.Unmarshal(body, &ref)
+	if err != nil {
+		return QuotaSpec{}, fmt.Errorf("%s. %s. %w", unmarshalError, string(body), err)
+	}
+
+	return ref, nil
+}
+
+// SetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#set-bucket-quota
+func (api *API) SetBucketQuota(ctx context.Context, quota QuotaSpec) error {
+	// Always for bucket quota type
+	quota.QuotaType = "bucket"
+
+	if quota.UID == "" {
+		return errMissingUserID
+	}
+
+	_, err := api.call(ctx, http.MethodPut, "/user?quota", valueToURLParams(quota, []string{"uid", "quota-type", "enabled", "max-size", "max-size-kb", "max-objects"}))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/rgw/admin/user_bucket_quota_test.go
+++ b/rgw/admin/user_bucket_quota_test.go
@@ -1,0 +1,50 @@
+//go:build ceph_preview
+
+package admin
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosGWTestSuite) TestUserBucketQuota() {
+	suite.SetupConnection()
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
+	assert.NoError(suite.T(), err)
+
+	usercaps := "users=read"
+	_, err = co.CreateUser(context.Background(), User{ID: "leseb", DisplayName: "This is leseb", Email: "leseb@example.com", UserCaps: usercaps})
+	assert.NoError(suite.T(), err)
+	defer func() {
+		err = co.RemoveUser(context.Background(), User{ID: "leseb"})
+		assert.NoError(suite.T(), err)
+	}()
+
+	suite.T().Run("set bucket quota without uid", func(t *testing.T) {
+		err := co.SetBucketQuota(context.Background(), QuotaSpec{})
+		assert.Error(suite.T(), err)
+		assert.EqualError(suite.T(), err, errMissingUserID.Error())
+	})
+
+	suite.T().Run("set bucket quota", func(t *testing.T) {
+		maxObjects := int64(101)
+		err := co.SetBucketQuota(context.Background(), QuotaSpec{UID: "leseb", MaxObjects: &maxObjects})
+		assert.NoError(suite.T(), err)
+	})
+
+	suite.T().Run("get bucket quota without uid", func(t *testing.T) {
+		_, err := co.GetBucketQuota(context.Background(), QuotaSpec{})
+		assert.Error(suite.T(), err)
+		assert.EqualError(suite.T(), err, errMissingUserID.Error())
+	})
+
+	suite.T().Run("get bucket quota", func(t *testing.T) {
+		q, err := co.GetBucketQuota(context.Background(), QuotaSpec{UID: "leseb"})
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), int64(101), *q.MaxObjects)
+		assert.Equal(suite.T(), false, *q.Enabled)
+	})
+}


### PR DESCRIPTION
Following APIs have been added to set and get bucket quotas for users.
- _SetBucketQuota_
- _GetBucketQuota_

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

Credits: [Pavel Boev](https://github.com/R4scal)