### PR TITLE
Prepare release v0.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ go test -tags pacific ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.26.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.25.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.24.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.23.0         | pacific, quincy, reef   | nautilus, octopus        |

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2010,14 +2010,14 @@
       {
         "name": "API.GetBucketQuota",
         "comment": "GetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#get-bucket-quota\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.26.0",
+        "expected_stable_version": "v0.28.0"
       },
       {
         "name": "API.SetBucketQuota",
         "comment": "SetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#set-bucket-quota\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.26.0",
+        "expected_stable_version": "v0.28.0"
       }
     ],
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -41,8 +41,8 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 API.GetInfo | v0.25.0 | v0.27.0 | 
-API.GetBucketQuota | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
-API.SetBucketQuota | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+API.GetBucketQuota | v0.26.0 | v0.28.0 | 
+API.SetBucketQuota | v0.26.0 | v0.28.0 | 
 
 ## Package: common/admin/manager
 


### PR DESCRIPTION
- Update api-status files
- Update README
- No new stable APIs
