### PR TITLE
rbd: implement librbd.rbd_group_snap_get_info

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1961,6 +1961,12 @@
         "comment": "CloneImageByID creates a clone of the image from a snapshot with the given\nID in the provided io-context with the given name and image options.\n\nImplements:\n\n\tint rbd_clone4(rados_ioctx_t p_ioctx, const char *p_name,\n\t               uint64_t p_snap_id, rados_ioctx_t c_ioctx,\n\t               const char *c_name, rbd_image_options_t c_opts);\n",
         "added_in_version": "v0.29.0",
         "expected_stable_version": "v0.31.0"
+      },
+      {
+        "name": "GroupSnapGetInfo",
+        "comment": "GroupSnapGetInfo returns a slice of RBD image snapshots that are part of a\ngroup snapshot.\n\nImplements:\n\n\tint rbd_group_snap_get_info(rados_ioctx_t group_p,\n\t                        const char *group_name,\n\t                        const char *snap_name,\n\t                        rbd_group_snap_info2_t *snaps);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -27,6 +27,7 @@ WriteOp.Exec | v0.29.0 | v0.31.0 |
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 CloneImageByID | v0.29.0 | v0.31.0 | 
+GroupSnapGetInfo | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ### Deprecated APIs
 

--- a/rbd/group_snap.go
+++ b/rbd/group_snap.go
@@ -91,11 +91,25 @@ const (
 	GroupSnapStateComplete = GroupSnapState(C.RBD_GROUP_SNAP_STATE_COMPLETE)
 )
 
-// GroupSnapInfo values are returned by GroupSnapList, representing the
-// snapshots that are part of an rbd group.
+// GroupSnap contains the information of a single snapshot that is part of a
+// group snapshot.
+type GroupSnap struct {
+	Name   string
+	PoolID uint64
+	SnapID uint64
+}
+
+// GroupSnapInfo values are returned by GroupSnapList and GroupSnapGetInfo,
+// representing the group snapshots that are created of an rbd group.
+// SnapName, ID and Snapshots are only set by the GroupSnapGetInfo function.
 type GroupSnapInfo struct {
 	Name  string
 	State GroupSnapState
+
+	SnapName string
+	ID       string
+
+	Snapshots []GroupSnap
 }
 
 // GroupSnapList returns a slice of snapshots in a group.

--- a/rbd/group_snap_info.go
+++ b/rbd/group_snap_info.go
@@ -1,0 +1,71 @@
+//go:build ceph_preview && !(nautilus || octopus || pacific || quincy || reef || squid)
+
+package rbd
+
+/*
+#cgo LDFLAGS: -lrbd
+#include <errno.h>
+#include <stdlib.h>
+#include <rbd/librbd.h>
+
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/cutil"
+	"github.com/ceph/go-ceph/rados"
+)
+
+type imgSnapInfoArray [cutil.MaxIdx]C.rbd_group_image_snap_info_t
+
+// GroupSnapGetInfo returns a slice of RBD image snapshots that are part of a
+// group snapshot.
+//
+// Implements:
+//
+//	int rbd_group_snap_get_info(rados_ioctx_t group_p,
+//	                        const char *group_name,
+//	                        const char *snap_name,
+//	                        rbd_group_snap_info2_t *snaps);
+func GroupSnapGetInfo(ioctx *rados.IOContext, group, snap string) (GroupSnapInfo, error) {
+	cGroupName := C.CString(group)
+	defer C.free(unsafe.Pointer(cGroupName))
+	cSnapName := C.CString(snap)
+	defer C.free(unsafe.Pointer(cSnapName))
+
+	cSnapInfo := C.rbd_group_snap_info2_t{}
+
+	ret := C.rbd_group_snap_get_info(
+		cephIoctx(ioctx),
+		cGroupName,
+		cSnapName,
+		&cSnapInfo)
+	err := getErrorIfNegative(ret)
+	if err != nil {
+		return GroupSnapInfo{}, err
+	}
+
+	snapCount := uint64(cSnapInfo.image_snaps_count)
+
+	snapInfo := GroupSnapInfo{
+		ID:        C.GoString(cSnapInfo.id),
+		Name:      C.GoString(cSnapInfo.name),
+		SnapName:  C.GoString(cSnapInfo.image_snap_name),
+		State:     GroupSnapState(cSnapInfo.state),
+		Snapshots: make([]GroupSnap, snapCount),
+	}
+
+	imgSnaps := (*imgSnapInfoArray)(unsafe.Pointer(cSnapInfo.image_snaps))[0:snapCount]
+
+	for i, imgSnap := range imgSnaps {
+		snapInfo.Snapshots[i].Name = C.GoString(imgSnap.image_name)
+		snapInfo.Snapshots[i].PoolID = uint64(imgSnap.pool_id)
+		snapInfo.Snapshots[i].SnapID = uint64(imgSnap.snap_id)
+	}
+
+	// free C memory allocated by C.rbd_group_snap_get_info call
+	C.rbd_group_snap_get_info_cleanup(&cSnapInfo)
+	return snapInfo, nil
+}

--- a/rbd/group_snap_info.go
+++ b/rbd/group_snap_info.go
@@ -1,4 +1,4 @@
-//go:build ceph_preview && !(nautilus || octopus || pacific || quincy || reef || squid)
+//go:build ceph_preview
 
 package rbd
 
@@ -8,17 +8,83 @@ package rbd
 #include <stdlib.h>
 #include <rbd/librbd.h>
 
+// Types and constants are copied from librbd.h with added "_" as prefix. This
+// prevents redefinition of the types on librbd versions that have them
+// already.
+
+typedef enum {
+  _RBD_GROUP_SNAP_NAMESPACE_TYPE_USER = 0
+} _rbd_group_snap_namespace_type_t;
+
+typedef struct {
+  char *image_name;
+  int64_t pool_id;
+  uint64_t snap_id;
+} _rbd_group_image_snap_info_t;
+
+typedef struct {
+  char *id;
+  char *name;
+  char *image_snap_name;
+  rbd_group_snap_state_t state;
+  _rbd_group_snap_namespace_type_t namespace_type;
+  size_t image_snaps_count;
+  _rbd_group_image_snap_info_t *image_snaps;
+} _rbd_group_snap_info2_t;
+
+// rbd_group_snap_get_info_fn matches the rbd_group_snap_get_info function signature.
+typedef int(*rbd_group_snap_get_info_fn)(rados_ioctx_t group_p,
+                                         const char *group_name,
+                                         const char *snap_name,
+                                         _rbd_group_snap_info2_t *snaps);
+
+// rbd_group_snap_get_info_dlsym take *fn as rbd_group_snap_get_info_fn and
+// calls the dynamically loaded rbd_group_snap_get_info function passed as 1st
+// argument.
+static inline int rbd_group_snap_get_info_dlsym(void *fn,
+                                                rados_ioctx_t group_p,
+                                                const char *group_name,
+                                                const char *snap_name,
+                                                _rbd_group_snap_info2_t *snaps) {
+  // cast function pointer fn to rbd_group_snap_get_info and call the function
+  return ((rbd_group_snap_get_info_fn) fn)(group_p, group_name, snap_name, snaps);
+}
+
+// rbd_group_snap_get_info_cleanup_fn matches the rbd_group_snap_get_info_cleanup function signature.
+typedef int(*rbd_group_snap_get_info_cleanup_fn)(_rbd_group_snap_info2_t *snaps);
+
+// rbd_group_snap_get_info_cleanup_dlsym take *fn as rbd_group_snap_get_info_cleanup_fn and
+// calls the dynamically loaded rbd_group_snap_get_info_cleanup function passed as 1st
+// argument.
+static inline int rbd_group_snap_get_info_cleanup_dlsym(void *fn,
+                                                _rbd_group_snap_info2_t *snaps) {
+  // cast function pointer fn to rbd_group_snap_get_info_cleanup and call the function
+  return ((rbd_group_snap_get_info_cleanup_fn) fn)(snaps);
+}
 */
 import "C"
 
 import (
+	"fmt"
+	"sync"
 	"unsafe"
 
 	"github.com/ceph/go-ceph/internal/cutil"
+	"github.com/ceph/go-ceph/internal/dlsym"
 	"github.com/ceph/go-ceph/rados"
 )
 
-type imgSnapInfoArray [cutil.MaxIdx]C.rbd_group_image_snap_info_t
+type imgSnapInfoArray [cutil.MaxIdx]C._rbd_group_image_snap_info_t
+
+var (
+	rbdGroupGetSnapInfoOnce sync.Once
+	rbdGroupGetSnapInfo     unsafe.Pointer
+	rbdGroupGetSnapInfoErr  error
+
+	rbdGroupSnapGetInfoCleanupOnce sync.Once
+	rbdGroupSnapGetInfoCleanup     unsafe.Pointer
+	rbdGroupSnapGetInfoCleanupErr  error
+)
 
 // GroupSnapGetInfo returns a slice of RBD image snapshots that are part of a
 // group snapshot.
@@ -30,14 +96,31 @@ type imgSnapInfoArray [cutil.MaxIdx]C.rbd_group_image_snap_info_t
 //	                        const char *snap_name,
 //	                        rbd_group_snap_info2_t *snaps);
 func GroupSnapGetInfo(ioctx *rados.IOContext, group, snap string) (GroupSnapInfo, error) {
+	rbdGroupGetSnapInfoOnce.Do(func() {
+		rbdGroupGetSnapInfo, rbdGroupGetSnapInfoErr = dlsym.LookupSymbol("rbd_group_snap_get_info")
+	})
+
+	if rbdGroupGetSnapInfoErr != nil {
+		return GroupSnapInfo{}, fmt.Errorf("%w: %w", ErrNotImplemented, rbdGroupGetSnapInfoErr)
+	}
+
+	rbdGroupSnapGetInfoCleanupOnce.Do(func() {
+		rbdGroupSnapGetInfoCleanup, rbdGroupSnapGetInfoCleanupErr = dlsym.LookupSymbol("rbd_group_snap_get_info_cleanup")
+	})
+
+	if rbdGroupSnapGetInfoCleanupErr != nil {
+		return GroupSnapInfo{}, fmt.Errorf("%w: %w", ErrNotImplemented, rbdGroupSnapGetInfoCleanupErr)
+	}
+
 	cGroupName := C.CString(group)
 	defer C.free(unsafe.Pointer(cGroupName))
 	cSnapName := C.CString(snap)
 	defer C.free(unsafe.Pointer(cSnapName))
 
-	cSnapInfo := C.rbd_group_snap_info2_t{}
+	cSnapInfo := C._rbd_group_snap_info2_t{}
 
-	ret := C.rbd_group_snap_get_info(
+	ret := C.rbd_group_snap_get_info_dlsym(
+		rbdGroupGetSnapInfo,
 		cephIoctx(ioctx),
 		cGroupName,
 		cSnapName,
@@ -66,6 +149,6 @@ func GroupSnapGetInfo(ioctx *rados.IOContext, group, snap string) (GroupSnapInfo
 	}
 
 	// free C memory allocated by C.rbd_group_snap_get_info call
-	C.rbd_group_snap_get_info_cleanup(&cSnapInfo)
+	C.rbd_group_snap_get_info_cleanup_dlsym(rbdGroupSnapGetInfoCleanup, &cSnapInfo)
 	return snapInfo, nil
 }

--- a/rbd/group_snap_test.go
+++ b/rbd/group_snap_test.go
@@ -104,6 +104,26 @@ func TestGroupSnapshots(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, gsl, 0)
 	})
+	t.Run("groupSnapGetInfo", func(t *testing.T) {
+		err := GroupSnapCreate(ioctx, gname, "snapDetails")
+		assert.NoError(t, err)
+		defer func() {
+			err = GroupSnapRemove(ioctx, gname, "snapDetails")
+			assert.NoError(t, err)
+		}()
+
+		info, err := GroupSnapGetInfo(ioctx, gname, "snapDetails")
+		assert.NoError(t, err)
+
+		assert.Equal(t, GroupSnapStateComplete, info.State)
+
+		names := make([]string, len(info.Snapshots))
+		for i, snap := range info.Snapshots {
+			names[i] = snap.Name
+		}
+		assert.Contains(t, names, name1)
+		assert.Contains(t, names, name2)
+	})
 	t.Run("groupSnapRollback", func(t *testing.T) {
 		img, err := OpenImage(ioctx, name1, NoSnapshot)
 		assert.NoError(t, err)

--- a/rbd/group_snap_test.go
+++ b/rbd/group_snap_test.go
@@ -1,6 +1,7 @@
 package rbd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,6 +114,9 @@ func TestGroupSnapshots(t *testing.T) {
 		}()
 
 		info, err := GroupSnapGetInfo(ioctx, gname, "snapDetails")
+		if errors.Is(err, ErrNotImplemented) {
+			t.Skipf("GroupSnapGetInfo is not supported: %v", err)
+		}
 		assert.NoError(t, err)
 
 		assert.Equal(t, GroupSnapStateComplete, info.State)


### PR DESCRIPTION
The new GroupSnapGetInfo function can be used to get a list of the RBD
image snapshots that were created as part of the RBD group snapshot.

This feature is implemented in 2 steps:

1. direct librbd call (only in Ceph **main** branch)
2. modification to use `dlsym`

I hope that makes it easier to understand, and might help others contributing such dynamically loaded functions too.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs
