### PR TITLE
cephfs: Adjust with the fallocate API changes

### DIFF
--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -37,6 +37,9 @@ var (
 	ErrNotConnected = getError(-C.ENOTCONN)
 	// ErrNotExist indicates a non-specific missing resource.
 	ErrNotExist = getError(-C.ENOENT)
+	// ErrOpNotSupported is returned in general for operations that are not
+	// supported.
+	ErrOpNotSupported = getError(-C.EOPNOTSUPP)
 
 	// Private errors:
 

--- a/cephfs/file_fallocate_mode_zero_unsupported_test.go
+++ b/cephfs/file_fallocate_mode_zero_unsupported_test.go
@@ -1,0 +1,30 @@
+//go:build main
+
+package cephfs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFallocateModeZeroUnsupported and this test file exists merely to track
+// the backports for https://tracker.ceph.com/issues/68026. Once they are
+// available with release versions this can probably vanish.
+func TestFallocateModeZeroUnsupported(t *testing.T) {
+	mount := fsConnect(t)
+	defer fsDisconnect(t, mount)
+	fname := "file1.txt"
+	f, err := mount.Open(fname, os.O_RDWR|os.O_CREATE, 0644)
+	assert.NoError(t, err)
+	assert.NotNil(t, f)
+	defer func() {
+		assert.NoError(t, f.Close())
+		assert.NoError(t, mount.Unlink(fname))
+	}()
+
+	err = f.Fallocate(FallocNoFlag, 0, 10)
+	assert.Error(t, err)
+	assert.Equal(t, ErrOpNotSupported, err)
+}

--- a/cephfs/file_test.go
+++ b/cephfs/file_test.go
@@ -8,6 +8,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	serverVersion string
+)
+
+const (
+	cephOctopus = "octopus"
+	cephPacfic  = "pacific"
+	cephQuincy  = "quincy"
+	cephReef    = "reef"
+	cephSquid   = "squid"
+	cephMain    = "main"
+)
+
+func init() {
+	switch vname := os.Getenv("CEPH_VERSION"); vname {
+	case cephOctopus, cephPacfic, cephQuincy, cephReef, cephSquid, cephMain:
+		serverVersion = vname
+	}
+}
+
 func TestFileOpen(t *testing.T) {
 	mount := fsConnect(t)
 	defer fsDisconnect(t, mount)
@@ -492,6 +512,10 @@ func TestFallocate(t *testing.T) {
 
 	// Allocate space - default case, mode == 0.
 	t.Run("modeIsZero", func(t *testing.T) {
+		if serverVersion == cephMain {
+			t.Skip("fallocate with mode 0 is unsupported: https://tracker.ceph.com/issues/68026")
+		}
+
 		// check file size.
 		sx, err := mount.Statx(fname, StatxBasicStats, 0)
 		assert.NoError(t, err)
@@ -507,6 +531,10 @@ func TestFallocate(t *testing.T) {
 
 	// Allocate space - size increases, data remains intact.
 	t.Run("increaseSize", func(t *testing.T) {
+		if serverVersion == cephMain {
+			t.Skip("fallocate with mode 0 is unsupported: https://tracker.ceph.com/issues/68026")
+		}
+
 		fname := "file2.txt"
 		f1, err := mount.Open(fname, os.O_RDWR|os.O_CREATE, 0644)
 		assert.NoError(t, err)


### PR DESCRIPTION
Recent behavioural [changes](https://github.com/ceph/ceph/pull/59725) w.r.t fallocate API calls for corresponding changes in our tests which uses mode 0. In addition to skipping those existing tests we try to cover up the time taken for backports to land in released versions causing CI failures in our pre-release jobs. This has been implemented by creating a new test file intended to be controlled and maintained using required build tags. The new test file can be removed once all the expected backports are available with released versions.

fixes #1044 
