### PR TITLE
Dockerfile: Avoid conflict with curl-minimal package

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -14,7 +14,7 @@ RUN true && \
     yum update -y --disablerepo=ganesha && \
     cv="$(rpm -q --queryformat '%{version}-%{release}' ceph-common)" && \
     yum install -y \
-    git wget curl make \
+    git wget /usr/bin/curl make \
     /usr/bin/cc /usr/bin/c++ \
     "libcephfs-devel-${cv}" "librados-devel-${cv}" "librbd-devel-${cv}" \
     gdb libcephfs2-debuginfo librados2-debuginfo librbd1-debuginfo && \


### PR DESCRIPTION
With CentOS Stream 8 reaching end of builds phase most of our ceph images are migrating their bases to CentOS Stream 9. Since they come with _curl_ by default in a minimal rpm package we switch to attempt the install by directly linking the binary than the package name. This is due to the conflict between _curl_ and _curl-minimal_ packages in CentOS Stream 9 images.

fixes #994 