### PR TITLE
workflows: enable squid job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         - "pacific"
         - "quincy"
         - "reef"
-      # - "squid"
+        - "squid"
         - "pre-quincy"
         - "pre-reef"
         - "pre-squid"


### PR DESCRIPTION
Enable the squid ci job now that the squid RC is available. This won't be required for merge until after the full release.

depends on #1013 
closes #975 
