### PR TITLE
workflows: remove pre-quincy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,6 @@ jobs:
         - "quincy"
         - "reef"
         - "squid"
-        - "pre-quincy"
         - "pre-reef"
         - "pre-squid"
         - "main"


### PR DESCRIPTION
The quincy branch is EOL on the ceph side and there will not be another quincy release so there's no point in having a pre-quincy job now.


