### PR TITLE
Add new rados/striper package

### DIFF
--- a/contrib/implements/internal/implements/cast.go
+++ b/contrib/implements/internal/implements/cast.go
@@ -17,6 +17,9 @@ var (
 	radosCStub = `
 #include "rados/librados.h"
 `
+	radosStriperCStub = `
+#include "radosstriper/libradosstriper.h"
+`
 	rbdCStub = `
 #include "rbd/librbd.h"
 #include "rbd/features.h"
@@ -44,9 +47,10 @@ var (
 #define __linux__ 1
 `
 	stubs = map[string]string{
-		"cephfs": cephfsCStub,
-		"rados":  radosCStub,
-		"rbd":    rbdCStub,
+		"cephfs":        cephfsCStub,
+		"rados":         radosCStub,
+		"rados/striper": radosStriperCStub,
+		"rbd":           rbdCStub,
 	}
 	funcPrefix = map[string]string{
 		"cephfs": "ceph_",

--- a/contrib/implements/main.go
+++ b/contrib/implements/main.go
@@ -104,7 +104,7 @@ func main() {
 		source, pkg := splitPkg(pkgref)
 		checkCLang := false
 		switch pkg {
-		case "cephfs", "rados", "rbd":
+		case "cephfs", "rados", "rbd", "rados/striper":
 			checkCLang = true
 			if verbose {
 				logger.Printf("Processing package (with C): %s\n", pkg)

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2264,5 +2264,111 @@
         "became_stable_version": "v0.18.0"
       }
     ]
+  },
+  "rados/striper": {
+    "preview_api": [
+      {
+        "name": "Striper.Read",
+        "comment": "Read bytes into data from the striped object at the specified offset.\n\nImplements:\n\n\tint rados_striper_read(rados_striper_t striper,\n\t                       const char *soid,\n\t                       const char *buf,\n\t                       size_t len,\n\t                       uint64_t off);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.Stat",
+        "comment": "Stat returns metadata describing the striped object.\n\nImplements:\n\n\tint rados_striper_stat2(rados_striper_t striper,\n\t                       const char* soid,\n\t                       uint64_t *psize,\n\t                       struct timespec *pmtime);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "New",
+        "comment": "New returns a rados Striper object created from a rados IOContext.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewWithLayout",
+        "comment": "NewWithLayout returns a rados Striper object created from a rados IOContext\nand striper layout parameters. These parameters will be used when new\nobjects are created.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.Destroy",
+        "comment": "Destroy the radosstriper object at the Ceph API level.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.SetObjectLayoutStripeUnit",
+        "comment": "SetObjectLayoutStripeUnit sets the stripe unit value used to layout\nnew objects.\n\nImplements:\n\n\tint rados_striper_set_object_layout_stripe_unit(rados_striper_t striper,\n\t                                                unsigned int stripe_unit);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.SetObjectLayoutStripeCount",
+        "comment": "SetObjectLayoutStripeCount sets the stripe count value used to layout\nnew objects.\n\nImplements:\n\n\tint rados_striper_set_object_layout_stripe_count(rados_striper_t striper,\n\t                                                 unsigned int stripe_count);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.SetObjectLayoutObjectSize",
+        "comment": "SetObjectLayoutObjectSize sets the object size value used to layout\nnew objects.\n\nImplements:\n\n\tint rados_striper_set_object_layout_object_size(rados_striper_t striper,\n\t                                                unsigned int object_size);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.Write",
+        "comment": "Write bytes from data into the striped object at the specified offset.\n\nImplements:\n\n\tint rados_striper_write(rados_striper_t striper,\n\t                        const char *soid,\n\t                        const char *buf,\n\t                        size_t len,\n\t                        uint64_t off);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.WriteFull",
+        "comment": "WriteFull writes all of the bytes in data to the striped object, truncating\nthe object to the length of data.\n\nImplements:\n\n\tint rados_striper_write_full(rados_striper_t striper,\n\t                             const char *soid,\n\t                             const char *buf,\n\t                             size_t len);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.Append",
+        "comment": "Append the bytes in data to the end of the striped object.\n\nImplements:\n\n\tint rados_striper_append(rados_striper_t striper,\n\t                         const char *soid,\n\t                         const char *buf,\n\t                         size_t len);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.Remove",
+        "comment": "Remove a striped RADOS object.\n\nImplements:\n\n\tint rados_striper_remove(rados_striper_t striper,\n\t                         const char *soid);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.Truncate",
+        "comment": "Truncate a striped object, setting it to the specified size.\n\nImplements:\n\n\tint rados_striper_trunc(rados_striper_t striper, const char *soid, uint64_t size);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.GetXattr",
+        "comment": "GetXattr retrieves an extended attribute (xattr) of the given name from the\nspecified striped object.\n\nImplements:\n\n\tint rados_striper_getxattr(rados_striper_t striper,\n\t                           const char *oid,\n\t                           const char *name,\n\t                           char *buf,\n\t                           size_t len);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.SetXattr",
+        "comment": "SetXattr sets an extended attribute (xattr) of the given name on the\nspecified striped object.\n\nImplements:\n\n\tint rados_striper_setxattr(rados_striper_t striper,\n\t                           const char *oid,\n\t                           const char *name,\n\t                           const char *buf,\n\t                           size_t len);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.RmXattr",
+        "comment": "RmXattr removes the extended attribute (xattr) of the given name from the\nstriped object.\n\nImplements:\n\n\tint rados_striper_rmxattr(rados_striper_t striper,\n\t                          const char *oid,\n\t                          const char *name);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Striper.ListXattrs",
+        "comment": "ListXattrs returns a map containing all of the extended attributes (xattrs)\nfor a striped object. The xattr names provide the key strings and the map's\nvalues are byte slices.\n\nImplements:\n\n\tint rados_striper_getxattrs(rados_striper_t striper,\n\t                            const char *oid,\n\t                            rados_xattrs_iter_t *iter);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ]
   }
 }

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -61,3 +61,27 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 No Preview/Deprecated APIs found. All APIs are considered stable.
 
+## Package: rados/striper
+
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+Striper.Read | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.Stat | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+New | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewWithLayout | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.Destroy | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.SetObjectLayoutStripeUnit | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.SetObjectLayoutStripeCount | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.SetObjectLayoutObjectSize | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.Write | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.WriteFull | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.Append | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.Remove | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.Truncate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.GetXattr | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.SetXattr | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.RmXattr | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Striper.ListXattrs | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+

--- a/rados/striper/doc.go
+++ b/rados/striper/doc.go
@@ -1,0 +1,22 @@
+//go:build ceph_preview
+
+/*
+Package striper contains a set of wrappers around Ceph's libradosstriper API.
+
+The Striper type supports synchronous operations to read and write data,
+as well as read and manipulate xattrs. Note that a striped object will
+consist of one or more objects in RADOS.
+
+There is no object list API in libradosstriper. Listing objects must be done
+using the base RADOS APIs. Striped objects will be stored in RADOS using the
+provided Striped Object ID (soid) suffixed by a dot (.) and a 16 byte
+0-prefixed hex number (for example, "foo.0000000000000000" or
+"bar.000000000000000a"). The object suffixed with ".0000000000000000" is the
+0-index stripe and will also possess striper specific xattrs (see the [ceph
+libradosstriper implementation] for a list) that are hidden from the
+libradosstriper xattr APIs.  You can use the name and/or these striper xattrs
+to distinguish a striped object from a non-striped RADOS object.
+
+[ceph libradosstriper implementation]: https://github.com/ceph/ceph/blob/2fa0e43b7e714df9811f87cbc5bf862ac503483c/src/libradosstriper/RadosStriperImpl.cc#L94-L97
+*/
+package striper

--- a/rados/striper/errors.go
+++ b/rados/striper/errors.go
@@ -1,0 +1,32 @@
+//go:build ceph_preview
+
+package striper
+
+/*
+#include <errno.h>
+*/
+import "C"
+
+import (
+	"github.com/ceph/go-ceph/internal/errutil"
+)
+
+// radosStriperError represents an error condition returned from the Ceph
+// rados striper APIs.
+type radosStriperError int
+
+// Error returns the error string for the radosStriperError type.
+func (e radosStriperError) Error() string {
+	return errutil.FormatErrorCode("rados", int(e))
+}
+
+func (e radosStriperError) ErrorCode() int {
+	return int(e)
+}
+
+func getError(e C.int) error {
+	if e == 0 {
+		return nil
+	}
+	return radosStriperError(e)
+}

--- a/rados/striper/read.go
+++ b/rados/striper/read.go
@@ -1,0 +1,42 @@
+//go:build ceph_preview
+
+package striper
+
+// #cgo LDFLAGS: -lrados -lradosstriper
+// #include <stdlib.h>
+// #include <radosstriper/libradosstriper.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+// Read bytes into data from the striped object at the specified offset.
+//
+// Implements:
+//
+//	int rados_striper_read(rados_striper_t striper,
+//	                       const char *soid,
+//	                       const char *buf,
+//	                       size_t len,
+//	                       uint64_t off);
+func (s *Striper) Read(soid string, data []byte, offset uint64) (int, error) {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	var bufptr *C.char
+	if len(data) > 0 {
+		bufptr = (*C.char)(unsafe.Pointer(&data[0]))
+	}
+
+	ret := C.rados_striper_read(
+		s.striper,
+		csoid,
+		bufptr,
+		C.size_t(len(data)),
+		C.uint64_t(offset))
+	if ret >= 0 {
+		return int(ret), nil
+	}
+	return 0, getError(ret)
+}

--- a/rados/striper/stat.go
+++ b/rados/striper/stat.go
@@ -1,0 +1,47 @@
+//go:build (octopus || pacific || quincy) && ceph_preview
+
+package striper
+
+// #cgo LDFLAGS: -lrados -lradosstriper
+// #include <stdlib.h>
+// #include <radosstriper/libradosstriper.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+// Stat returns metadata describing the striped object.
+// This version of Stat uses an older API that does not provide time
+// granularity below a second: the Nsec value of the StatInfo.ModTime field
+// will always be zero.
+//
+// Implements:
+//
+//	int rados_striper_stat(rados_striper_t striper,
+//	                       const char* soid,
+//	                       uint64_t *psize,
+//	                       time_t *pmtime);
+func (s *Striper) Stat(soid string) (StatInfo, error) {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	var (
+		size  C.uint64_t
+		mtime C.time_t
+	)
+	ret := C.rados_striper_stat(
+		s.striper,
+		csoid,
+		&size,
+		&mtime)
+
+	if ret < 0 {
+		return StatInfo{}, getError(ret)
+	}
+	modts := Timespec{Sec: int64(mtime)}
+	return StatInfo{
+		Size:    uint64(size),
+		ModTime: modts,
+	}, nil
+}

--- a/rados/striper/stat2.go
+++ b/rados/striper/stat2.go
@@ -1,0 +1,45 @@
+//go:build !(octopus || pacific || quincy) && ceph_preview
+
+package striper
+
+// #cgo LDFLAGS: -lrados -lradosstriper
+// #include <stdlib.h>
+// #include <radosstriper/libradosstriper.h>
+import "C"
+
+import (
+	"unsafe"
+
+	ts "github.com/ceph/go-ceph/internal/timespec"
+)
+
+// Stat returns metadata describing the striped object.
+//
+// Implements:
+//
+//	int rados_striper_stat2(rados_striper_t striper,
+//	                       const char* soid,
+//	                       uint64_t *psize,
+//	                       struct timespec *pmtime);
+func (s *Striper) Stat(soid string) (StatInfo, error) {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	var (
+		size  C.uint64_t
+		mtime C.struct_timespec
+	)
+	ret := C.rados_striper_stat2(
+		s.striper,
+		csoid,
+		&size,
+		&mtime)
+
+	if ret < 0 {
+		return StatInfo{}, getError(ret)
+	}
+	return StatInfo{
+		Size:    uint64(size),
+		ModTime: Timespec(ts.CStructToTimespec(ts.CTimespecPtr(&mtime))),
+	}, nil
+}

--- a/rados/striper/stat_info.go
+++ b/rados/striper/stat_info.go
@@ -1,0 +1,16 @@
+//go:build ceph_preview
+
+package striper
+
+import (
+	ts "github.com/ceph/go-ceph/internal/timespec"
+)
+
+// Timespec behaves similarly to C's struct timespec.
+type Timespec ts.Timespec
+
+// StatInfo contains values returned by a Striper's Stat call.
+type StatInfo struct {
+	Size    uint64
+	ModTime Timespec
+}

--- a/rados/striper/striper.go
+++ b/rados/striper/striper.go
@@ -1,0 +1,121 @@
+//go:build ceph_preview
+
+package striper
+
+// #cgo LDFLAGS: -lrados -lradosstriper
+// #include <errno.h>
+// #include <stdlib.h>
+// #include <radosstriper/libradosstriper.h>
+import "C"
+
+import (
+	"github.com/ceph/go-ceph/rados"
+)
+
+// Striper helps manage the reading, writing, and management of RADOS
+// striped objects.
+type Striper struct {
+	striper C.rados_striper_t
+
+	// Hold a reference back to the ioctx that the striper depends on so
+	// that Go doesn't garbage collect it prematurely.
+	ioctx *rados.IOContext
+}
+
+// Layout contains a group of values used to define the size parameters of
+// striped objects. Note that these parameters only effect new striped objects.
+// Existing striped objects retain the parameters they were created with.
+type Layout struct {
+	StripeUnit  uint
+	StripeCount uint
+	ObjectSize  uint
+}
+
+// New returns a rados Striper object created from a rados IOContext.
+func New(ioctx *rados.IOContext) (*Striper, error) {
+	var s C.rados_striper_t
+	ret := C.rados_striper_create(cephIoctx(ioctx), &s)
+	if err := getError(ret); err != nil {
+		return nil, err
+	}
+	return &Striper{s, ioctx}, nil
+}
+
+// NewWithLayout returns a rados Striper object created from a rados IOContext
+// and striper layout parameters. These parameters will be used when new
+// objects are created.
+func NewWithLayout(ioctx *rados.IOContext, layout Layout) (*Striper, error) {
+	striper, err := New(ioctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := striper.SetObjectLayoutStripeUnit(layout.StripeUnit); err != nil {
+		return nil, err
+	}
+	if err := striper.SetObjectLayoutStripeCount(layout.StripeCount); err != nil {
+		return nil, err
+	}
+	if err := striper.SetObjectLayoutObjectSize(layout.ObjectSize); err != nil {
+		return nil, err
+	}
+	return striper, nil
+}
+
+// Destroy the radosstriper object at the Ceph API level.
+func (s *Striper) Destroy() {
+	C.rados_striper_destroy(s.striper)
+}
+
+// SetObjectLayoutStripeUnit sets the stripe unit value used to layout
+// new objects.
+//
+// Implements:
+//
+//	int rados_striper_set_object_layout_stripe_unit(rados_striper_t striper,
+//	                                                unsigned int stripe_unit);
+func (s *Striper) SetObjectLayoutStripeUnit(count uint) error {
+	ret := C.rados_striper_set_object_layout_stripe_unit(
+		s.striper,
+		C.uint(count),
+	)
+	return getError(ret)
+}
+
+// SetObjectLayoutStripeCount sets the stripe count value used to layout
+// new objects.
+//
+// Implements:
+//
+//	int rados_striper_set_object_layout_stripe_count(rados_striper_t striper,
+//	                                                 unsigned int stripe_count);
+func (s *Striper) SetObjectLayoutStripeCount(count uint) error {
+	ret := C.rados_striper_set_object_layout_stripe_count(
+		s.striper,
+		C.uint(count),
+	)
+	return getError(ret)
+}
+
+// SetObjectLayoutObjectSize sets the object size value used to layout
+// new objects.
+//
+// Implements:
+//
+//	int rados_striper_set_object_layout_object_size(rados_striper_t striper,
+//	                                                unsigned int object_size);
+func (s *Striper) SetObjectLayoutObjectSize(count uint) error {
+	ret := C.rados_striper_set_object_layout_object_size(
+		s.striper,
+		C.uint(count),
+	)
+	return getError(ret)
+}
+
+// cephIoctx returns a ceph rados_ioctx_t given a go-ceph rados IOContext.
+func cephIoctx(radosIoctx *rados.IOContext) C.rados_ioctx_t {
+	p := radosIoctx.Pointer()
+	if p == nil {
+		panic("invalid IOContext pointer")
+	}
+	return C.rados_ioctx_t(p)
+}

--- a/rados/striper/striper_test.go
+++ b/rados/striper/striper_test.go
@@ -98,8 +98,8 @@ func (suite *StriperTestSuite) TestNewStriperWithLayout() {
 	ioctx := suite.defaultContext()
 	defer ioctx.Destroy()
 
-	p := StriperLayout{65536, 16, 8388608}
-	striper, err := NewWithLayout(ioctx, p)
+	l := Layout{65536, 16, 8388608}
+	striper, err := NewWithLayout(ioctx, l)
 	assert.NoError(suite.T(), err)
 	striper.Destroy()
 }

--- a/rados/striper/striper_test.go
+++ b/rados/striper/striper_test.go
@@ -1,0 +1,109 @@
+//go:build ceph_preview
+
+package striper
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tsuite "github.com/stretchr/testify/suite"
+
+	"github.com/ceph/go-ceph/rados"
+)
+
+type StriperTestSuite struct {
+	tsuite.Suite
+
+	pool string
+	conn *rados.Conn
+}
+
+func (suite *StriperTestSuite) connect() *rados.Conn {
+	conn, err := rados.NewConn()
+	require.NoError(suite.T(), err)
+
+	err = conn.ReadDefaultConfigFile()
+	require.NoError(suite.T(), err)
+
+	timeout := time.After(time.Second * 5)
+	ch := make(chan error)
+	go func(conn *rados.Conn) {
+		ch <- conn.Connect()
+	}(conn)
+	select {
+	case err = <-ch:
+	case <-timeout:
+		err = fmt.Errorf("timed out waiting for connect")
+	}
+	require.NoError(suite.T(), err)
+	return conn
+}
+
+func (suite *StriperTestSuite) defaultContext() *rados.IOContext {
+	ioctx, err := suite.conn.OpenIOContext(suite.pool)
+	require.NoError(suite.T(), err)
+	return ioctx
+}
+
+func (suite *StriperTestSuite) SetupSuite() {
+	suite.pool = fmt.Sprintf("striper%s", uuid.Must(uuid.NewV4()).String())
+	conn := suite.connect()
+	defer conn.Shutdown()
+	require.NoError(suite.T(), conn.MakePool(suite.pool))
+}
+
+func (suite *StriperTestSuite) TearDownSuite() {
+	conn := suite.connect()
+	defer conn.Shutdown()
+	assert.NoError(suite.T(), conn.DeletePool(suite.pool))
+}
+
+func (suite *StriperTestSuite) SetupTest() {
+	suite.conn = suite.connect()
+}
+
+func (suite *StriperTestSuite) TearDownTest() {
+	suite.conn.Shutdown()
+	suite.conn = nil
+}
+
+func (suite *StriperTestSuite) TestNewStriper() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	assert.NoError(suite.T(), err)
+	striper.Destroy()
+
+}
+
+func (suite *StriperTestSuite) TestStriperSetObjectLayout() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	assert.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	assert.NoError(suite.T(), striper.SetObjectLayoutStripeUnit(65536))
+	assert.NoError(suite.T(), striper.SetObjectLayoutStripeCount(16))
+	assert.NoError(suite.T(), striper.SetObjectLayoutObjectSize(8388608))
+}
+
+func (suite *StriperTestSuite) TestNewStriperWithLayout() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	p := StriperLayout{65536, 16, 8388608}
+	striper, err := NewWithLayout(ioctx, p)
+	assert.NoError(suite.T(), err)
+	striper.Destroy()
+}
+
+func TestStriperTestSuite(t *testing.T) {
+	tsuite.Run(t, new(StriperTestSuite))
+}

--- a/rados/striper/write.go
+++ b/rados/striper/write.go
@@ -1,0 +1,106 @@
+//go:build ceph_preview
+
+package striper
+
+// #cgo LDFLAGS: -lrados -lradosstriper
+// #include <stdlib.h>
+// #include <radosstriper/libradosstriper.h>
+import "C"
+
+import "unsafe"
+
+// Write bytes from data into the striped object at the specified offset.
+//
+// Implements:
+//
+//	int rados_striper_write(rados_striper_t striper,
+//	                        const char *soid,
+//	                        const char *buf,
+//	                        size_t len,
+//	                        uint64_t off);
+func (s *Striper) Write(soid string, data []byte, offset uint64) error {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	bufptr := (*C.char)(unsafe.Pointer(&data[0]))
+	ret := C.rados_striper_write(
+		s.striper,
+		csoid,
+		bufptr,
+		C.size_t(len(data)),
+		C.uint64_t(offset))
+	return getError(ret)
+}
+
+// WriteFull writes all of the bytes in data to the striped object, truncating
+// the object to the length of data.
+//
+// Implements:
+//
+//	int rados_striper_write_full(rados_striper_t striper,
+//	                             const char *soid,
+//	                             const char *buf,
+//	                             size_t len);
+func (s *Striper) WriteFull(soid string, data []byte) error {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	bufptr := (*C.char)(unsafe.Pointer(&data[0]))
+	ret := C.rados_striper_write_full(
+		s.striper,
+		csoid,
+		bufptr,
+		C.size_t(len(data)))
+	return getError(ret)
+}
+
+// Append the bytes in data to the end of the striped object.
+//
+// Implements:
+//
+//	int rados_striper_append(rados_striper_t striper,
+//	                         const char *soid,
+//	                         const char *buf,
+//	                         size_t len);
+func (s *Striper) Append(soid string, data []byte) error {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	bufptr := (*C.char)(unsafe.Pointer(&data[0]))
+	ret := C.rados_striper_append(
+		s.striper,
+		csoid,
+		bufptr,
+		C.size_t(len(data)))
+	return getError(ret)
+}
+
+// Remove a striped RADOS object.
+//
+// Implements:
+//
+//	int rados_striper_remove(rados_striper_t striper,
+//	                         const char *soid);
+func (s *Striper) Remove(soid string) error {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	ret := C.rados_striper_remove(s.striper, csoid)
+	return getError(ret)
+}
+
+// Truncate a striped object, setting it to the specified size.
+//
+// Implements:
+//
+//	int rados_striper_trunc(rados_striper_t striper, const char *soid, uint64_t size);
+func (s *Striper) Truncate(soid string, size uint64) error {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	ret := C.rados_striper_trunc(
+		s.striper,
+		csoid,
+		C.uint64_t(size))
+	return getError(ret)
+}

--- a/rados/striper/write_test.go
+++ b/rados/striper/write_test.go
@@ -1,0 +1,163 @@
+//go:build ceph_preview
+
+package striper
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *StriperTestSuite) TestReadWrite() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestReadWrite"
+	err = striper.Write(name, []byte("hello world"), 0)
+	require.NoError(suite.T(), err)
+
+	err = striper.Write(name, []byte("earthlings"), 6)
+	require.NoError(suite.T(), err)
+
+	buf := make([]byte, 32)
+	size, err := striper.Read(name, buf, 0)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 16, size)
+	assert.Equal(suite.T(), "hello earthlings", string(buf[:size]))
+}
+
+func (suite *StriperTestSuite) TestReadWriteFull() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestReadWriteFull"
+	err = striper.WriteFull(name, []byte("hello world"))
+	require.NoError(suite.T(), err)
+
+	err = striper.WriteFull(name, []byte("earthlings"))
+	require.NoError(suite.T(), err)
+
+	buf := make([]byte, 32)
+	size, err := striper.Read(name, buf, 0)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 10, size)
+	assert.Equal(suite.T(), "earthlings", string(buf[:size]))
+}
+
+func (suite *StriperTestSuite) TestReadAppend() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestReadAppend"
+	err = striper.Append(name, []byte("hello world"))
+	require.NoError(suite.T(), err)
+
+	err = striper.Append(name, []byte(" and all you earthlings"))
+	require.NoError(suite.T(), err)
+
+	buf := make([]byte, 64)
+	size, err := striper.Read(name, buf, 0)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 34, size)
+	assert.Equal(suite.T(),
+		"hello world and all you earthlings",
+		string(buf[:size]))
+}
+
+func (suite *StriperTestSuite) TestRemove() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestRemove"
+	err = striper.Append(name, []byte("goodbye world"))
+	require.NoError(suite.T(), err)
+
+	err = striper.Remove(name)
+	require.NoError(suite.T(), err)
+
+	buf := make([]byte, 32)
+	_, err = striper.Read(name, buf, 0)
+	require.Error(suite.T(), err)
+	require.Equal(suite.T(), -2, err.(radosStriperError).ErrorCode())
+}
+
+func (suite *StriperTestSuite) TestTruncate() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestTruncate"
+	err = striper.Write(name, []byte("that's all folks"), 0)
+	require.NoError(suite.T(), err)
+
+	err = striper.Truncate(name, 10)
+	require.NoError(suite.T(), err)
+
+	buf := make([]byte, 32)
+	size, err := striper.Read(name, buf, 0)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), 10, size)
+	assert.Equal(suite.T(), "that's all", string(buf[:size]))
+}
+
+func (suite *StriperTestSuite) TestStat() {
+	ut := time.Now().Unix()
+
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestStat"
+	err = striper.Write(name, []byte("that's all..."), 0)
+	require.NoError(suite.T(), err)
+	err = striper.Write(name, []byte("...folks"), 4096)
+	require.NoError(suite.T(), err)
+
+	ss, err := striper.Stat(name)
+	require.NoError(suite.T(), err)
+
+	assert.Equal(suite.T(), uint64(4104), ss.Size)
+	assert.Equal(suite.T(), uint64(4104), ss.Size)
+	// the Seconds field of the timespec should be between the time we started
+	// the test and two seconds after the time we started the test (as that
+	// ought to be a pretty large window for this operation)
+	assert.GreaterOrEqual(suite.T(), ss.ModTime.Sec, ut)
+	assert.GreaterOrEqual(suite.T(), ut+2, ss.ModTime.Sec)
+}
+
+func (suite *StriperTestSuite) TestStatMissing() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestStatMissing"
+	_, err = striper.Stat(name)
+	require.Error(suite.T(), err)
+	require.Equal(suite.T(), -2, err.(radosStriperError).ErrorCode())
+}

--- a/rados/striper/xattr.go
+++ b/rados/striper/xattr.go
@@ -1,0 +1,150 @@
+//go:build ceph_preview
+
+package striper
+
+// #cgo LDFLAGS: -lrados -lradosstriper
+// #include <stdlib.h>
+// #include <radosstriper/libradosstriper.h>
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+var errStopIteration = errors.New("stop iteraton")
+
+// GetXattr retrieves an extended attribute (xattr) of the given name from the
+// specified striped object.
+//
+// Implements:
+//
+//	int rados_striper_getxattr(rados_striper_t striper,
+//	                           const char *oid,
+//	                           const char *name,
+//	                           char *buf,
+//	                           size_t len);
+func (s *Striper) GetXattr(soid string, name string, data []byte) (int, error) {
+	csoid := C.CString(soid)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(csoid))
+	defer C.free(unsafe.Pointer(cName))
+
+	ret := C.rados_striper_getxattr(
+		s.striper,
+		csoid,
+		cName,
+		(*C.char)(unsafe.Pointer(&data[0])),
+		(C.size_t)(len(data)))
+
+	if ret >= 0 {
+		return int(ret), nil
+	}
+	return 0, getError(ret)
+}
+
+// SetXattr sets an extended attribute (xattr) of the given name on the
+// specified striped object.
+//
+// Implements:
+//
+//	int rados_striper_setxattr(rados_striper_t striper,
+//	                           const char *oid,
+//	                           const char *name,
+//	                           const char *buf,
+//	                           size_t len);
+func (s *Striper) SetXattr(soid string, name string, data []byte) error {
+	csoid := C.CString(soid)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(csoid))
+	defer C.free(unsafe.Pointer(cName))
+
+	ret := C.rados_striper_setxattr(
+		s.striper,
+		csoid,
+		cName,
+		(*C.char)(unsafe.Pointer(&data[0])),
+		(C.size_t)(len(data)))
+
+	return getError(ret)
+}
+
+// RmXattr removes the extended attribute (xattr) of the given name from the
+// striped object.
+//
+// Implements:
+//
+//	int rados_striper_rmxattr(rados_striper_t striper,
+//	                          const char *oid,
+//	                          const char *name);
+func (s *Striper) RmXattr(soid string, name string) error {
+	csoid := C.CString(soid)
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(csoid))
+	defer C.free(unsafe.Pointer(cName))
+
+	ret := C.rados_striper_rmxattr(s.striper, csoid, cName)
+	return getError(ret)
+}
+
+// getXattrsNext wraps the function to fetch a xattr name/value pair
+// from the iterator. If the iterator is exhausted the error value
+// will be errStopIteration.
+//
+// Implements:
+//
+//	int rados_striper_getxattrs_next(rados_xattrs_iter_t iter,
+//	                                 const char **name,
+//	                                 const char **val,
+//	                                 size_t *len);
+func getXattrsNext(it C.rados_xattrs_iter_t) (string, []byte, error) {
+	var (
+		cName, cValue *C.char
+		cLen          C.size_t
+	)
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cValue))
+
+	ret := C.rados_striper_getxattrs_next(it, &cName, &cValue, &cLen)
+	if ret < 0 {
+		return "", nil, getError(ret)
+	}
+	if cName == nil && cValue == nil {
+		return "", nil, errStopIteration
+	}
+	return C.GoString(cName), C.GoBytes(unsafe.Pointer(cValue), C.int(cLen)), nil
+}
+
+// ListXattrs returns a map containing all of the extended attributes (xattrs)
+// for a striped object. The xattr names provide the key strings and the map's
+// values are byte slices.
+//
+// Implements:
+//
+//	int rados_striper_getxattrs(rados_striper_t striper,
+//	                            const char *oid,
+//	                            rados_xattrs_iter_t *iter);
+func (s *Striper) ListXattrs(soid string) (map[string][]byte, error) {
+	csoid := C.CString(soid)
+	defer C.free(unsafe.Pointer(csoid))
+
+	var it C.rados_xattrs_iter_t
+	ret := C.rados_striper_getxattrs(s.striper, csoid, &it)
+	if ret < 0 {
+		return nil, getError(ret)
+	}
+	defer C.rados_striper_getxattrs_end(it)
+
+	m := make(map[string][]byte)
+	for {
+		xname, xvalue, err := getXattrsNext(it)
+		if err == errStopIteration {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		m[xname] = xvalue
+	}
+	return m, nil
+}

--- a/rados/striper/xattr_test.go
+++ b/rados/striper/xattr_test.go
@@ -1,0 +1,100 @@
+//go:build ceph_preview
+
+package striper
+
+import (
+	"github.com/stretchr/testify/require"
+)
+
+func (suite *StriperTestSuite) TestSetGetXattr() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestSetGetXattr"
+	err = striper.Write(name, []byte("foo"), 0)
+	require.NoError(suite.T(), err)
+
+	xname := "foo.bar"
+	err = striper.SetXattr(name, xname, []byte("razzmatazz"))
+	require.NoError(suite.T(), err)
+
+	buf := make([]byte, 32)
+	size, err := striper.GetXattr(name, xname, buf)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), 10, size)
+	require.Equal(suite.T(), "razzmatazz", string(buf[:size]))
+
+	size, err = striper.GetXattr(name, "nope.nope.nope", buf)
+	require.Error(suite.T(), err)
+	require.Equal(suite.T(), -61, err.(radosStriperError).ErrorCode())
+}
+
+func (suite *StriperTestSuite) TestRmXattr() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestRmXattr"
+	err = striper.Write(name, []byte("foo"), 0)
+	require.NoError(suite.T(), err)
+
+	xname := "foo.bar"
+	err = striper.SetXattr(name, xname, []byte("razzmatazz"))
+	require.NoError(suite.T(), err)
+
+	buf := make([]byte, 32)
+	size, err := striper.GetXattr(name, xname, buf)
+	require.NoError(suite.T(), err)
+	require.Equal(suite.T(), 10, size)
+	require.Equal(suite.T(), "razzmatazz", string(buf[:size]))
+
+	err = striper.RmXattr(name, xname)
+	require.NoError(suite.T(), err)
+
+	size, err = striper.GetXattr(name, xname, buf)
+	require.Error(suite.T(), err)
+	require.Equal(suite.T(), -61, err.(radosStriperError).ErrorCode())
+}
+
+func (suite *StriperTestSuite) TestListXattrs() {
+	ioctx := suite.defaultContext()
+	defer ioctx.Destroy()
+
+	striper, err := New(ioctx)
+	require.NoError(suite.T(), err)
+	defer striper.Destroy()
+
+	name := "TestListXattrs"
+	err = striper.Write(name, []byte("foo"), 0)
+	require.NoError(suite.T(), err)
+
+	err = striper.SetXattr(name, "foo.bar", []byte("razzmatazz"))
+	require.NoError(suite.T(), err)
+	err = striper.SetXattr(name, "foo.baz", []byte("razzle"))
+	require.NoError(suite.T(), err)
+	err = striper.SetXattr(name, "foo.zap", []byte("dazzle"))
+	require.NoError(suite.T(), err)
+
+	xm, err := striper.ListXattrs(name)
+	require.NoError(suite.T(), err)
+	require.Len(suite.T(), xm, 3)
+	require.Equal(suite.T(), "razzmatazz", string(xm["foo.bar"]))
+	require.Equal(suite.T(), "razzle", string(xm["foo.baz"]))
+	require.Equal(suite.T(), "dazzle", string(xm["foo.zap"]))
+
+	err = striper.RmXattr(name, "foo.bar")
+	require.NoError(suite.T(), err)
+
+	xm, err = striper.ListXattrs(name)
+	require.NoError(suite.T(), err)
+	require.Len(suite.T(), xm, 2)
+	require.Equal(suite.T(), "razzle", string(xm["foo.baz"]))
+	require.Equal(suite.T(), "dazzle", string(xm["foo.zap"]))
+}

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -20,9 +20,11 @@ RUN true \
         "libcephfs-devel-${cv}" \
         "librados-devel-${cv}" \
         "librbd-devel-${cv}" \
+        "libradosstriper-devel-${cv}" \
         libcephfs2-debuginfo \
         librados2-debuginfo \
         librbd1-debuginfo \
+        libradosstriper1-debuginfo \
     && yum clean all \
     && true
 

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -8,19 +8,23 @@ FROM ${CEPH_IMG}:${CEPH_TAG}
 ARG GO_CEPH_VERSION
 ENV GO_CEPH_VERSION=${GO_CEPH_VERSION:-$CEPH_VERSION}
 
-RUN true && \
-    echo "Check: [ ${CEPH_VERSION} = ${GO_CEPH_VERSION} ]" && \
-    [ "${CEPH_VERSION}" = "${GO_CEPH_VERSION}" ] && \
-    (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) && \
-    yum update -y --disablerepo=ganesha && \
-    cv="$(rpm -q --queryformat '%{version}-%{release}' ceph-common)" && \
-    yum install -y \
-    git wget /usr/bin/curl make \
-    /usr/bin/cc /usr/bin/c++ \
-    "libcephfs-devel-${cv}" "librados-devel-${cv}" "librbd-devel-${cv}" \
-    gdb libcephfs2-debuginfo librados2-debuginfo librbd1-debuginfo && \
-    yum clean all && \
-    true
+RUN true \
+    && echo "Check: [ ${CEPH_VERSION} = ${GO_CEPH_VERSION} ]" \
+    && [ "${CEPH_VERSION}" = "${GO_CEPH_VERSION}" ] \
+    && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
+    && yum update -y --disablerepo=ganesha \
+    && cv="$(rpm -q --queryformat '%{version}-%{release}' ceph-common)" \
+    && yum install -y \
+        git wget /usr/bin/curl make \
+        /usr/bin/cc /usr/bin/c++ gdb \
+        "libcephfs-devel-${cv}" \
+        "librados-devel-${cv}" \
+        "librbd-devel-${cv}" \
+        libcephfs2-debuginfo \
+        librados2-debuginfo \
+        librbd1-debuginfo \
+    && yum clean all \
+    && true
 
 ARG GO_VERSION=1.21.8
 ENV GO_VERSION=${GO_VERSION}


### PR DESCRIPTION
Add a new `rados/striper` package that wraps Ceph's libradosstriper. The libradosstriper library builds on top of the librados library to support striping large "objects" over multiple RADOS objects.

Fixes: #1011


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
