### PR TITLE
build: Bump golang version to 1.21

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -21,7 +21,7 @@ RUN true && \
     yum clean all && \
     true
 
-ARG GO_VERSION=1.19.5
+ARG GO_VERSION=1.21.8
 ENV GO_VERSION=${GO_VERSION}
 ARG GOARCH
 ENV GOARCH=${GOARCH}


### PR DESCRIPTION
This bumps the Go version of the test container to 1.21.8, which is the oldest supported Go version as of now. The -_go.mod_ file (including an upgrade of its dependencies) is bumped to 1.21 as well.