### PR TITLE
[ci] workaround recent changes in ceph's CI built container images

### DIFF
--- a/cephfs/file_test.go
+++ b/cephfs/file_test.go
@@ -512,7 +512,8 @@ func TestFallocate(t *testing.T) {
 
 	// Allocate space - default case, mode == 0.
 	t.Run("modeIsZero", func(t *testing.T) {
-		if serverVersion == cephMain {
+		switch serverVersion {
+		case cephMain, cephSquid, cephReef, cephQuincy:
 			t.Skip("fallocate with mode 0 is unsupported: https://tracker.ceph.com/issues/68026")
 		}
 
@@ -531,7 +532,8 @@ func TestFallocate(t *testing.T) {
 
 	// Allocate space - size increases, data remains intact.
 	t.Run("increaseSize", func(t *testing.T) {
-		if serverVersion == cephMain {
+		switch serverVersion {
+		case cephMain, cephSquid, cephReef, cephQuincy:
 			t.Skip("fallocate with mode 0 is unsupported: https://tracker.ceph.com/issues/68026")
 		}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,11 @@ PKG_PREFIX=github.com/ceph/go-ceph
 ALT_FS="@/tmp/ceph/altfs.txt"
 GOFLAGS="-buildvcs=false ${GOFLAGS}"
 
+# hack around a change to the ci container environment
+if [ -z "${CEPH_VERSION}" ]; then
+    export CEPH_VERSION="${CEPH_REF}"
+fi
+
 # Default env vars that are not currently changed by this script
 # but can be used to change the test behavior:
 # GO_CEPH_TEST_MDS_NAME

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -9,9 +9,11 @@ ARG GO_CEPH_VERSION
 ENV GO_CEPH_VERSION=${GO_CEPH_VERSION:-$CEPH_VERSION}
 
 RUN true \
+    && if [ -z "${CEPH_VERSION}" ]; then CEPH_VERSION="${CEPH_REF}"; fi \
     && echo "Check: [ ${CEPH_VERSION} = ${GO_CEPH_VERSION} ]" \
     && [ "${CEPH_VERSION}" = "${GO_CEPH_VERSION}" ] \
     && (. /etc/os-release ; if [ "$ID" = centos -a "$VERSION" = 8 ]; then find /etc/yum.repos.d/ -name '*.repo' -exec sed -i -e 's|^mirrorlist=|#mirrorlist=|g' -e 's|^#baseurl=http://mirror.centos.org|baseurl=https://vault.centos.org|g'  {} \; ; fi ) \
+    && if [ ! -f /etc/yum.repos.d/ceph.repo ]; then yum reinstall -y "$(curl -fs "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/9/x86_64&flavor=default&ref=${CEPH_REF}&sha1=${CEPH_SHA:-latest}" | jq -r .[0].url)/noarch/ceph-release-1-0.el9.noarch.rpm"; fi \
     && yum install -y \
         git wget /usr/bin/curl make \
         /usr/bin/cc /usr/bin/c++ gdb \


### PR DESCRIPTION
Experimental workaround for ceph ci container build changes. 

Depends on #1043 


## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
