### PR TITLE
Prepare for release v0.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ go test -tags pacific ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.27.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.26.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.25.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.24.0         | pacific, quincy, reef   | nautilus, octopus        |

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -618,8 +618,8 @@
       {
         "name": "FSAdmin.FSQuiesce",
         "comment": "FSQuiesce will quiesce the specified subvolumes in a volume.\nQuiescing a fs will prevent new writes to the subvolumes.\nSimilar To:\n\nceph fs quiesce <volume>\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.27.0",
+        "expected_stable_version": "v0.29.0"
       }
     ]
   },
@@ -1935,8 +1935,8 @@
       {
         "name": "Image.GetSnapGroupNamespace",
         "comment": "GetSnapGroupNamespace returns the SnapGroupNamespace of the snapshot which\nis part of a group. The caller should make sure that the snapshot ID passed\nin this function belongs to a snapshot that was taken as part of a group\nsnapshot.\n\nImplements:\n\n\t\tint rbd_snap_get_group_namespace(rbd_image_t image, uint64_t snap_id,\n\t                                      rbd_snap_group_namespace_t *group_snap,\n\t                                      size_t group_snap_size)\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.27.0",
+        "expected_stable_version": "v0.29.0"
       }
     ]
   },

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2015,12 +2015,6 @@
   "rgw/admin": {
     "preview_api": [
       {
-        "name": "API.GetInfo",
-        "comment": "GetInfo - https://docs.ceph.com/en/latest/radosgw/adminops/#info\n",
-        "added_in_version": "v0.25.0",
-        "expected_stable_version": "v0.27.0"
-      },
-      {
         "name": "API.GetBucketQuota",
         "comment": "GetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#get-bucket-quota\n",
         "added_in_version": "v0.26.0",
@@ -2164,6 +2158,12 @@
         "comment": "ListBucketsWithStat will return the list of all buckets with stat (system admin API only)\n",
         "added_in_version": "v0.20.0",
         "became_stable_version": "v0.22.0"
+      },
+      {
+        "name": "API.GetInfo",
+        "comment": "GetInfo - https://docs.ceph.com/en/latest/radosgw/adminops/#info\n",
+        "added_in_version": "v0.25.0",
+        "became_stable_version": "v0.27.0"
       }
     ]
   },

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1923,15 +1923,15 @@
         "comment": "LockRelease releases a lock on the image.\n\nImplements:\n\n\tint rbd_lock_release(rbd_image_t image);\n",
         "added_in_version": "v0.22.0",
         "became_stable_version": "v0.24.0"
-      }
-    ],
-    "preview_api": [
+      },
       {
         "name": "Image.Resize2",
         "comment": "Resize2 resizes an rbd image and allows configuration of allow_shrink and a callback function. The callback\nfunction will be called with the first argument as the progress, the second argument as the total, and the third\nargument as an opaque value that is passed to the Resize2 function's data argument in each callback execution.\nThe resize operation will be aborted if the progress callback returns a non-zero value.\n\nImplements:\n\n\tint rbd_resize2(rbd_image_t image, uint64_t size, allow_shrink bool, librbd_progress_fn_t cb, void *cbdata);\n",
         "added_in_version": "v0.25.0",
-        "expected_stable_version": "v0.27.0"
-      },
+        "became_stable_version": "v0.27.0"
+      }
+    ],
+    "preview_api": [
       {
         "name": "Image.GetSnapGroupNamespace",
         "comment": "GetSnapGroupNamespace returns the SnapGroupNamespace of the snapshot which\nis part of a group. The caller should make sure that the snapshot ID passed\nin this function belongs to a snapshot that was taken as part of a group\nsnapshot.\n\nImplements:\n\n\t\tint rbd_snap_get_group_namespace(rbd_image_t image, uint64_t snap_id,\n\t                                      rbd_snap_group_namespace_t *group_snap,\n\t                                      size_t group_snap_size)\n",

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -12,7 +12,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-FSAdmin.FSQuiesce | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+FSAdmin.FSQuiesce | v0.27.0 | v0.29.0 | 
 
 ## Package: rados
 
@@ -24,7 +24,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-Image.GetSnapGroupNamespace | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Image.GetSnapGroupNamespace | v0.27.0 | v0.29.0 | 
 
 ### Deprecated APIs
 

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -24,7 +24,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-Image.Resize2 | v0.25.0 | v0.27.0 | 
 Image.GetSnapGroupNamespace | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ### Deprecated APIs

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -44,7 +44,6 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
-API.GetInfo | v0.25.0 | v0.27.0 | 
 API.GetBucketQuota | v0.26.0 | v0.28.0 | 
 API.SetBucketQuota | v0.26.0 | v0.28.0 | 
 

--- a/rbd/resize.go
+++ b/rbd/resize.go
@@ -1,5 +1,3 @@
-//go:build ceph_preview
-
 package rbd
 
 /*

--- a/rbd/resize_test.go
+++ b/rbd/resize_test.go
@@ -1,5 +1,3 @@
-//go:build ceph_preview
-
 package rbd
 
 import (

--- a/rgw/admin/info.go
+++ b/rgw/admin/info.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus || pacific) && ceph_preview
-// +build !nautilus,!octopus,!pacific,ceph_preview
+//go:build !(nautilus || octopus || pacific)
+// +build !nautilus,!octopus,!pacific
 
 package admin
 

--- a/rgw/admin/info_test.go
+++ b/rgw/admin/info_test.go
@@ -1,5 +1,5 @@
-//go:build !(nautilus || octopus || pacific) && ceph_preview
-// +build !nautilus,!octopus,!pacific,ceph_preview
+//go:build !(nautilus || octopus || pacific)
+// +build !nautilus,!octopus,!pacific
 
 package admin
 


### PR DESCRIPTION
Release prep:
* Make rbd Image.Resize2 stable
* Make rgw/admin API.GetInfo stable
* Fixup version numbers for new apis
* Add v0.27 to README version matrix

Fixes: #981 


Side note:
I expect that by the next release of go-ceph the Ceph Squid will be out and we'll add squid to our matrix. With squid coming out I plan on removing nautilus from the test matrix at long last. I don't plan to do any more than that - nautilus build tags will not be proactively removed from the code but after removing it from the test matrix new code will not be required to handle it.