### PR TITLE
internal/dlsym: Define _GNU_SOURCE for RTLD_DEFAULT

### DIFF
--- a/internal/dlsym/dlsym.go
+++ b/internal/dlsym/dlsym.go
@@ -2,12 +2,10 @@ package dlsym
 
 // #cgo LDFLAGS: -ldl
 //
+// #define _GNU_SOURCE
+//
 // #include <stdlib.h>
 // #include <dlfcn.h>
-//
-// #ifndef RTLD_DEFAULT /* from dlfcn.h */
-// #define RTLD_DEFAULT ((void *) 0)
-// #endif
 import "C"
 
 import (


### PR DESCRIPTION
man [dlsym(3)](https://www.man7.org/linux/man-pages/man3/dlsym.3.html) says the following:

> The _GNU_SOURCE feature test macro must be defined in order to obtain the definitions of RTLD_DEFAULT and RTLD_NEXT from <dlfcn.h>.