### PR TITLE
containers: work around centos 8 stream getting archived

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -11,6 +11,7 @@ ENV GO_CEPH_VERSION=${GO_CEPH_VERSION:-$CEPH_VERSION}
 RUN true && \
     echo "Check: [ ${CEPH_VERSION} = ${GO_CEPH_VERSION} ]" && \
     [ "${CEPH_VERSION}" = "${GO_CEPH_VERSION}" ] && \
+    (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) && \
     yum update -y --disablerepo=ganesha && \
     cv="$(rpm -q --queryformat '%{version}-%{release}' ceph-common)" && \
     yum install -y \


### PR DESCRIPTION
The centos 8 stream distribution is now EOL and the yum repo mirrors are now offline. However, our CI is designed to test older released versions of ceph where the container images are still using centos 8 stream. Borrow and adapt a line from the ceph-csi project in order to use the centos 8 archives (vault) until either we stop testing these versions of ceph or the ceph project changes the base distro for these release versions.

*Infra only change*