### PR TITLE
docs: update README for release v0.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ go test -tags pacific ....
 
 | go-ceph version | Supported Ceph Versions | Deprecated Ceph Versions |
 | --------------- | ------------------------| -------------------------|
+| v0.30.0         | pacific, quincy, reef, squid   | octopus           |
 | v0.29.0         | pacific, quincy, reef   | octopus                  |
 | v0.28.0         | pacific, quincy, reef   | nautilus, octopus        |
 | v0.27.0         | pacific, quincy, reef   | nautilus, octopus        |


### PR DESCRIPTION
Add the v0.30.0 release to the versions table. This adds ceph squid to the supported ceph versions in the table.