### PR TITLE
rbd: prevent warning about redefining _POSIX_C_SOURCE

### DIFF
--- a/rbd/resize.go
+++ b/rbd/resize.go
@@ -4,7 +4,10 @@ package rbd
 
 /*
 #cgo LDFLAGS: -lrbd
+#ifndef _POSIX_C_SOURCE
+// possibly defined in /usr/include/features.h already
 #define _POSIX_C_SOURCE 200112L
+#endif
 #undef _GNU_SOURCE
 #include <errno.h>
 #include <stdlib.h>


### PR DESCRIPTION
While building an application with the latest version of go-ceph, the following warning is spit out:

```
In file included from _cgo_export.c:4:
resize.go:7: warning: "_POSIX_C_SOURCE" redefined
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdlib.h:26,
                 from _cgo_export.c:3:
/usr/include/features.h:292: note: this is the location of the previous definition
  292 | # define _POSIX_C_SOURCE        200809L
```

When _POSIX_C_SOURCE is already defined, ther is no need to define it again.