### PR TITLE
Prepare for release v0.28.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.test
 /*.json
 /implements
+/_results

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ go test -tags pacific ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.28.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.27.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.26.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.25.0         | pacific, quincy, reef   | nautilus, octopus        |

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2013,20 +2013,7 @@
     ]
   },
   "rgw/admin": {
-    "preview_api": [
-      {
-        "name": "API.GetBucketQuota",
-        "comment": "GetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#get-bucket-quota\n",
-        "added_in_version": "v0.26.0",
-        "expected_stable_version": "v0.28.0"
-      },
-      {
-        "name": "API.SetBucketQuota",
-        "comment": "SetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#set-bucket-quota\n",
-        "added_in_version": "v0.26.0",
-        "expected_stable_version": "v0.28.0"
-      }
-    ],
+    "preview_api": [],
     "stable_api": [
       {
         "name": "API.ListBuckets",
@@ -2164,6 +2151,18 @@
         "comment": "GetInfo - https://docs.ceph.com/en/latest/radosgw/adminops/#info\n",
         "added_in_version": "v0.25.0",
         "became_stable_version": "v0.27.0"
+      },
+      {
+        "name": "API.GetBucketQuota",
+        "comment": "GetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#get-bucket-quota\n",
+        "added_in_version": "v0.26.0",
+        "became_stable_version": "v0.28.0"
+      },
+      {
+        "name": "API.SetBucketQuota",
+        "comment": "SetBucketQuota - https://docs.ceph.com/en/latest/radosgw/adminops/#set-bucket-quota\n",
+        "added_in_version": "v0.26.0",
+        "became_stable_version": "v0.28.0"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -40,12 +40,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rgw/admin
 
-### Preview APIs
-
-Name | Added in Version | Expected Stable Version | 
----- | ---------------- | ----------------------- | 
-API.GetBucketQuota | v0.26.0 | v0.28.0 | 
-API.SetBucketQuota | v0.26.0 | v0.28.0 | 
+No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: common/admin/manager
 

--- a/rgw/admin/user_bucket_quota.go
+++ b/rgw/admin/user_bucket_quota.go
@@ -1,5 +1,3 @@
-//go:build ceph_preview
-
 package admin
 
 import (

--- a/rgw/admin/user_bucket_quota_test.go
+++ b/rgw/admin/user_bucket_quota_test.go
@@ -1,5 +1,3 @@
-//go:build ceph_preview
-
 package admin
 
 import (


### PR DESCRIPTION
- Make _{Get,Set}BucketQuota_ APIs stable
- Add v0.28.0 to README matrix

misc
- Add __results_ directory to gitignore

fixes #983 