### PR TITLE
Do not use standard names as function arguments

### DIFF
--- a/rados/snapshot.go
+++ b/rados/snapshot.go
@@ -85,8 +85,8 @@ func (ioctx *IOContext) GetSnapName(snapID SnapID) (string, error) {
 		err error
 	)
 	// range from 1k to 64KiB
-	retry.WithSizes(1024, 1<<16, func(len int) retry.Hint {
-		cLen := C.int(len)
+	retry.WithSizes(1024, 1<<16, func(length int) retry.Hint {
+		cLen := C.int(length)
 		buf = make([]byte, cLen)
 		ret := C.rados_ioctx_snap_get_name(
 			ioctx.ioctx,

--- a/rados/watcher.go
+++ b/rados/watcher.go
@@ -298,11 +298,11 @@ func (c *Conn) WatcherFlush() error {
 //
 // NOTE: starting with pacific this is implemented as a C function and this can
 // be replaced later
-func decodeNotifyResponse(response *C.char, len C.size_t) ([]NotifyAck, []NotifyTimeout) {
-	if len == 0 || response == nil {
+func decodeNotifyResponse(response *C.char, length C.size_t) ([]NotifyAck, []NotifyTimeout) {
+	if length == 0 || response == nil {
 		return nil, nil
 	}
-	b := (*[math.MaxInt32]byte)(unsafe.Pointer(response))[:len:len]
+	b := (*[math.MaxInt32]byte)(unsafe.Pointer(response))[:length:length]
 	pos := 0
 
 	num := binary.LittleEndian.Uint32(b[pos:])

--- a/rbd/snapshot_octopus.go
+++ b/rbd/snapshot_octopus.go
@@ -50,8 +50,8 @@ func (image *Image) GetSnapByID(snapID uint64) (string, error) {
 		err error
 	)
 	// range from 1k to 64KiB
-	retry.WithSizes(1024, 1<<16, func(len int) retry.Hint {
-		cLen := C.size_t(len)
+	retry.WithSizes(1024, 1<<16, func(length int) retry.Hint {
+		cLen := C.size_t(length)
 		buf = make([]byte, cLen)
 		ret := C.rbd_snap_get_name(
 			image.image,


### PR DESCRIPTION
`len` is already a standard library function. revive [v1.4.0](https://github.com/mgechev/revive/releases/tag/v1.4.0) started looking into function related variables for such standard names as part of redefines-builtin-id rule. Therefore use a different variable name instead of `len`.