### PR TITLE
rgw/admin: Add Error parser to extract RGW API error models

### DIFF
--- a/rgw/admin/errors.go
+++ b/rgw/admin/errors.go
@@ -127,3 +127,20 @@ func (e statusError) Is(target error) bool { return target == errorReason(e.Code
 
 // Error returns non-empty string if there was an error.
 func (e statusError) Error() string { return fmt.Sprintf("%s %s %s", e.Code, e.RequestID, e.HostID) }
+
+// ParseError parses an error returned by the RGW API and attempts to
+// extract error model. It returns the extracted error model and a boolean
+// indicating whether the error was successfully parsed.
+//
+// Does not handle internal client errors such as "missing user ID"
+func ParseError(err error) (statusError, bool) {
+	statusErr := statusError{}
+	if err == nil {
+		return statusErr, true
+	}
+	ok := errors.As(err, &statusErr)
+	if !ok {
+		return statusErr, false
+	}
+	return statusErr, true
+}

--- a/rgw/admin/errors.go
+++ b/rgw/admin/errors.go
@@ -105,7 +105,7 @@ type errorReason string
 
 // statusError is the API response when an error occurs
 type statusError struct {
-	Code      string `json:"Code,omitempty"`
+	Code      string `json:"Code,omitempty"` // see errorReason constants
 	RequestID string `json:"RequestId,omitempty"`
 	HostID    string `json:"HostId,omitempty"`
 }

--- a/rgw/admin/errors_test.go
+++ b/rgw/admin/errors_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,4 +21,64 @@ func TestHandleStatusError(t *testing.T) {
 	err = handleStatusError(fakeGetSubUserError)
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, ErrNoSuchSubUser), err)
+}
+func TestParseError(t *testing.T) {
+	var (
+		nilError         error = nil
+		nilErrorExpected       = statusError{}
+
+		nonValidStatusError         = errors.New("missing user ID")
+		nonValidStatusErrorExpected = statusError{}
+
+		getUserError error = statusError{
+			Code:      "NoSuchUser",
+			RequestID: "tx0000000000000000005a9-00608957a2-10496-my-store",
+			HostID:    "10496-my-store-my-store",
+		}
+		getUserErrorExpected = statusError{
+			Code:      "NoSuchUser",
+			RequestID: "tx0000000000000000005a9-00608957a2-10496-my-store",
+			HostID:    "10496-my-store-my-store",
+		}
+
+		getSubUserError error = statusError{
+			Code:      "NoSuchSubUser",
+			RequestID: "tx0000000000000000005a9-00608957a2-10496-my-store",
+			HostID:    "10496-my-store-my-store",
+		}
+		getSubUserErrorExpected = statusError{
+			Code:      "NoSuchSubUser",
+			RequestID: "tx0000000000000000005a9-00608957a2-10496-my-store",
+			HostID:    "10496-my-store-my-store",
+		}
+	)
+
+	// Nil error
+	statusError, ok := ParseError(nilError)
+	assert.True(t, ok)
+	assert.Equal(t, nilErrorExpected, statusError)
+
+	// Non-valid error
+	statusError, ok = ParseError(nonValidStatusError)
+	assert.False(t, ok)
+	assert.Equal(t, nonValidStatusErrorExpected, statusError)
+
+	// Get user error
+	statusError, ok = ParseError(getUserError)
+	assert.True(t, ok)
+	assert.EqualExportedValues(t, getUserErrorExpected, statusError)
+	assert.True(t, statusError.Is(ErrNoSuchUser))
+
+	// Get sub-user error
+	statusError, ok = ParseError(getSubUserError)
+	assert.True(t, ok)
+	assert.EqualExportedValues(t, getSubUserErrorExpected, statusError)
+	assert.True(t, statusError.Is(ErrNoSuchSubUser))
+
+	// Wrapped error
+	wrappedError := fmt.Errorf("additional note: %w", getUserError)
+	statusError, ok = ParseError(wrappedError)
+	assert.True(t, ok)
+	assert.EqualExportedValues(t, getUserErrorExpected, statusError)
+	assert.True(t, statusError.Is(ErrNoSuchUser))
 }


### PR DESCRIPTION
[topic]: [rgw/admin]

Add ParseError function to extract RGW API error models.
Essential for handling error reasons as in a project.

## Checklist
- [X] Added tests for features and functional changes
- [X] Public functions and types are documented
- [X] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs