### PR TITLE
Code Lint: Fix lint errors caused by revive check for unused parameters

### DIFF
--- a/cephfs/userperm_test.go
+++ b/cephfs/userperm_test.go
@@ -25,7 +25,7 @@ func TestUserPerm(t *testing.T) {
 		uperm.Destroy()
 		uperm.Destroy()
 	})
-	t.Run("tryForceGc", func(t *testing.T) {
+	t.Run("tryForceGc", func(_ *testing.T) {
 		func() {
 			uperm := NewUserPerm(0, 0, nil)
 			_ = uperm

--- a/internal/cutil/command_input_test.go
+++ b/internal/cutil/command_input_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCommandInput(t *testing.T) {
-	t.Run("newAndFree", func(t *testing.T) {
+	t.Run("newAndFree", func(_ *testing.T) {
 		ci := NewCommandInput(
 			[][]byte{[]byte("foobar")},
 			nil)

--- a/internal/cutil/ptrguard_test.go
+++ b/internal/cutil/ptrguard_test.go
@@ -40,7 +40,7 @@ func TestPtrGuard(t *testing.T) {
 		var pgDone, uDone bool
 		goPtr := func(b *bool) unsafe.Pointer {
 			s := "ok"
-			runtime.SetFinalizer(&s, func(p *string) { *b = true })
+			runtime.SetFinalizer(&s, func(_ *string) { *b = true })
 			return unsafe.Pointer(&s)
 		}
 		cPtr := Malloc(PtrSize)

--- a/internal/retry/sizer_test.go
+++ b/internal/retry/sizer_test.go
@@ -60,7 +60,7 @@ func TestSizer(t *testing.T) {
 	t.Run("exceedsMax", func(t *testing.T) {
 		var tries int
 		var err error
-		WithSizes(1, 1024, func(size int) Hint {
+		WithSizes(1, 1024, func(_ int) Hint {
 			tries++
 			err = errors.New("foo")
 			return DoubleSize

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -1054,7 +1054,7 @@ func (suite *RadosTestSuite) TestListAcrossNamespaces() {
 	// count objects in pool
 	suite.ioctx.SetNamespace(AllNamespaces)
 	allFoundObjects := 0
-	err = suite.ioctx.ListObjects(func(oid string) {
+	err = suite.ioctx.ListObjects(func(_ string) {
 		allFoundObjects++
 	})
 	assert.NoError(suite.T(), err)
@@ -1289,14 +1289,14 @@ func (suite *RadosTestSuite) TestSetGetNamespace() {
 		assert.Equal(t, "space1", ns)
 	})
 
-	suite.T().Run("allNamespaces", func(t *testing.T) {
+	suite.T().Run("allNamespaces", func(_ *testing.T) {
 		suite.ioctx.SetNamespace(AllNamespaces)
 		ns, err := suite.ioctx.GetNamespace()
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), AllNamespaces, ns)
 	})
 
-	suite.T().Run("invalidIoctx", func(t *testing.T) {
+	suite.T().Run("invalidIoctx", func(_ *testing.T) {
 		i := &IOContext{}
 		ns, err := i.GetNamespace()
 		assert.Error(suite.T(), err)

--- a/rbd/diff_iterate_test.go
+++ b/rbd/diff_iterate_test.go
@@ -46,7 +46,7 @@ func TestDiffIterate(t *testing.T) {
 			DiffIterateConfig{
 				Offset: 0,
 				Length: uint64(1 << 22),
-				Callback: func(o, l uint64, e int, x interface{}) int {
+				Callback: func(_, _ uint64, _ int, _ interface{}) int {
 					gotCalled++
 					return 0
 				},
@@ -111,7 +111,7 @@ func testDiffIterateBasic(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -127,7 +127,7 @@ func testDiffIterateBasic(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -146,7 +146,7 @@ func testDiffIterateBasic(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -167,7 +167,7 @@ func testDiffIterateBasic(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -190,7 +190,7 @@ func testDiffIterateBasic(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -256,7 +256,7 @@ func testDiffIterateTwoAtOnce(t *testing.T, ioctx *rados.IOContext) {
 			DiffIterateConfig{
 				Offset: 0,
 				Length: isize,
-				Callback: func(o, l uint64, e int, x interface{}) int {
+				Callback: func(o, l uint64, _ int, _ interface{}) int {
 					time.Sleep(8 * time.Millisecond)
 					calls = append(calls, diResult{offset: o, length: l})
 					return 0
@@ -326,7 +326,7 @@ func testDiffIterateEarlyExit(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				if o > 1 {
 					return -5
 				}
@@ -372,7 +372,7 @@ func testDiffIterateSnapshot(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -389,7 +389,7 @@ func testDiffIterateSnapshot(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -411,7 +411,7 @@ func testDiffIterateSnapshot(t *testing.T, ioctx *rados.IOContext) {
 			SnapName: "ss1",
 			Offset:   0,
 			Length:   isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -438,7 +438,7 @@ func testDiffIterateSnapshot(t *testing.T, ioctx *rados.IOContext) {
 			SnapName: "ss1",
 			Offset:   0,
 			Length:   isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
 				calls = append(calls, diResult{offset: o, length: l})
 				return 0
 			},
@@ -481,7 +481,7 @@ func testDiffIterateCallbackData(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, x interface{}) int {
 				if v, ok := x.(int); ok {
 					assert.EqualValues(t, 77, v)
 				} else {
@@ -503,7 +503,7 @@ func testDiffIterateCallbackData(t *testing.T, ioctx *rados.IOContext) {
 		DiffIterateConfig{
 			Offset: 0,
 			Length: isize,
-			Callback: func(o, l uint64, e int, x interface{}) int {
+			Callback: func(o, l uint64, _ int, x interface{}) int {
 				if v, ok := x.(string); ok {
 					assert.EqualValues(t, "bob", v)
 				} else {

--- a/rbd/group_snap_test.go
+++ b/rbd/group_snap_test.go
@@ -186,7 +186,7 @@ func TestGroupSnapshots(t *testing.T) {
 		assert.NoError(t, err)
 
 		cc := 0
-		cb := func(offset, total uint64, v interface{}) int {
+		cb := func(_, total uint64, v interface{}) int {
 			cc++
 			val := v.(int)
 			assert.Equal(t, 0, val)
@@ -234,7 +234,7 @@ func TestGroupSnapshots(t *testing.T) {
 			GroupSnapRollback(nil, gname, "foo")
 		})
 		assert.Panics(t, func() {
-			cb := func(o, t uint64, v interface{}) int { return 0 }
+			cb := func(_, _ uint64, _ interface{}) int { return 0 }
 			GroupSnapRollbackWithProgress(nil, gname, "foo", cb, nil)
 		})
 	})

--- a/rbd/resize_test.go
+++ b/rbd/resize_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestImageResize2(t *testing.T) {
 	cc := 0
-	cb := func(offset, total uint64, v interface{}) int {
+	cb := func(_, total uint64, v interface{}) int {
 		cc++
 		val := v.(int)
 		assert.Equal(t, 0, val)

--- a/rbd/sparsify_test.go
+++ b/rbd/sparsify_test.go
@@ -34,7 +34,7 @@ func TestSparsifyWithProgress(t *testing.T) {
 		defer func() { assert.NoError(t, img.Close()) }()
 
 		cc := 0
-		cb := func(offset, total uint64, v interface{}) int {
+		cb := func(_, total uint64, v interface{}) int {
 			cc++
 			val := v.(int)
 			assert.Equal(t, 0, val)
@@ -53,7 +53,7 @@ func TestSparsifyWithProgress(t *testing.T) {
 		defer func() { assert.NoError(t, img.Close()) }()
 
 		cc := 0
-		cb := func(offset, total uint64, v interface{}) int {
+		cb := func(_, total uint64, v interface{}) int {
 			cc++
 			val := v.(int)
 			assert.Equal(t, 0, val)
@@ -71,7 +71,7 @@ func TestSparsifyWithProgress(t *testing.T) {
 		assert.NoError(t, img.Close())
 
 		cc := 0
-		cb := func(offset, total uint64, v interface{}) int {
+		cb := func(_, total uint64, v interface{}) int {
 			cc++
 			val := v.(int)
 			assert.Equal(t, 0, val)

--- a/rbd/watchers_test.go
+++ b/rbd/watchers_test.go
@@ -143,7 +143,7 @@ func TestWatch(t *testing.T) {
 		err = image.Close()
 		require.NoError(t, err)
 
-		_, err = image.UpdateWatch(func(d interface{}) {
+		_, err = image.UpdateWatch(func(_ interface{}) {
 		}, nil)
 		assert.Equal(t, ErrImageNotOpen, err)
 	})
@@ -158,7 +158,7 @@ func TestWatch(t *testing.T) {
 		}()
 
 		cc := 0
-		w, err := image.UpdateWatch(func(d interface{}) {
+		w, err := image.UpdateWatch(func(_ interface{}) {
 			cc++
 		}, nil)
 		assert.NoError(t, err)
@@ -232,7 +232,7 @@ func TestWatchMultiChannels(t *testing.T) {
 		defer func() {
 			assert.NoError(t, img.Close())
 		}()
-		w, err := img.UpdateWatch(func(d interface{}) {
+		w, err := img.UpdateWatch(func(_ interface{}) {
 			mon <- n
 		}, nil)
 		require.NoError(t, err)

--- a/rgw/admin/bucket_quota_test.go
+++ b/rgw/admin/bucket_quota_test.go
@@ -21,19 +21,19 @@ func (suite *RadosGWTestSuite) TestBucketQuota() {
 	err = s3.createBucket(suite.bucketTestName)
 	assert.NoError(suite.T(), err)
 
-	suite.T().Run("set bucket quota but no user is specified", func(t *testing.T) {
+	suite.T().Run("set bucket quota but no user is specified", func(_ *testing.T) {
 		err := co.SetIndividualBucketQuota(context.Background(), QuotaSpec{})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("set bucket quota but no bucket is specified", func(t *testing.T) {
+	suite.T().Run("set bucket quota but no bucket is specified", func(_ *testing.T) {
 		err := co.SetIndividualBucketQuota(context.Background(), QuotaSpec{UID: "admin"})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserBucket.Error())
 	})
 
-	suite.T().Run("set bucket quota", func(t *testing.T) {
+	suite.T().Run("set bucket quota", func(_ *testing.T) {
 		err := co.SetIndividualBucketQuota(context.Background(), QuotaSpec{UID: "admin", Bucket: suite.bucketTestName, MaxSizeKb: &testBucketQuota})
 		assert.NoError(suite.T(), err)
 

--- a/rgw/admin/bucket_test.go
+++ b/rgw/admin/bucket_test.go
@@ -21,46 +21,46 @@ func (suite *RadosGWTestSuite) TestBucket() {
 	err = s3.createBucket(suite.bucketTestName)
 	assert.NoError(suite.T(), err)
 
-	suite.T().Run("list buckets", func(t *testing.T) {
+	suite.T().Run("list buckets", func(_ *testing.T) {
 		buckets, err := co.ListBuckets(context.Background())
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 1, len(buckets))
 	})
 
-	suite.T().Run("info non-existing bucket", func(t *testing.T) {
+	suite.T().Run("info non-existing bucket", func(_ *testing.T) {
 		_, err := co.GetBucketInfo(context.Background(), Bucket{Bucket: "foo"})
 		assert.Error(suite.T(), err)
 		assert.True(suite.T(), errors.Is(err, ErrNoSuchBucket), err)
 	})
 
-	suite.T().Run("info existing bucket", func(t *testing.T) {
+	suite.T().Run("info existing bucket", func(_ *testing.T) {
 		_, err := co.GetBucketInfo(context.Background(), Bucket{Bucket: suite.bucketTestName})
 		assert.NoError(suite.T(), err)
 	})
 
-	suite.T().Run("get policy non-existing bucket", func(t *testing.T) {
+	suite.T().Run("get policy non-existing bucket", func(_ *testing.T) {
 		_, err := co.GetBucketPolicy(context.Background(), Bucket{Bucket: "foo"})
 		assert.Error(suite.T(), err)
 		assert.True(suite.T(), errors.Is(err, ErrNoSuchKey), err)
 	})
 
-	suite.T().Run("get policy existing bucket", func(t *testing.T) {
+	suite.T().Run("get policy existing bucket", func(_ *testing.T) {
 		_, err := co.GetBucketPolicy(context.Background(), Bucket{Bucket: suite.bucketTestName})
 		assert.NoError(suite.T(), err)
 	})
 
-	suite.T().Run("remove bucket", func(t *testing.T) {
+	suite.T().Run("remove bucket", func(_ *testing.T) {
 		err := co.RemoveBucket(context.Background(), Bucket{Bucket: suite.bucketTestName})
 		assert.NoError(suite.T(), err)
 	})
 
-	suite.T().Run("list bucket is now zero", func(t *testing.T) {
+	suite.T().Run("list bucket is now zero", func(_ *testing.T) {
 		buckets, err := co.ListBuckets(context.Background())
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 0, len(buckets))
 	})
 
-	suite.T().Run("remove non-existing bucket", func(t *testing.T) {
+	suite.T().Run("remove non-existing bucket", func(_ *testing.T) {
 		err := co.RemoveBucket(context.Background(), Bucket{Bucket: "foo"})
 		assert.Error(suite.T(), err)
 		if util.CurrentCephVersion() <= util.CephOctopus {

--- a/rgw/admin/caps_test.go
+++ b/rgw/admin/caps_test.go
@@ -13,27 +13,27 @@ func (suite *RadosGWTestSuite) TestCaps() {
 	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 
 	assert.NoError(suite.T(), err)
-	suite.T().Run("create test user", func(t *testing.T) {
+	suite.T().Run("create test user", func(_ *testing.T) {
 		user, err := co.CreateUser(context.Background(), User{ID: "test", DisplayName: "test-user", Email: "test@example.com"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "test", user.ID)
 		assert.Zero(suite.T(), len(user.Caps))
 	})
 
-	suite.T().Run("add caps to the user but user ID is empty", func(t *testing.T) {
+	suite.T().Run("add caps to the user but user ID is empty", func(_ *testing.T) {
 		_, err := co.AddUserCap(context.Background(), "", "users=read")
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("add caps to the user but no cap is specified", func(t *testing.T) {
+	suite.T().Run("add caps to the user but no cap is specified", func(_ *testing.T) {
 		_, err := co.AddUserCap(context.Background(), "test", "")
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserCap.Error())
 
 	})
 
-	suite.T().Run("add caps to the user, returns success", func(t *testing.T) {
+	suite.T().Run("add caps to the user, returns success", func(_ *testing.T) {
 		usercap, err := co.AddUserCap(context.Background(), "test", "users=read")
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "users", usercap[0].Type)
@@ -41,26 +41,26 @@ func (suite *RadosGWTestSuite) TestCaps() {
 
 	})
 
-	suite.T().Run("remove caps from the user but user ID is empty", func(t *testing.T) {
+	suite.T().Run("remove caps from the user but user ID is empty", func(_ *testing.T) {
 		_, err := co.RemoveUserCap(context.Background(), "", "users=read")
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("remove caps from the user but no cap is specified", func(t *testing.T) {
+	suite.T().Run("remove caps from the user but no cap is specified", func(_ *testing.T) {
 		_, err := co.RemoveUserCap(context.Background(), "test", "")
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserCap.Error())
 
 	})
 
-	suite.T().Run("remove caps from the user returns success", func(t *testing.T) {
+	suite.T().Run("remove caps from the user returns success", func(_ *testing.T) {
 		usercap, err := co.RemoveUserCap(context.Background(), "test", "users=read")
 		assert.NoError(suite.T(), err)
 		assert.Zero(suite.T(), len(usercap))
 	})
 
-	suite.T().Run("delete test user", func(t *testing.T) {
+	suite.T().Run("delete test user", func(_ *testing.T) {
 		err := co.RemoveUser(context.Background(), User{ID: "test"})
 		assert.NoError(suite.T(), err)
 	})

--- a/rgw/admin/info_test.go
+++ b/rgw/admin/info_test.go
@@ -44,7 +44,7 @@ func (suite *RadosGWTestSuite) TestGetInfo() {
 	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 	assert.NoError(suite.T(), err)
 
-	suite.T().Run("test get rgw cluster/endpoint information", func(t *testing.T) {
+	suite.T().Run("test get rgw cluster/endpoint information", func(_ *testing.T) {
 		info, err := co.GetInfo(context.Background())
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "rados", info.InfoSpec.StorageBackends[0].Name)

--- a/rgw/admin/keys_test.go
+++ b/rgw/admin/keys_test.go
@@ -19,49 +19,49 @@ func (suite *RadosGWTestSuite) TestKeys() {
 
 	var keys *[]UserKeySpec
 
-	suite.T().Run("create keys but user ID and SubUser is empty", func(t *testing.T) {
+	suite.T().Run("create keys but user ID and SubUser is empty", func(_ *testing.T) {
 		_, err := co.CreateKey(context.Background(), UserKeySpec{})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("create swift keys but SubUser is empty", func(t *testing.T) {
+	suite.T().Run("create swift keys but SubUser is empty", func(_ *testing.T) {
 		_, err := co.CreateKey(context.Background(), UserKeySpec{KeyType: "swift"})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingSubuserID.Error())
 	})
 
-	suite.T().Run("create some unknown key type", func(t *testing.T) {
+	suite.T().Run("create some unknown key type", func(_ *testing.T) {
 		_, err := co.CreateKey(context.Background(), UserKeySpec{KeyType: "some-key-type"})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errUnsupportedKeyType.Error())
 	})
 
-	suite.T().Run("create keys without ak or sk provided", func(t *testing.T) {
+	suite.T().Run("create keys without ak or sk provided", func(_ *testing.T) {
 		keys, err = co.CreateKey(context.Background(), UserKeySpec{UID: "admin"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 2, len(*keys))
 	})
 
-	suite.T().Run("create keys with ak provided", func(t *testing.T) {
+	suite.T().Run("create keys with ak provided", func(_ *testing.T) {
 		keys, err = co.CreateKey(context.Background(), UserKeySpec{UID: "admin", AccessKey: testAk})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 3, len(*keys))
 	})
 
-	suite.T().Run("remove keys but user ID and SubUser is empty", func(t *testing.T) {
+	suite.T().Run("remove keys but user ID and SubUser is empty", func(_ *testing.T) {
 		err := co.RemoveKey(context.Background(), UserKeySpec{})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("remove s3 keys but ak is empty", func(t *testing.T) {
+	suite.T().Run("remove s3 keys but ak is empty", func(_ *testing.T) {
 		err := co.RemoveKey(context.Background(), UserKeySpec{UID: "admin"})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserAccessKey.Error())
 	})
 
-	suite.T().Run("remove s3 key", func(t *testing.T) {
+	suite.T().Run("remove s3 key", func(_ *testing.T) {
 		for _, key := range *keys {
 			if key.AccessKey != suite.accessKey {
 				err := co.RemoveKey(context.Background(), UserKeySpec{UID: "admin", AccessKey: key.AccessKey})

--- a/rgw/admin/link_test.go
+++ b/rgw/admin/link_test.go
@@ -13,7 +13,7 @@ func (suite *RadosGWTestSuite) TestLink() {
 	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 	assert.NoError(suite.T(), err)
 
-	suite.T().Run("create test user1", func(t *testing.T) {
+	suite.T().Run("create test user1", func(_ *testing.T) {
 		user, err := co.CreateUser(context.Background(), User{ID: "test-user1", DisplayName: "test-user1", Email: "test1@example.com"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "test-user1", user.ID)
@@ -28,7 +28,7 @@ func (suite *RadosGWTestSuite) TestLink() {
 		assert.NoError(t, err)
 	})
 
-	suite.T().Run("create test user2", func(t *testing.T) {
+	suite.T().Run("create test user2", func(_ *testing.T) {
 		user, err := co.CreateUser(context.Background(), User{ID: "test-user2", DisplayName: "test-user2", Email: "test2@example.com"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "test-user2", user.ID)
@@ -62,17 +62,17 @@ func (suite *RadosGWTestSuite) TestLink() {
 		assert.NoError(t, err)
 	})
 
-	suite.T().Run("remove bucket", func(t *testing.T) {
+	suite.T().Run("remove bucket", func(_ *testing.T) {
 		err := co.RemoveBucket(context.Background(), Bucket{Bucket: suite.bucketTestName})
 		assert.NoError(suite.T(), err)
 	})
 
-	suite.T().Run("delete test user1", func(t *testing.T) {
+	suite.T().Run("delete test user1", func(_ *testing.T) {
 		err := co.RemoveUser(context.Background(), User{ID: "test-user1"})
 		assert.NoError(suite.T(), err)
 	})
 
-	suite.T().Run("delete test user2", func(t *testing.T) {
+	suite.T().Run("delete test user2", func(_ *testing.T) {
 		err := co.RemoveUser(context.Background(), User{ID: "test-user2"})
 		assert.NoError(suite.T(), err)
 	})

--- a/rgw/admin/list_bucket_with_stats_test.go
+++ b/rgw/admin/list_bucket_with_stats_test.go
@@ -2,9 +2,10 @@ package admin
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func (suite *RadosGWTestSuite) TestListBucketsWithStat() {
@@ -18,7 +19,7 @@ func (suite *RadosGWTestSuite) TestListBucketsWithStat() {
 	err = s3.createBucket(suite.bucketTestName)
 	assert.NoError(suite.T(), err)
 
-	suite.T().Run("list buckets with stat", func(t *testing.T) {
+	suite.T().Run("list buckets with stat", func(_ *testing.T) {
 		buckets, err := co.ListBucketsWithStat(context.Background())
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 1, len(buckets))

--- a/rgw/admin/quota_test.go
+++ b/rgw/admin/quota_test.go
@@ -13,13 +13,13 @@ func (suite *RadosGWTestSuite) TestQuota() {
 	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 	assert.NoError(suite.T(), err)
 
-	suite.T().Run("set quota to user but user ID is empty", func(t *testing.T) {
+	suite.T().Run("set quota to user but user ID is empty", func(_ *testing.T) {
 		err := co.SetUserQuota(context.Background(), QuotaSpec{})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("get user quota but no user is specified", func(t *testing.T) {
+	suite.T().Run("get user quota but no user is specified", func(_ *testing.T) {
 		_, err := co.GetUserQuota(context.Background(), QuotaSpec{})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())

--- a/rgw/admin/usage_test.go
+++ b/rgw/admin/usage_test.go
@@ -20,7 +20,7 @@ func (suite *RadosGWTestSuite) TestUsage() {
 		assert.NotEmpty(t, usage)
 	})
 
-	suite.T().Run("trim usage", func(t *testing.T) {
+	suite.T().Run("trim usage", func(_ *testing.T) {
 		pFalse := false
 		_, err := co.GetUsage(context.Background(), Usage{RemoveAll: &pFalse})
 		assert.NoError(suite.T(), err)

--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -26,7 +26,7 @@ type User struct {
 	UserQuota           QuotaSpec      `json:"user_quota"`
 	TempURLKeys         []interface{}  `json:"temp_url_keys"`
 	Type                string         `json:"type"`
-	MfaIds              []interface{}  `json:"mfa_ids"`
+	MfaIDs              []interface{}  `json:"mfa_ids"`
 	KeyType             string         `url:"key-type"`
 	Tenant              string         `url:"tenant"`
 	GenerateKey         *bool          `url:"generate-key"`

--- a/rgw/admin/user_bucket_quota_test.go
+++ b/rgw/admin/user_bucket_quota_test.go
@@ -23,25 +23,25 @@ func (suite *RadosGWTestSuite) TestUserBucketQuota() {
 		assert.NoError(suite.T(), err)
 	}()
 
-	suite.T().Run("set bucket quota without uid", func(t *testing.T) {
+	suite.T().Run("set bucket quota without uid", func(_ *testing.T) {
 		err := co.SetBucketQuota(context.Background(), QuotaSpec{})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("set bucket quota", func(t *testing.T) {
+	suite.T().Run("set bucket quota", func(_ *testing.T) {
 		maxObjects := int64(101)
 		err := co.SetBucketQuota(context.Background(), QuotaSpec{UID: "leseb", MaxObjects: &maxObjects})
 		assert.NoError(suite.T(), err)
 	})
 
-	suite.T().Run("get bucket quota without uid", func(t *testing.T) {
+	suite.T().Run("get bucket quota without uid", func(_ *testing.T) {
 		_, err := co.GetBucketQuota(context.Background(), QuotaSpec{})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("get bucket quota", func(t *testing.T) {
+	suite.T().Run("get bucket quota", func(_ *testing.T) {
 		q, err := co.GetBucketQuota(context.Background(), QuotaSpec{UID: "leseb"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(101), *q.MaxObjects)

--- a/rgw/admin/user_bucket_test.go
+++ b/rgw/admin/user_bucket_test.go
@@ -20,31 +20,31 @@ func (suite *RadosGWTestSuite) TestUserBucket() {
 	err = s3.createBucket(suite.bucketTestName)
 	assert.NoError(suite.T(), err)
 
-	suite.T().Run("list empty user's buckets", func(t *testing.T) {
+	suite.T().Run("list empty user's buckets", func(_ *testing.T) {
 		_, err := co.ListUsersBuckets(context.Background(), "")
 		assert.Error(suite.T(), err)
 		assert.True(suite.T(), errors.Is(err, errMissingUserID), err)
 	})
 
-	suite.T().Run("list user's buckets", func(t *testing.T) {
+	suite.T().Run("list user's buckets", func(_ *testing.T) {
 		buckets, err := co.ListUsersBuckets(context.Background(), "admin")
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 1, len(buckets))
 	})
 
-	suite.T().Run("list unknown user's buckets", func(t *testing.T) {
+	suite.T().Run("list unknown user's buckets", func(_ *testing.T) {
 		buckets, err := co.ListUsersBuckets(context.Background(), "foo")
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 0, len(buckets))
 	})
 
-	suite.T().Run("list empty user's buckets with stat", func(t *testing.T) {
+	suite.T().Run("list empty user's buckets with stat", func(_ *testing.T) {
 		_, err := co.ListUsersBucketsWithStat(context.Background(), "")
 		assert.Error(suite.T(), err)
 		assert.True(suite.T(), errors.Is(err, errMissingUserID), err)
 	})
 
-	suite.T().Run("list user's buckets with stat", func(t *testing.T) {
+	suite.T().Run("list user's buckets with stat", func(_ *testing.T) {
 		buckets, err := co.ListUsersBucketsWithStat(context.Background(), "admin")
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 1, len(buckets))
@@ -55,7 +55,7 @@ func (suite *RadosGWTestSuite) TestUserBucket() {
 		assert.NotNil(suite.T(), b.BucketQuota.MaxSize)
 	})
 
-	suite.T().Run("list unknown user's buckets with stat", func(t *testing.T) {
+	suite.T().Run("list unknown user's buckets with stat", func(_ *testing.T) {
 		buckets, err := co.ListUsersBucketsWithStat(context.Background(), "foo")
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 0, len(buckets))

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -93,26 +93,26 @@ func (suite *RadosGWTestSuite) TestUser() {
 	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
 	assert.NoError(suite.T(), err)
 
-	suite.T().Run("fail to create user since no UID provided", func(t *testing.T) {
+	suite.T().Run("fail to create user since no UID provided", func(_ *testing.T) {
 		_, err = co.CreateUser(context.Background(), User{Email: "leseb@example.com"})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserID.Error())
 	})
 
-	suite.T().Run("fail to create user since no no display name provided", func(t *testing.T) {
+	suite.T().Run("fail to create user since no no display name provided", func(_ *testing.T) {
 		_, err = co.CreateUser(context.Background(), User{ID: "leseb", Email: "leseb@example.com"})
 		assert.Error(suite.T(), err)
 		assert.EqualError(suite.T(), err, errMissingUserDisplayName.Error())
 	})
 
-	suite.T().Run("user creation success", func(t *testing.T) {
+	suite.T().Run("user creation success", func(_ *testing.T) {
 		usercaps := "users=read"
 		user, err := co.CreateUser(context.Background(), User{ID: "leseb", DisplayName: "This is leseb", Email: "leseb@example.com", UserCaps: usercaps})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@example.com", user.Email)
 	})
 
-	suite.T().Run("get user leseb by uid", func(t *testing.T) {
+	suite.T().Run("get user leseb by uid", func(_ *testing.T) {
 		user, err := co.GetUser(context.Background(), User{ID: "leseb"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@example.com", user.Email)
@@ -121,20 +121,20 @@ func (suite *RadosGWTestSuite) TestUser() {
 		os.Setenv("LESEB_ACCESS_KEY", user.Keys[0].AccessKey)
 	})
 
-	suite.T().Run("get user leseb by key", func(t *testing.T) {
+	suite.T().Run("get user leseb by key", func(_ *testing.T) {
 		user, err := co.GetUser(context.Background(), User{Keys: []UserKeySpec{{AccessKey: os.Getenv("LESEB_ACCESS_KEY")}}})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@example.com", user.Email)
 		os.Unsetenv("LESEB_ACCESS_KEY")
 	})
 
-	suite.T().Run("modify user email", func(t *testing.T) {
+	suite.T().Run("modify user email", func(_ *testing.T) {
 		user, err := co.ModifyUser(context.Background(), User{ID: "leseb", Email: "leseb@leseb.com"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@leseb.com", user.Email)
 	})
 
-	suite.T().Run("modify user max bucket", func(t *testing.T) {
+	suite.T().Run("modify user max bucket", func(_ *testing.T) {
 		maxBuckets := -1
 		user, err := co.ModifyUser(context.Background(), User{ID: "leseb", MaxBuckets: &maxBuckets})
 		assert.NoError(suite.T(), err)
@@ -142,39 +142,39 @@ func (suite *RadosGWTestSuite) TestUser() {
 		assert.Equal(suite.T(), -1, *user.MaxBuckets)
 	})
 
-	suite.T().Run("user already exists", func(t *testing.T) {
+	suite.T().Run("user already exists", func(_ *testing.T) {
 		_, err := co.CreateUser(context.Background(), User{ID: "admin", DisplayName: "Admin user"})
 		assert.Error(suite.T(), err)
 		assert.True(suite.T(), errors.Is(err, ErrUserExists), fmt.Sprintf("%+v", err))
 	})
 
-	suite.T().Run("get users", func(t *testing.T) {
+	suite.T().Run("get users", func(_ *testing.T) {
 		users, err := co.GetUsers(context.Background())
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), 2, len(*users))
 	})
 
-	suite.T().Run("set user quota", func(t *testing.T) {
+	suite.T().Run("set user quota", func(_ *testing.T) {
 		quotaEnable := true
 		maxObjects := int64(100)
 		err := co.SetUserQuota(context.Background(), QuotaSpec{QuotaType: "user", UID: "leseb", MaxObjects: &maxObjects, Enabled: &quotaEnable})
 		assert.NoError(suite.T(), err)
 	})
 
-	suite.T().Run("get user quota", func(t *testing.T) {
+	suite.T().Run("get user quota", func(_ *testing.T) {
 		q, err := co.GetUserQuota(context.Background(), QuotaSpec{QuotaType: "user", UID: "leseb"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), int64(100), *q.MaxObjects)
 	})
 
-	suite.T().Run("get user stat", func(t *testing.T) {
+	suite.T().Run("get user stat", func(_ *testing.T) {
 		statEnable := true
 		user, err := co.GetUser(context.Background(), User{ID: "leseb", GenerateStat: &statEnable})
 		assert.NoError(suite.T(), err)
 		assert.NotNil(suite.T(), user.Stat.Size)
 	})
 
-	suite.T().Run("create a subuser", func(t *testing.T) {
+	suite.T().Run("create a subuser", func(_ *testing.T) {
 		err := co.CreateSubuser(context.Background(), User{ID: "leseb"}, SubuserSpec{Name: "foo", Access: SubuserAccessReadWrite})
 		assert.NoError(suite.T(), err)
 
@@ -187,7 +187,7 @@ func (suite *RadosGWTestSuite) TestUser() {
 		}
 	})
 
-	suite.T().Run("modify a subuser", func(t *testing.T) {
+	suite.T().Run("modify a subuser", func(_ *testing.T) {
 		err := co.ModifySubuser(context.Background(), User{ID: "leseb"}, SubuserSpec{Name: "foo", Access: SubuserAccessRead})
 		assert.NoError(suite.T(), err)
 
@@ -199,7 +199,7 @@ func (suite *RadosGWTestSuite) TestUser() {
 		}
 	})
 
-	suite.T().Run("remove a subuser", func(t *testing.T) {
+	suite.T().Run("remove a subuser", func(_ *testing.T) {
 		err := co.RemoveSubuser(context.Background(), User{ID: "leseb"}, SubuserSpec{Name: "foo"})
 		assert.NoError(suite.T(), err)
 
@@ -210,7 +210,7 @@ func (suite *RadosGWTestSuite) TestUser() {
 		}
 	})
 
-	suite.T().Run("remove user", func(t *testing.T) {
+	suite.T().Run("remove user", func(_ *testing.T) {
 		err = co.RemoveUser(context.Background(), User{ID: "leseb"})
 		assert.NoError(suite.T(), err)
 	})


### PR DESCRIPTION
revive v1.3.7 added https://github.com/mgechev/revive/pull/966 which checks for unused parameters in function literals. This caused several lint errors in go-ceph code.


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
