### PR TITLE
rbd: trigger an error on invalid max snaps value

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -936,7 +936,10 @@ func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 	var cMaxSnaps C.int
 
 	ret := C.rbd_snap_list(image.image, nil, &cMaxSnaps)
-
+	// bugfix index out of range(&cSnaps[0])
+	if cMaxSnaps < 1 {
+		return nil, rbdError(ret)
+	}
 	cSnaps := make([]C.rbd_snap_info_t, cMaxSnaps)
 	snaps = make([]SnapInfo, cMaxSnaps)
 


### PR DESCRIPTION
It is necessary to determine whether cMaxSnaps is a large 0. Otherwise, the following code will panic

```
// GetSnapshotNames returns more than just the names of snapshots
// associated with the rbd image.
//
// Implements:
//
//	int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps, int *max_snaps);
func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
	if err := image.validate(imageIsOpen); err != nil {
		return nil, err
	}

	var c_max_snaps C.int

	ret := C.rbd_snap_list(image.image, nil, &c_max_snaps)
 	if c_max_snaps < 1 {
		return nil, RBDError(ret)
	}
	c_snaps := make([]C.rbd_snap_info_t, c_max_snaps)
	snaps = make([]SnapInfo, c_max_snaps)

	ret = C.rbd_snap_list(image.image,
		&c_snaps[0], &c_max_snaps)
	if ret < 0 {
		return nil, RBDError(ret)
	}

	for i, s := range c_snaps {
		snaps[i] = SnapInfo{Id: uint64(s.id),
			Size: uint64(s.size),
			Name: C.GoString(s.name)}
	}

	C.rbd_snap_list_end(&c_snaps[0])
	return snaps[:len(snaps)-1], nil
}
```