### PR TITLE
goodbye nautilus

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,6 @@ queue_rules:
     conditions:
       - check-success=check
       - check-success=dpulls
-      - check-success=test-suite (nautilus)
       - check-success=test-suite (octopus)
       - check-success=test-suite (pacific)
       - check-success=test-suite (quincy)
@@ -40,7 +39,6 @@ pull_request_rules:
       - status-success=check
       - status-success=dpulls
       # See above
-      - status-success=test-suite (nautilus)
       - status-success=test-suite (octopus)
       - status-success=test-suite (pacific)
       - status-success=test-suite (quincy)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         ceph_version:
-        - "nautilus"
         - "octopus"
         - "pacific"
         - "quincy"

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,6 @@ ifeq ($(CONTAINER_CMD),)
 	CONTAINER_CMD:=$(shell podman version >/dev/null 2>&1 && echo podman)
 endif
 
-ifeq ($(CEPH_VERSION),nautilus)
-	CEPH_TAG := v14
-endif
 ifeq ($(CEPH_VERSION),octopus)
 	CEPH_TAG := v15
 endif


### PR DESCRIPTION
This PR removes nautilus from our github CI tests and related files.

Fixes: #648
Closes: #1005 

The original plan was to remove nautilus from our test matrix when Ceph
Squid was released. However, while Squid is not released yet, it is very
very soon. In the meantime, CentOS 7 is now EOL and the container images
for nautilus can not be updated. From the Ceph POV nautilus has been
long unsupported and they will not be making any changes to the base OS
for nautilus images. We have no desire to do workarounds for the EOLing
of CentOS7 either. As such we're ending direct support for nautilus a
little early but not by much.

Note that this is only disabling our testing of nautilus - we're not
going to be stripping the build tag from the sources. But we will no
longer require new code to to add it either.