### PR TITLE
rbd: add support for rbd_diff_iterate3 api

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1963,6 +1963,12 @@
         "comment": "EncryptionLoad2 enables IO on an open encrypted image. Multiple encryption\noption values can be passed to this call in a slice. For more information\nabout how items in the slice are applied to images, and possibly ancestor\nimages refer to the documentation in the C api for rbd_encryption_load2.\n\nImplements:\n\n\tint rbd_encryption_load2(rbd_image_t image,\n\t                         const rbd_encryption_spec_t *specs,\n\t                         size_t spec_count);\n",
         "added_in_version": "v0.32.0",
         "expected_stable_version": "v0.34.0"
+      },
+      {
+        "name": "Image.DiffIterateByID",
+        "comment": "DiffIterateByID calls a callback on changed extents of an image.\n\nCalling DiffIterateByID will cause the callback specified in the\nDiffIterateByIDConfig to be called as many times as there are changed\nregions in the image (controlled by the parameters as passed to librbd).\n\nSee the documentation of DiffIterateCallback for a description of the\narguments to the callback and the return behavior.\n\nImplements:\n\n\tint rbd_diff_iterate3(rbd_image_t image,\n\t                      uint64_t from_snap_id,\n\t                      uint64_t ofs, uint64_t len,\n\t                      uint32_t flags,\n\t                      int (*cb)(uint64_t, size_t, int, void *),\n\t                      void *arg);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -25,6 +25,7 @@ Conn.GetAddrs | v0.31.0 | v0.33.0 |
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 Image.EncryptionLoad2 | v0.32.0 | v0.34.0 | 
+Image.DiffIterateByID | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ### Deprecated APIs
 

--- a/rbd/diff_iterate_by_id.go
+++ b/rbd/diff_iterate_by_id.go
@@ -1,0 +1,127 @@
+//go:build ceph_preview
+
+package rbd
+
+/*
+#cgo LDFLAGS: -lrbd
+#undef _GNU_SOURCE
+#include <errno.h>
+#include <stdlib.h>
+#include <rbd/librbd.h>
+
+#ifndef LIBRBD_SUPPORTS_DIFF_ITERATE3
+#define RBD_DIFF_ITERATE_FLAG_INCLUDE_PARENT (1U<<0) // SHOULD MATCH THE VALUE IN librbd.h
+#define RBD_DIFF_ITERATE_FLAG_WHOLE_OBJECT (1U<<1) // SHOULD MATCH THE VALUE IN librbd.h
+#endif
+
+extern int diffIterateByIDCallback(uint64_t, size_t, int, uintptr_t);
+
+// rbd_diff_iterate3_fn matches the rbd_diff_iterate3 function signature.
+typedef int(*rbd_diff_iterate3_fn)(rbd_image_t image, uint64_t from_snap_id,
+	uint64_t ofs, uint64_t len, uint32_t flags,
+	int (*cb)(uint64_t, size_t, int, void *), void *arg);
+
+// rbd_diff_iterate3_dlsym take *fn as rbd_diff_iterate3_fn and calls the dynamically loaded
+// rbd_diff_iterate3 function passed as 1st argument.
+static inline int rbd_diff_iterate3_dlsym(void *fn, rbd_image_t image,
+	uint64_t from_snap_id, uint64_t ofs, uint64_t len, uint32_t flags, uintptr_t arg) {
+	// cast function pointer fn to rbd_diff_iterate3 and call the function
+	return ((rbd_diff_iterate3_fn) fn)(image, from_snap_id, ofs, len, flags, (void*)diffIterateByIDCallback, (void*)arg);
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/callbacks"
+	"github.com/ceph/go-ceph/internal/dlsym"
+)
+
+var (
+	diffIterateByIDCallbacks = callbacks.New()
+	diffIterateByIDOnce      sync.Once
+	diffIterateById          unsafe.Pointer
+	diffIterateByIdErr       error
+)
+
+// DiffIterateByIDConfig is used to define the parameters of a DiffIterateByID call.
+// Callback, Offset, and Length should always be specified when passed to
+// DiffIterateByID. The other values are optional.
+type DiffIterateByIDConfig struct {
+	FromSnapID    uint64
+	Offset        uint64
+	Length        uint64
+	IncludeParent DiffIncludeParent
+	WholeObject   DiffWholeObject
+	Callback      DiffIterateCallback
+	Data          interface{}
+}
+
+// DiffIterateByID calls a callback on changed extents of an image.
+//
+// Calling DiffIterateByID will cause the callback specified in the
+// DiffIterateByIDConfig to be called as many times as there are changed
+// regions in the image (controlled by the parameters as passed to librbd).
+//
+// See the documentation of DiffIterateCallback for a description of the
+// arguments to the callback and the return behavior.
+//
+// Implements:
+//
+//	int rbd_diff_iterate3(rbd_image_t image,
+//	                      uint64_t from_snap_id,
+//	                      uint64_t ofs, uint64_t len,
+//	                      uint32_t flags,
+//	                      int (*cb)(uint64_t, size_t, int, void *),
+//	                      void *arg);
+func (image *Image) DiffIterateByID(config DiffIterateByIDConfig) error {
+	if err := image.validate(imageIsOpen); err != nil {
+		return err
+	}
+	if config.Callback == nil {
+		return getError(-C.EINVAL)
+	}
+
+	diffIterateByIDOnce.Do(func() {
+		diffIterateById, diffIterateByIdErr = dlsym.LookupSymbol("rbd_diff_iterate3")
+	})
+
+	if diffIterateByIdErr != nil {
+		return fmt.Errorf("%w: %w", ErrNotImplemented, diffIterateByIdErr)
+	}
+
+	cbIndex := diffIterateByIDCallbacks.Add(config)
+	defer diffIterateByIDCallbacks.Remove(cbIndex)
+
+	flags := C.uint32_t(0)
+	if config.IncludeParent == IncludeParent {
+		flags |= C.RBD_DIFF_ITERATE_FLAG_INCLUDE_PARENT
+	}
+	if config.WholeObject == EnableWholeObject {
+		flags |= C.RBD_DIFF_ITERATE_FLAG_WHOLE_OBJECT
+	}
+
+	ret := C.rbd_diff_iterate3_dlsym(
+		diffIterateById,
+		image.image,
+		C.uint64_t(config.FromSnapID),
+		C.uint64_t(config.Offset),
+		C.uint64_t(config.Length),
+		flags,
+		C.uintptr_t(cbIndex))
+
+	return getError(ret)
+}
+
+//export diffIterateByIDCallback
+func diffIterateByIDCallback(
+	offset C.uint64_t, length C.size_t, exists C.int, index uintptr) C.int {
+
+	v := diffIterateByIDCallbacks.Lookup(index)
+	config := v.(DiffIterateByIDConfig)
+	return C.int(config.Callback(
+		uint64(offset), uint64(length), int(exists), config.Data))
+}

--- a/rbd/diff_iterate_by_id_test.go
+++ b/rbd/diff_iterate_by_id_test.go
@@ -1,0 +1,536 @@
+//go:build ceph_preview
+
+package rbd
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ceph/go-ceph/internal/dlsym"
+	"github.com/ceph/go-ceph/rados"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffIterateByID(t *testing.T) {
+	_, diffIterateByIdErr := dlsym.LookupSymbol("rbd_diff_iterate3")
+	if diffIterateByIdErr != nil {
+		t.Logf("skipping DiffIterateByID tests: rbd_diff_iterate3 not found: %v", diffIterateByIdErr)
+
+		return
+	}
+
+	conn := radosConnect(t)
+	defer conn.Shutdown()
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+	defer conn.DeletePool(poolname)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+	defer ioctx.Destroy()
+
+	t.Run("basic", func(t *testing.T) {
+		testDiffIterateByIDBasic(t, ioctx)
+	})
+	t.Run("twoAtOnce", func(t *testing.T) {
+		testDiffIterateByIDTwoAtOnce(t, ioctx)
+	})
+	t.Run("earlyExit", func(t *testing.T) {
+		testDiffIterateByIDEarlyExit(t, ioctx)
+	})
+	t.Run("snapshot", func(t *testing.T) {
+		testDiffIterateByIDSnapshot(t, ioctx)
+	})
+	t.Run("callbackData", func(t *testing.T) {
+		testDiffIterateByIDCallbackData(t, ioctx)
+	})
+	t.Run("badImage", func(t *testing.T) {
+		var gotCalled int
+		img := GetImage(ioctx, "bob")
+		err := img.DiffIterateByID(
+			DiffIterateByIDConfig{
+				Offset: 0,
+				Length: uint64(1 << 22),
+				Callback: func(_, _ uint64, _ int, _ interface{}) int {
+					gotCalled++
+					return 0
+				},
+			})
+		assert.Error(t, err)
+		assert.EqualValues(t, 0, gotCalled)
+	})
+	t.Run("missingCallback", func(t *testing.T) {
+		name := GetUUID()
+		isize := uint64(1 << 23) // 8MiB
+		iorder := 20             // 1MiB
+		options := NewRbdImageOptions()
+		defer options.Destroy()
+		assert.NoError(t,
+			options.SetUint64(RbdImageOptionOrder, uint64(iorder)))
+		err := CreateImage(ioctx, name, isize, options)
+		assert.NoError(t, err)
+
+		img, err := OpenImage(ioctx, name, NoSnapshot)
+		assert.NoError(t, err)
+		defer func() {
+			assert.NoError(t, img.Close())
+			assert.NoError(t, img.Remove())
+		}()
+
+		var gotCalled int
+		err = img.DiffIterateByID(
+			DiffIterateByIDConfig{
+				Offset: 0,
+				Length: uint64(1 << 22),
+			})
+		assert.Error(t, err)
+		assert.EqualValues(t, 0, gotCalled)
+	})
+}
+
+func testDiffIterateByIDBasic(t *testing.T, ioctx *rados.IOContext) {
+	name := GetUUID()
+	isize := uint64(1 << 23) // 8MiB
+	iorder := 20             // 1MiB
+	options := NewRbdImageOptions()
+	defer options.Destroy()
+	assert.NoError(t,
+		options.SetUint64(RbdImageOptionOrder, uint64(iorder)))
+	err := CreateImage(ioctx, name, isize, options)
+	assert.NoError(t, err)
+
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, img.Close())
+		assert.NoError(t, img.Remove())
+	}()
+
+	type diResult struct {
+		offset uint64
+		length uint64
+	}
+	calls := []diResult{}
+
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.NoError(t, err)
+	// Image is new, empty. Callback will not be called
+	assert.Len(t, calls, 0)
+
+	_, err = img.WriteAt([]byte("sometimes you feel like a nut"), 0)
+	assert.NoError(t, err)
+
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.NoError(t, err)
+	if assert.Len(t, calls, 1) {
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 29, calls[0].length)
+	}
+
+	_, err = img.WriteAt([]byte("sometimes you don't"), 32)
+	assert.NoError(t, err)
+
+	calls = []diResult{}
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	if assert.NoError(t, err) {
+		assert.Len(t, calls, 1)
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 51, calls[0].length)
+	}
+
+	// dirty a 2nd chunk
+	newOffset := 3145728 // 3MiB
+	_, err = img.WriteAt([]byte("alright, alright, alright"), int64(newOffset))
+	assert.NoError(t, err)
+
+	calls = []diResult{}
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.NoError(t, err)
+	if assert.Len(t, calls, 2) {
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 51, calls[0].length)
+		assert.EqualValues(t, newOffset, calls[1].offset)
+		assert.EqualValues(t, 25, calls[1].length)
+	}
+
+	// dirty a 3rd chunk
+	newOffset2 := 5242880 + 1024 // 5MiB + 1KiB
+	_, err = img.WriteAt([]byte("zowie!"), int64(newOffset2))
+	assert.NoError(t, err)
+
+	calls = []diResult{}
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.NoError(t, err)
+	if assert.Len(t, calls, 3) {
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 51, calls[0].length)
+		assert.EqualValues(t, newOffset, calls[1].offset)
+		assert.EqualValues(t, 25, calls[1].length)
+		assert.EqualValues(t, newOffset2-1024, calls[2].offset)
+		assert.EqualValues(t, 6+1024, calls[2].length)
+	}
+}
+
+// testDiffIterateByIDTwoAtOnce aims to verify that multiple DiffIterateByID
+// callbacks can be executed at the same time without error.
+func testDiffIterateByIDTwoAtOnce(t *testing.T, ioctx *rados.IOContext) {
+	isize := uint64(1 << 23) // 8MiB
+	iorder := 20             // 1MiB
+	options := NewRbdImageOptions()
+	defer options.Destroy()
+	assert.NoError(t,
+		options.SetUint64(RbdImageOptionOrder, uint64(iorder)))
+
+	name1 := GetUUID()
+	err := CreateImage(ioctx, name1, isize, options)
+	assert.NoError(t, err)
+
+	img1, err := OpenImage(ioctx, name1, NoSnapshot)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, img1.Close())
+		assert.NoError(t, img1.Remove())
+	}()
+
+	name2 := GetUUID()
+	err = CreateImage(ioctx, name2, isize, options)
+	assert.NoError(t, err)
+
+	img2, err := OpenImage(ioctx, name2, NoSnapshot)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, img2.Close())
+		assert.NoError(t, img2.Remove())
+	}()
+
+	type diResult struct {
+		offset uint64
+		length uint64
+	}
+
+	diffTest := func(wg *sync.WaitGroup, inbuf []byte, img *Image) {
+		_, err = img.WriteAt(inbuf[0:3], 0)
+		assert.NoError(t, err)
+		_, err = img.WriteAt(inbuf[3:6], 3145728)
+		assert.NoError(t, err)
+		_, err = img.WriteAt(inbuf[6:9], 5242880)
+		assert.NoError(t, err)
+
+		calls := []diResult{}
+		err = img.DiffIterateByID(
+			DiffIterateByIDConfig{
+				Offset: 0,
+				Length: isize,
+				Callback: func(o, l uint64, _ int, _ interface{}) int {
+					time.Sleep(8 * time.Millisecond)
+					calls = append(calls, diResult{offset: o, length: l})
+					return 0
+				},
+			})
+		assert.NoError(t, err)
+		if assert.Len(t, calls, 3) {
+			assert.EqualValues(t, 0, calls[0].offset)
+			assert.EqualValues(t, 3, calls[0].length)
+			assert.EqualValues(t, 3145728, calls[1].offset)
+			assert.EqualValues(t, 3, calls[1].length)
+			assert.EqualValues(t, 5242880, calls[2].offset)
+			assert.EqualValues(t, 3, calls[2].length)
+		}
+
+		wg.Done()
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go diffTest(wg, []byte("foobarbaz"), img1)
+	wg.Add(1)
+	go diffTest(wg, []byte("abcdefghi"), img2)
+	wg.Wait()
+}
+
+// testDiffIterateByIDEarlyExit checks that returning an error from the callback
+// function triggers the DiffIterateByID call to stop.
+func testDiffIterateByIDEarlyExit(t *testing.T, ioctx *rados.IOContext) {
+	isize := uint64(1 << 23) // 8MiB
+	iorder := 20             // 1MiB
+	options := NewRbdImageOptions()
+	defer options.Destroy()
+	assert.NoError(t,
+		options.SetUint64(RbdImageOptionOrder, uint64(iorder)))
+
+	name := GetUUID()
+	err := CreateImage(ioctx, name, isize, options)
+	assert.NoError(t, err)
+
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, img.Close())
+		assert.NoError(t, img.Remove())
+	}()
+
+	type diResult struct {
+		offset uint64
+		length uint64
+	}
+
+	// "damage" the image
+	inbuf := []byte("xxxyyyzzz")
+	_, err = img.WriteAt(inbuf[0:3], 0)
+	assert.NoError(t, err)
+	_, err = img.WriteAt(inbuf[3:6], 3145728)
+	assert.NoError(t, err)
+	_, err = img.WriteAt(inbuf[6:9], 5242880)
+	assert.NoError(t, err)
+
+	// if the offset is less than zero the callback will return an "error" and
+	// that will abort the DiffIterateByID call early and it will return the error
+	// code our callback used.
+	calls := []diResult{}
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				if o > 1 {
+					return -5
+				}
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.Error(t, err)
+	if errno, ok := err.(interface{ ErrorCode() int }); assert.True(t, ok) {
+		assert.EqualValues(t, -5, errno.ErrorCode())
+	}
+	if assert.Len(t, calls, 1) {
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 3, calls[0].length)
+	}
+}
+
+func testDiffIterateByIDSnapshot(t *testing.T, ioctx *rados.IOContext) {
+	name := GetUUID()
+	isize := uint64(1 << 23) // 8MiB
+	iorder := 20             // 1MiB
+	options := NewRbdImageOptions()
+	defer options.Destroy()
+	assert.NoError(t,
+		options.SetUint64(RbdImageOptionOrder, uint64(iorder)))
+	err := CreateImage(ioctx, name, isize, options)
+	assert.NoError(t, err)
+
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, img.Close())
+		assert.NoError(t, img.Remove())
+	}()
+
+	type diResult struct {
+		offset uint64
+		length uint64
+	}
+	calls := []diResult{}
+
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.NoError(t, err)
+	// Image is new, empty. Callback will not be called
+	assert.Len(t, calls, 0)
+
+	_, err = img.WriteAt([]byte("sometimes you feel like a nut"), 0)
+	assert.NoError(t, err)
+
+	calls = []diResult{}
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.NoError(t, err)
+	if assert.Len(t, calls, 1) {
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 29, calls[0].length)
+	}
+
+	ss1, err := img.CreateSnapshot("ss1")
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, ss1.Remove()) }()
+
+	ss1ID, err := ss1.image.GetSnapID(ss1.name)
+	assert.NoError(t, err)
+
+	// there should be no differences between "now" and "ss1"
+	calls = []diResult{}
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			FromSnapID: ss1ID,
+			Offset:     0,
+			Length:     isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.NoError(t, err)
+	assert.Len(t, calls, 0)
+
+	// this next check was shamelessly cribbed from the pybind
+	// tests for diff_iterate out of the ceph tree
+	// it discards the current image, makes a 2nd snap, and compares
+	// the diff between snapshots 1 & 2.
+	_, err = img.Discard(0, isize)
+	assert.NoError(t, err)
+
+	ss2, err := img.CreateSnapshot("ss2")
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, ss2.Remove()) }()
+
+	err = ss2.Set() // caution: this side-effects img!
+	assert.NoError(t, err)
+
+	calls = []diResult{}
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			FromSnapID: ss1ID,
+			Offset:     0,
+			Length:     isize,
+			Callback: func(o, l uint64, _ int, _ interface{}) int {
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+		})
+	assert.NoError(t, err)
+	if assert.Len(t, calls, 1) {
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 29, calls[0].length)
+	}
+}
+
+func testDiffIterateByIDCallbackData(t *testing.T, ioctx *rados.IOContext) {
+	name := GetUUID()
+	isize := uint64(1 << 23) // 8MiB
+	iorder := 20             // 1MiB
+	options := NewRbdImageOptions()
+	defer options.Destroy()
+	assert.NoError(t,
+		options.SetUint64(RbdImageOptionOrder, uint64(iorder)))
+	err := CreateImage(ioctx, name, isize, options)
+	assert.NoError(t, err)
+
+	img, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, img.Close())
+		assert.NoError(t, img.Remove())
+	}()
+
+	type diResult struct {
+		offset uint64
+		length uint64
+	}
+	calls := []diResult{}
+
+	_, err = img.WriteAt([]byte("sometimes you feel like a nut"), 0)
+	assert.NoError(t, err)
+
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, x interface{}) int {
+				if v, ok := x.(int); ok {
+					assert.EqualValues(t, 77, v)
+				} else {
+					t.Fatalf("incorrect type")
+				}
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+			Data: 77,
+		})
+	assert.NoError(t, err)
+	if assert.Len(t, calls, 1) {
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 29, calls[0].length)
+	}
+
+	calls = []diResult{}
+	err = img.DiffIterateByID(
+		DiffIterateByIDConfig{
+			Offset: 0,
+			Length: isize,
+			Callback: func(o, l uint64, _ int, x interface{}) int {
+				if v, ok := x.(string); ok {
+					assert.EqualValues(t, "bob", v)
+				} else {
+					t.Fatalf("incorrect type")
+				}
+				calls = append(calls, diResult{offset: o, length: l})
+				return 0
+			},
+			Data: "bob",
+		})
+	assert.NoError(t, err)
+	if assert.Len(t, calls, 1) {
+		assert.EqualValues(t, 0, calls[0].offset)
+		assert.EqualValues(t, 29, calls[0].length)
+	}
+}


### PR DESCRIPTION
This commit adds support for rbd_diff_iterate3
through DiffIterateByID() which performs
diff interate using snapshot id instead of
snapshot name.

This is useful in cases such as when rbd snapshot is in trash or rbd(group) snapshot in in group namespace.

refer:
- https://tracker.ceph.com/issues/65720

Related ceph PR: ceph/ceph#60844


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
