### PR TITLE
rados: implement rados_getaddrs

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1159,6 +1159,12 @@
         "comment": "Exec executes an OSD class method on an object.\nSee rados_exec() in the RADOS C api documentation for a general description.\n\nImplements:\n\n\tvoid rados_write_op_exec(rados_write_op_t write_op,\n\t                         const char *cls,\n\t                         const char *method,\n\t                         const char *in_buf,\n\t                         size_t in_len,\n\t                         int *prval)\n",
         "added_in_version": "v0.29.0",
         "expected_stable_version": "v0.31.0"
+      },
+      {
+        "name": "Conn.GetAddrs",
+        "comment": "GetAddrs returns the addresses of the RADOS session,\nsuitable for blocklisting.\n\nImplements:\n\n\tint rados_getaddrs(rados_t cluster, char **addrs)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -19,6 +19,7 @@ Name | Added in Version | Expected Stable Version |
 ReadOpExecStep.Bytes | v0.29.0 | v0.31.0 | 
 ReadOp.Exec | v0.29.0 | v0.31.0 | 
 WriteOp.Exec | v0.29.0 | v0.31.0 | 
+Conn.GetAddrs | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: rbd
 

--- a/rados/rados_getaddrs.go
+++ b/rados/rados_getaddrs.go
@@ -1,0 +1,30 @@
+//go:build ceph_preview
+
+package rados
+
+// #cgo LDFLAGS: -lrados
+// #include <stdlib.h>
+// #include <rados/librados.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+// GetAddrs returns the addresses of the RADOS session,
+// suitable for blocklisting.
+//
+// Implements:
+//
+//	int rados_getaddrs(rados_t cluster, char **addrs)
+func (c *Conn) GetAddrs() (string, error) {
+	var cAddrs *C.char
+	defer C.free(unsafe.Pointer(cAddrs))
+
+	ret := C.rados_getaddrs(c.cluster, &cAddrs)
+	if ret < 0 {
+		return "", getError(ret)
+	}
+
+	return C.GoString(cAddrs), nil
+}

--- a/rados/rados_getaddrs_test.go
+++ b/rados/rados_getaddrs_test.go
@@ -1,0 +1,15 @@
+//go:build ceph_preview
+
+package rados
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestGetAddrs() {
+	suite.SetupConnection()
+
+	addrs, err := suite.conn.GetAddrs()
+	assert.NoError(suite.T(), err)
+	assert.NotEmpty(suite.T(), addrs, "rados_getaddrs")
+}


### PR DESCRIPTION
This PR implements binding for rados_getaddrs.

Includes a unit test.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs
