### PR TITLE
github: Update mergify config to replace deprecated attributes

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,11 +1,4 @@
 ---
-defaults:
-  actions:
-    queue:
-      name: default
-      method: rebase
-      update_method: rebase
-
 # each test should be listed separately, do not use regular expressions:
 # https://docs.mergify.io/conditions.html#validating-all-status-check
 # Until mergify allows us to have default conditions, we will need to
@@ -19,6 +12,8 @@ queue_rules:
       - check-success=test-suite (pacific)
       - check-success=test-suite (quincy)
       - check-success=test-suite (reef)
+    merge_method: rebase
+    update_method: rebase
 
 pull_request_rules:
   # Clearing approvals after content changes


### PR DESCRIPTION
> ❗❗ Action Required ❗❗
> 
> **The configuration uses the deprecated `merge_method` attribute of the queue action in one or more `pull_request_rules`. It must now be used under the `queue_rules` configuration.**
> A brownout is planned on August 26th, 2024.
> This option will be removed on September 23rd, 2024. For more information: https://docs.mergify.com/configuration/file-format/#queue-rules
> 
> ❗❗ Action Required ❗❗
> 
> **The configuration uses the deprecated `update_method` attribute of the queue action in one or more `pull_request_rules`. It must now be used under the `queue_rules` configuration.**
> A brownout is planned on August 26th, 2024.
> This option will be removed on September 23rd, 2024. For more information: https://docs.mergify.com/configuration/file-format/#queue-rules
> 

ref: https://docs.mergify.com/workflow/actions/queue/#parameters