### PR TITLE
Detect `rbd_clone4` support by using `dlsym()`

### DIFF
--- a/internal/dlsym/dlsym.go
+++ b/internal/dlsym/dlsym.go
@@ -1,0 +1,41 @@
+package dlsym
+
+// #cgo LDFLAGS: -ldl
+//
+// #include <stdlib.h>
+// #include <dlfcn.h>
+//
+// #ifndef RTLD_DEFAULT /* from dlfcn.h */
+// #define RTLD_DEFAULT ((void *) 0)
+// #endif
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+)
+
+// ErrUndefinedSymbol is returned by LookupSymbol when the requested symbol
+// could not be found.
+var ErrUndefinedSymbol = errors.New("symbol not found")
+
+// LookupSymbol resolves the named symbol from the already dynamically loaded
+// libraries. If the symbol is found, a pointer to it is returned, in case of a
+// failure, the message provided by dlerror() is included in the error message.
+func LookupSymbol(symbol string) (unsafe.Pointer, error) {
+	cSymName := C.CString(symbol)
+	defer C.free(unsafe.Pointer(cSymName))
+
+	// clear dlerror before looking up the symbol
+	C.dlerror()
+	// resolve the address of the symbol
+	sym := C.dlsym(C.RTLD_DEFAULT, cSymName)
+	e := C.dlerror()
+	dlerr := C.GoString(e)
+	if dlerr != "" {
+		return nil, fmt.Errorf("%w: %s", ErrUndefinedSymbol, dlerr)
+	}
+
+	return sym, nil
+}

--- a/internal/dlsym/dlsym_test.go
+++ b/internal/dlsym/dlsym_test.go
@@ -1,0 +1,22 @@
+package dlsym
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupSymbol(t *testing.T) {
+	t.Run("ValidSymbol", func(t *testing.T) {
+		sym, err := LookupSymbol("dlsym")
+		assert.NotNil(t, sym)
+		assert.NoError(t, err)
+	})
+
+	t.Run("InvalidSymbol", func(t *testing.T) {
+		sym, err := LookupSymbol("go_ceph_dlsym")
+		assert.Nil(t, sym)
+		assert.True(t, errors.Is(err, ErrUndefinedSymbol))
+	})
+}

--- a/rbd/clone_image_by_id.go
+++ b/rbd/clone_image_by_id.go
@@ -1,18 +1,44 @@
-//go:build !(nautilus || octopus || pacific || quincy || reef) && ceph_preview
+//go:build ceph_preview
 
 package rbd
 
-// #cgo LDFLAGS: -lrbd
-// #include <errno.h>
-// #include <stdlib.h>
-// #include <rados/librados.h>
-// #include <rbd/librbd.h>
+/*
+#cgo LDFLAGS: -lrbd
+#include <errno.h>
+#include <stdlib.h>
+#include <rados/librados.h>
+#include <rbd/librbd.h>
+
+// rbd_clone4_fn matches the rbd_clone4 function signature.
+typedef int(*rbd_clone4_fn)(rados_ioctx_t p_ioctx, const char *p_name,
+                            uint64_t p_snap_id, rados_ioctx_t c_ioctx,
+			    const char *c_name, rbd_image_options_t c_opts);
+
+// rbd_clone4_dlsym take *fn as rbd_clone4_fn and calls the dynamically loaded
+// rbd_clone4 function passed as 1st argument.
+static inline int rbd_clone4_dlsym(void *fn, rados_ioctx_t p_ioctx,
+				   const char *p_name, uint64_t p_snap_id,
+				   rados_ioctx_t c_ioctx, const char *c_name,
+                                   rbd_image_options_t c_opts) {
+  // cast function pointer fn to rbd_clone4 and call the function
+  return ((rbd_clone4_fn) fn)(p_ioctx, p_name, p_snap_id, c_ioctx, c_name, c_opts);
+}
+*/
 import "C"
 
 import (
+	"fmt"
+	"sync"
 	"unsafe"
 
+	"github.com/ceph/go-ceph/internal/dlsym"
 	"github.com/ceph/go-ceph/rados"
+)
+
+var (
+	rbdClone4Once sync.Once
+	rbdClone4     unsafe.Pointer
+	rbdClone4Err  error
 )
 
 // CloneImageByID creates a clone of the image from a snapshot with the given
@@ -25,9 +51,16 @@ import (
 //	               const char *c_name, rbd_image_options_t c_opts);
 func CloneImageByID(ioctx *rados.IOContext, parentName string, snapID uint64,
 	destctx *rados.IOContext, name string, rio *ImageOptions) error {
-
 	if rio == nil {
 		return rbdError(C.EINVAL)
+	}
+
+	rbdClone4Once.Do(func() {
+		rbdClone4, rbdClone4Err = dlsym.LookupSymbol("rbd_clone4")
+	})
+
+	if rbdClone4Err != nil {
+		return fmt.Errorf("%w: %w", ErrNotImplemented, rbdClone4Err)
 	}
 
 	cParentName := C.CString(parentName)
@@ -35,12 +68,16 @@ func CloneImageByID(ioctx *rados.IOContext, parentName string, snapID uint64,
 	cCloneName := C.CString(name)
 	defer C.free(unsafe.Pointer(cCloneName))
 
-	ret := C.rbd_clone4(
+	// call rbd_clone4_dlsym with the function pointer to rbd_clone4 as 1st
+	// argument
+	ret := C.rbd_clone4_dlsym(
+		rbdClone4,
 		cephIoctx(ioctx),
 		cParentName,
 		C.uint64_t(snapID),
 		cephIoctx(destctx),
 		cCloneName,
 		C.rbd_image_options_t(rio.options))
+
 	return getError(ret)
 }

--- a/rbd/clone_image_by_id_test.go
+++ b/rbd/clone_image_by_id_test.go
@@ -112,6 +112,9 @@ func TestCloneImageByID(t *testing.T) {
 	t.Run("CloneFromGroupSnap", func(t *testing.T) {
 		err := GroupSnapCreate(ioctx, gname, "groupsnap")
 		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, GroupSnapRemove(ioctx, gname, "groupsnap"))
+		}()
 
 		cloneName := "img-clone"
 		optionsClone := NewRbdImageOptions()
@@ -147,8 +150,5 @@ func TestCloneImageByID(t *testing.T) {
 		assert.Equal(t, parentInfo.Snap.ID, snapID)
 		assert.Equal(t, parentInfo.Image.PoolName, poolname)
 		assert.False(t, parentInfo.Image.Trash)
-
-		err = GroupSnapRemove(ioctx, gname, "groupsnap")
-		assert.NoError(t, err)
 	})
 }

--- a/rbd/clone_image_by_id_test.go
+++ b/rbd/clone_image_by_id_test.go
@@ -1,8 +1,9 @@
-//go:build !(nautilus || octopus || pacific || quincy || reef) && ceph_preview
+//go:build ceph_preview
 
 package rbd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,6 +92,9 @@ func TestCloneImageByID(t *testing.T) {
 
 		// Create a clone of the image using the snapshot.
 		err = CloneImageByID(ioctx, name1, snapID, ioctx, cloneName, optionsClone)
+		if errors.Is(err, ErrNotImplemented) {
+			t.Skipf("CloneImageByID is not supported: %v", err)
+		}
 		assert.NoError(t, err)
 		defer func() { assert.NoError(t, RemoveImage(ioctx, cloneName)) }()
 
@@ -135,6 +139,9 @@ func TestCloneImageByID(t *testing.T) {
 
 		// Create a clone of the image using the snapshot.
 		err = CloneImageByID(ioctx, name1, snapID, ioctx, cloneName, optionsClone)
+		if errors.Is(err, ErrNotImplemented) {
+			t.Skipf("CloneImageByID is not supported: %v", err)
+		}
 		assert.NoError(t, err)
 		defer func() { assert.NoError(t, RemoveImage(ioctx, cloneName)) }()
 

--- a/rbd/errors.go
+++ b/rbd/errors.go
@@ -75,6 +75,8 @@ var (
 const (
 	// ErrNotExist indicates a non-specific missing resource.
 	ErrNotExist = rbdError(-C.ENOENT)
+	// ErrNotImplemented indicates a function is not implemented in by librbd.
+	ErrNotImplemented = rbdError(-C.ENOSYS)
 )
 
 // Private errors:


### PR DESCRIPTION
The dlsym package provides LookupSymbol() which resolves a named symbol
(like "rbd_clone4") and returns a unsafe.Pointer to it. The caller is
expected to cast the symbol to function that can be called.

Some versions of librbd provide the rbd_clone4 function, and others do
not. Squid will have the function backported in the 1st update, the
initial release of Squid does not have it. This makes checking for the
function based on the named Ceph version impractical.

With the new dlsym.LookupSymbol() function, it is now possible to check
the availability of rbd_clone4 during runtime. If the symbol is not
found ErrNotImplemented is returned, which can be used to detect the
unavailability of the function.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
