### PR TITLE
containers: work around protobuf package issues

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -11,10 +11,11 @@ ENV GO_CEPH_VERSION=${GO_CEPH_VERSION:-$CEPH_VERSION}
 RUN true \
     && echo "Check: [ ${CEPH_VERSION} = ${GO_CEPH_VERSION} ]" \
     && [ "${CEPH_VERSION}" = "${GO_CEPH_VERSION}" ] \
-    && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
-    && yum update -y --disablerepo=ganesha \
+    && enablerepos="--enablerepo=crb" \
+    && . /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then enablerepos=""; find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi \
+    && yum update -y $enablerepos \
     && cv="$(rpm -q --queryformat '%{version}-%{release}' ceph-common)" \
-    && yum install -y \
+    && yum install $enablerepos -y \
         git wget /usr/bin/curl make \
         /usr/bin/cc /usr/bin/c++ gdb \
         "libcephfs-devel-${cv}" \


### PR DESCRIPTION
Work around errors related to protobuf package locations on centos. This is triggered by our squid jobs failing with errors like:
```
22.40  Problem: protobuf-3.14.0-13.el9.i686 from appstream  does not
belong to a distupgrade repository
22.40   - package protobuf-compiler-3.14.0-13.el9.x86_64 from @System
requires protobuf = 3.14.0-13.el9, but none of the providers can be
installed
22.40   - cannot install both protobuf-3.14.0-14.el9.x86_64 from
appstream and protobuf-3.14.0-13.el9.x86_64 from @System
22.40   - cannot install both protobuf-3.14.0-14.el9.x86_64 from
appstream and protobuf-3.14.0-13.el9.x86_64 from appstream
22.40   - cannot install the best update candidate for package
protobuf-3.14.0-13.el9.x86_64
22.40   - problem with installed package
protobuf-compiler-3.14.0-13.el9.x86_64
22.40 (try to add '--allowerasing' to command line to replace
conflicting packages or '--skip-broken' to skip uninstallable packages
or '--nobest' to use not only best candidate packages)
------
```

I tested this change on both squid and reef locally and both built the ci image successfully.

