### PR TITLE
Makefile: Remove leftovers related to EOL releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,18 +35,6 @@ endif
 # pre-<codename> indicates we want to consume pre-release versions of ceph from
 # the ceph ci. This way we can start testing on ceph versions before they hit
 # quay.io/ceph/ceph
-ifeq ($(CEPH_VERSION),pre-quincy)
-	CEPH_TAG ?= quincy
-	CEPH_IMG ?= quay.ceph.io/ceph-ci/ceph
-	GO_CEPH_VERSION := quincy
-	BUILD_TAGS := quincy,ceph_pre_quincy
-endif
-ifeq ($(CEPH_VERSION),pre-pacific)
-	CEPH_TAG ?= pacific
-	CEPH_IMG ?= quay.ceph.io/ceph-ci/ceph
-	GO_CEPH_VERSION := pacific
-	BUILD_TAGS := pacific,ceph_pre_pacific
-endif
 ifeq ($(CEPH_VERSION),pre-reef)
 	CEPH_TAG ?= reef
 	CEPH_IMG ?= quay.ceph.io/ceph-ci/ceph


### PR DESCRIPTION
Pacific and Quincy releases are already EOL. Therefore remove their corresponding pre-release definitions which are unused and irrelevant these days. On top of all we don't have any CI jobs currently running for _pre-pacific_ and _pre-quincy_.