### PR TITLE
cephfs/admin: Adjust build tags for subvolume quiescing API tests

### DIFF
--- a/cephfs/admin/fs_quiesce_reef_test.go
+++ b/cephfs/admin/fs_quiesce_reef_test.go
@@ -1,4 +1,4 @@
-//go:build (nautilus || octopus || pacific || quincy || reef || squid || ceph_pre_squid) && ceph_preview
+//go:build (nautilus || octopus || pacific || quincy || reef) && ceph_preview
 
 package admin
 

--- a/cephfs/admin/fs_quiesce_test.go
+++ b/cephfs/admin/fs_quiesce_test.go
@@ -1,4 +1,4 @@
-//go:build !(nautilus || octopus || pacific || quincy || reef || squid || ceph_pre_squid) && ceph_preview
+//go:build !(nautilus || octopus || pacific || quincy || reef) && ceph_preview
 
 package admin
 


### PR DESCRIPTION
With the feature itself getting a backport to upcoming squid release build tags calls for adjustments so that `pre-squid` and `main` CI jobs can run the real tests from _fs_quiesce_test.go_. Until the real squid job is enabled(after ceph squid GA) we could refrain from mentioning `squid` build tag in those related test files.