### PR TITLE
Introduce common cephError type to compare errors between packages

### DIFF
--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -11,23 +11,8 @@ import (
 	"github.com/ceph/go-ceph/internal/errutil"
 )
 
-// cephFSError represents an error condition returned from the CephFS APIs.
-type cephFSError int
-
-// Error returns the error string for the cephFSError type.
-func (e cephFSError) Error() string {
-	return errutil.FormatErrorCode("cephfs", int(e))
-}
-
-func (e cephFSError) ErrorCode() int {
-	return int(e)
-}
-
 func getError(e C.int) error {
-	if e == 0 {
-		return nil
-	}
-	return cephFSError(e)
+	return errutil.GetError("cephfs", int(e))
 }
 
 // getErrorIfNegative converts a ceph return code to error if negative.
@@ -46,22 +31,16 @@ var (
 	// ErrEmptyArgument may be returned if a function argument is passed
 	// a zero-length slice or map.
 	ErrEmptyArgument = errors.New("Argument must contain at least one item")
-)
 
-// Public CephFSErrors:
-
-const (
 	// ErrNotConnected may be returned when client is not connected
 	// to a cluster.
-	ErrNotConnected = cephFSError(-C.ENOTCONN)
+	ErrNotConnected = getError(-C.ENOTCONN)
 	// ErrNotExist indicates a non-specific missing resource.
-	ErrNotExist = cephFSError(-C.ENOENT)
-)
+	ErrNotExist = getError(-C.ENOENT)
 
-// Private errors:
+	// Private errors:
 
-const (
-	errInvalid     = cephFSError(-C.EINVAL)
-	errNameTooLong = cephFSError(-C.ENAMETOOLONG)
-	errRange       = cephFSError(-C.ERANGE)
+	errInvalid     = getError(-C.EINVAL)
+	errNameTooLong = getError(-C.ENAMETOOLONG)
+	errRange       = getError(-C.ERANGE)
 )

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -118,13 +118,6 @@
         "comment": "RewindDir sets the directory stream to the beginning of the directory.\n\nImplements:\n void ceph_rewinddir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);\n"
       },
       {
-        "name": "cephFSError.Error",
-        "comment": "Error returns the error string for the cephFSError type.\n"
-      },
-      {
-        "name": "cephFSError.ErrorCode"
-      },
-      {
         "name": "MountInfo.Open",
         "comment": "Open a file at the given path. The flags are the same os flags as\na local open call. Mode is the same mode bits as a local open call.\n\nImplements:\n int ceph_open(struct ceph_mount_info *cmount, const char *path, int flags, mode_t mode);\n"
       },
@@ -749,13 +742,6 @@
         "comment": "GetPoolByID returns the name of a pool by a given ID.\n"
       },
       {
-        "name": "radosError.Error",
-        "comment": "Error returns the error string for the radosError type.\n"
-      },
-      {
-        "name": "radosError.ErrorCode"
-      },
-      {
         "name": "IOContext.Pointer",
         "comment": "Pointer returns a pointer reference to an internal structure.\nThis function should NOT be used outside of go-ceph itself.\n"
       },
@@ -1209,12 +1195,6 @@
       {
         "name": "Image.EncryptionLoad",
         "comment": "EncryptionLoad enables IO on an open encrypted image\n\nImplements:\n int rbd_encryption_load(rbd_image_t image,\n                         rbd_encryption_format_t format,\n                         rbd_encryption_options_t opts,\n                         size_t opts_size);\n"
-      },
-      {
-        "name": "rbdError.Error"
-      },
-      {
-        "name": "rbdError.ErrorCode"
       },
       {
         "name": "FeatureSetFromNames",

--- a/internal/errutil/error.go
+++ b/internal/errutil/error.go
@@ -1,0 +1,57 @@
+package errutil
+
+type cephErrno int
+
+// Error returns the error string for the errno.
+func (e cephErrno) Error() string {
+	_, strerror := FormatErrno(int(e))
+	return strerror
+}
+
+// cephError combines the source/component that generated the error and its
+// related errno.
+type cephError struct {
+	source string
+	errno  cephErrno
+}
+
+// Error returns the error string with the source and errno.
+func (e cephError) Error() string {
+	return FormatErrorCode(e.source, int(e.errno))
+}
+
+// Unwrap returns an error without the source.
+func (e cephError) Unwrap() error {
+	if e.errno == 0 {
+		return nil
+	}
+
+	return e.errno
+}
+
+// Is checks if both errors have the same errno.
+func (e cephError) Is(err error) bool {
+	ce, ok := err.(cephError)
+	if !ok {
+		return false
+	}
+
+	return e.errno == ce.errno
+}
+
+// ErrorCode returns the errno of the error.
+func (e cephError) ErrorCode() int {
+	return int(e.errno)
+}
+
+// GetError returns a new error that can be compared with errors.Is(),
+// independently of the source/component of the error.
+func GetError(source string, e int) error {
+	if e == 0 {
+		return nil
+	}
+	return cephError{
+		source: source,
+		errno:  cephErrno(int(e)),
+	}
+}

--- a/internal/errutil/error_test.go
+++ b/internal/errutil/error_test.go
@@ -1,0 +1,22 @@
+package errutil
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCephError(t *testing.T) {
+	radosErr := cephErrno(107)
+	assert.Equal(t, "Transport endpoint is not connected", radosErr.Error())
+
+	cephFSErr := GetError("cephfs", 2)
+	assert.Equal(t, "cephfs: ret=2, No such file or directory",
+		cephFSErr.Error())
+	assert.Equal(t, 2, cephFSErr.(cephError).ErrorCode())
+
+	rbdErr := GetError("rbd", 2)
+	assert.True(t, errors.Is(cephFSErr, rbdErr))
+	assert.True(t, errors.Unwrap(cephFSErr) == errors.Unwrap(rbdErr))
+}

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -291,11 +291,11 @@ func (c *Conn) GetPoolByName(name string) (int64, error) {
 	}
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	ret := int64(C.rados_pool_lookup(c.cluster, cName))
+	ret := C.rados_pool_lookup(c.cluster, cName)
 	if ret < 0 {
-		return 0, radosError(ret)
+		return 0, getError(C.int(ret))
 	}
-	return ret, nil
+	return int64(ret), nil
 }
 
 // GetPoolByID returns the name of a pool by a given ID.
@@ -305,9 +305,9 @@ func (c *Conn) GetPoolByID(id int64) (string, error) {
 		return "", err
 	}
 	cid := C.int64_t(id)
-	ret := int(C.rados_pool_reverse_lookup(c.cluster, cid, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf))))
+	ret := C.rados_pool_reverse_lookup(c.cluster, cid, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
 	if ret < 0 {
-		return "", radosError(ret)
+		return "", getError(ret)
 	}
 	return C.GoString((*C.char)(unsafe.Pointer(&buf[0]))), nil
 }

--- a/rados/errors.go
+++ b/rados/errors.go
@@ -11,23 +11,46 @@ import (
 	"github.com/ceph/go-ceph/internal/errutil"
 )
 
-// radosError represents an error condition returned from the Ceph RADOS APIs.
-type radosError int
+// Public go errors:
 
-// Error returns the error string for the radosError type.
-func (e radosError) Error() string {
-	return errutil.FormatErrorCode("rados", int(e))
-}
+var (
+	// ErrNotConnected is returned when functions are called
+	// without a RADOS connection.
+	ErrNotConnected = getError(-C.ENOTCONN)
+	// ErrEmptyArgument may be returned if a function argument is passed
+	// a zero-length slice or map.
+	ErrEmptyArgument = errors.New("Argument must contain at least one item")
+	// ErrInvalidIOContext may be returned if an api call requires an IOContext
+	// but IOContext is not ready for use.
+	ErrInvalidIOContext = errors.New("IOContext is not ready for use")
+	// ErrOperationIncomplete is returned from write op or read op steps for
+	// which the operation has not been performed yet.
+	ErrOperationIncomplete = errors.New("Operation has not been performed yet")
 
-func (e radosError) ErrorCode() int {
-	return int(e)
-}
+	// ErrNotFound indicates a missing resource.
+	ErrNotFound = getError(-C.ENOENT)
+	// ErrPermissionDenied indicates a permissions issue.
+	ErrPermissionDenied = getError(-C.EPERM)
+	// ErrObjectExists indicates that an exclusive object creation failed.
+	ErrObjectExists = getError(-C.EEXIST)
 
-func getError(e C.int) error {
-	if e == 0 {
-		return nil
-	}
-	return radosError(e)
+	// RadosErrorNotFound indicates a missing resource.
+	//
+	// Deprecated: use ErrNotFound instead
+	RadosErrorNotFound = ErrNotFound
+	// RadosErrorPermissionDenied indicates a permissions issue.
+	//
+	// Deprecated: use ErrPermissionDenied instead
+	RadosErrorPermissionDenied = ErrPermissionDenied
+
+	// Private errors:
+
+	errNameTooLong = getError(-C.ENAMETOOLONG)
+	errRange       = getError(-C.ERANGE)
+)
+
+func getError(errno C.int) error {
+	return errutil.GetError("rados", int(errno))
 }
 
 // getErrorIfNegative converts a ceph return code to error if negative.
@@ -39,48 +62,3 @@ func getErrorIfNegative(ret C.int) error {
 	}
 	return getError(ret)
 }
-
-// Public go errors:
-
-var (
-	// ErrNotConnected is returned when functions are called
-	// without a RADOS connection.
-	ErrNotConnected = errors.New("RADOS not connected")
-	// ErrEmptyArgument may be returned if a function argument is passed
-	// a zero-length slice or map.
-	ErrEmptyArgument = errors.New("Argument must contain at least one item")
-	// ErrInvalidIOContext may be returned if an api call requires an IOContext
-	// but IOContext is not ready for use.
-	ErrInvalidIOContext = errors.New("IOContext is not ready for use")
-	// ErrOperationIncomplete is returned from write op or read op steps for
-	// which the operation has not been performed yet.
-	ErrOperationIncomplete = errors.New("Operation has not been performed yet")
-)
-
-// Public radosErrors:
-
-const (
-	// ErrNotFound indicates a missing resource.
-	ErrNotFound = radosError(-C.ENOENT)
-	// ErrPermissionDenied indicates a permissions issue.
-	ErrPermissionDenied = radosError(-C.EPERM)
-	// ErrObjectExists indicates that an exclusive object creation failed.
-	ErrObjectExists = radosError(-C.EEXIST)
-
-	// RadosErrorNotFound indicates a missing resource.
-	//
-	// Deprecated: use ErrNotFound instead
-	RadosErrorNotFound = ErrNotFound
-	// RadosErrorPermissionDenied indicates a permissions issue.
-	//
-	// Deprecated: use ErrPermissionDenied instead
-	RadosErrorPermissionDenied = ErrPermissionDenied
-)
-
-// Private errors:
-
-const (
-	errNameTooLong = radosError(-C.ENAMETOOLONG)
-
-	errRange = radosError(-C.ERANGE)
-)

--- a/rados/ioctx.go
+++ b/rados/ioctx.go
@@ -640,7 +640,7 @@ func (ioctx *IOContext) ListLockers(oid, name string) (*LockInfo, error) {
 	}
 
 	if ret < 0 {
-		return nil, radosError(ret)
+		return nil, getError(C.int(ret))
 	}
 	return &LockInfo{int(ret), cExclusive == 1, C.GoString(cTag), splitCString(cClients, cClientsLen), splitCString(cCookies, cCookiesLen), splitCString(cAddrs, cAddrsLen)}, nil
 }

--- a/rbd/clone_image_by_id.go
+++ b/rbd/clone_image_by_id.go
@@ -52,7 +52,7 @@ var (
 func CloneImageByID(ioctx *rados.IOContext, parentName string, snapID uint64,
 	destctx *rados.IOContext, name string, rio *ImageOptions) error {
 	if rio == nil {
-		return rbdError(C.EINVAL)
+		return getError(C.EINVAL)
 	}
 
 	rbdClone4Once.Do(func() {

--- a/rbd/diff_iterate.go
+++ b/rbd/diff_iterate.go
@@ -96,7 +96,7 @@ func (image *Image) DiffIterate(config DiffIterateConfig) error {
 		return err
 	}
 	if config.Callback == nil {
-		return rbdError(C.EINVAL)
+		return getError(C.EINVAL)
 	}
 
 	var cSnapName *C.char

--- a/rbd/features.go
+++ b/rbd/features.go
@@ -171,7 +171,7 @@ func (image *Image) GetFeatures() (features uint64, err error) {
 	}
 
 	if ret := C.rbd_get_features(image.image, (*C.uint64_t)(&features)); ret < 0 {
-		return 0, rbdError(ret)
+		return 0, getError(ret)
 	}
 
 	return features, nil

--- a/rbd/group_snap.go
+++ b/rbd/group_snap.go
@@ -204,7 +204,7 @@ func GroupSnapRollbackWithProgress(
 	cb GroupSnapRollbackCallback, data interface{}) error {
 	// the provided callback must be a real function
 	if cb == nil {
-		return rbdError(C.EINVAL)
+		return getError(C.EINVAL)
 	}
 
 	cGroupName := C.CString(group)

--- a/rbd/metadata.go
+++ b/rbd/metadata.go
@@ -62,7 +62,7 @@ func (image *Image) SetMetadata(key string, value string) error {
 
 	ret := C.rbd_metadata_set(image.image, cKey, cValue)
 	if ret < 0 {
-		return rbdError(ret)
+		return getError(ret)
 	}
 
 	return nil
@@ -83,7 +83,7 @@ func (image *Image) RemoveMetadata(key string) error {
 
 	ret := C.rbd_metadata_remove(image.image, cKey)
 	if ret < 0 {
-		return rbdError(ret)
+		return getError(ret)
 	}
 
 	return nil

--- a/rbd/resize.go
+++ b/rbd/resize.go
@@ -57,7 +57,7 @@ func resize2Callback(
 func (image *Image) Resize2(size uint64, allowShrink bool, cb Resize2ProgressCallback, data interface{}) error {
 	// the provided callback must be a real function
 	if cb == nil {
-		return rbdError(C.EINVAL)
+		return getError(C.EINVAL)
 	}
 
 	if err := image.validate(imageIsOpen); err != nil {

--- a/rbd/snapshot.go
+++ b/rbd/snapshot.go
@@ -33,7 +33,7 @@ func (image *Image) CreateSnapshot(snapname string) (*Snapshot, error) {
 
 	ret := C.rbd_snap_create(image.image, cSnapName)
 	if ret < 0 {
-		return nil, rbdError(ret)
+		return nil, getError(ret)
 	}
 
 	return &Snapshot{
@@ -147,7 +147,7 @@ func (snapshot *Snapshot) IsProtected() (bool, error) {
 	ret := C.rbd_snap_is_protected(snapshot.image.image, cSnapName,
 		&cIsProtected)
 	if ret < 0 {
-		return false, rbdError(ret)
+		return false, getError(ret)
 	}
 
 	return cIsProtected != 0, nil

--- a/rbd/snapshot_nautilus.go
+++ b/rbd/snapshot_nautilus.go
@@ -32,7 +32,7 @@ func (image *Image) GetParentInfo(pool, name, snapname []byte) error {
 	parentSnap := C.rbd_snap_spec_t{}
 	ret := C.rbd_get_parent(image.image, &parentImage, &parentSnap)
 	if ret != 0 {
-		return rbdError(ret)
+		return getError(ret)
 	}
 
 	defer C.rbd_linked_image_spec_cleanup(&parentImage)
@@ -40,26 +40,26 @@ func (image *Image) GetParentInfo(pool, name, snapname []byte) error {
 
 	strlen := int(C.strlen(parentImage.pool_name))
 	if len(pool) < strlen {
-		return rbdError(C.ERANGE)
+		return getError(C.ERANGE)
 	}
 	if copy(pool, C.GoString(parentImage.pool_name)) != strlen {
-		return rbdError(C.ERANGE)
+		return getError(C.ERANGE)
 	}
 
 	strlen = int(C.strlen(parentImage.image_name))
 	if len(name) < strlen {
-		return rbdError(C.ERANGE)
+		return getError(C.ERANGE)
 	}
 	if copy(name, C.GoString(parentImage.image_name)) != strlen {
-		return rbdError(C.ERANGE)
+		return getError(C.ERANGE)
 	}
 
 	strlen = int(C.strlen(parentSnap.name))
 	if len(snapname) < strlen {
-		return rbdError(C.ERANGE)
+		return getError(C.ERANGE)
 	}
 	if copy(snapname, C.GoString(parentSnap.name)) != strlen {
-		return rbdError(C.ERANGE)
+		return getError(C.ERANGE)
 	}
 
 	return nil

--- a/rbd/sparsify.go
+++ b/rbd/sparsify.go
@@ -60,7 +60,7 @@ func (image *Image) SparsifyWithProgress(
 ) error {
 	// the provided callback must be a real function
 	if cb == nil {
-		return rbdError(C.EINVAL)
+		return getError(C.EINVAL)
 	}
 
 	if err := image.validate(imageIsOpen); err != nil {


### PR DESCRIPTION
A new `internal/errutil.cephError` can be used as a common type to replace all error types that are specific to the different packages (`cephfsError`, `radosError`, `rbdError`). By using the new `cephError` type everywhere, it becomes possible to match `rados.ErrNotFound` and `rbd.ErrNotFound` with the standard `errors.Is()` function.

Some go-ceph functions from the cephfs and rbd packages can return errors generated by the lower-level rados package. In such a case, a caller may need to check for e.g. `rados.ErrNotFound` as well as `rbd.ErrNotFound`, depending on the function that was called. This is prone to errors, as users of go-ceph may not inspect what the go-ceph function does and which error type it could return.

Closes: #1031

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
