### PR TITLE
docs: fix version number for new GroupSnapGetInfo api

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1965,8 +1965,8 @@
       {
         "name": "GroupSnapGetInfo",
         "comment": "GroupSnapGetInfo returns a slice of RBD image snapshots that are part of a\ngroup snapshot.\n\nImplements:\n\n\tint rbd_group_snap_get_info(rados_ioctx_t group_p,\n\t                        const char *group_name,\n\t                        const char *snap_name,\n\t                        rbd_group_snap_info2_t *snaps);\n",
-        "added_in_version": "$NEXT_RELEASE",
-        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+        "added_in_version": "v0.30.0",
+        "expected_stable_version": "v0.32.0"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -27,7 +27,7 @@ WriteOp.Exec | v0.29.0 | v0.31.0 |
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 CloneImageByID | v0.29.0 | v0.31.0 | 
-GroupSnapGetInfo | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+GroupSnapGetInfo | v0.30.0 | v0.32.0 | 
 
 ### Deprecated APIs
 


### PR DESCRIPTION
Release prep task. Fix versions for one new api.
FWIW no apis become stable in v0.30.
