### PR TITLE
rbd: fix cleanup of GroupSnapRollback and Sparsify progress callbacks

### DIFF
--- a/rbd/group_snap.go
+++ b/rbd/group_snap.go
@@ -217,7 +217,7 @@ func GroupSnapRollbackWithProgress(
 		data:     data,
 	}
 	cbIndex := groupSnapRollbackCallbacks.Add(ctx)
-	defer diffIterateCallbacks.Remove(cbIndex)
+	defer groupSnapRollbackCallbacks.Remove(cbIndex)
 
 	ret := C.wrap_rbd_group_snap_rollback_with_progress(
 		cephIoctx(ioctx),

--- a/rbd/sparsify.go
+++ b/rbd/sparsify.go
@@ -72,7 +72,7 @@ func (image *Image) SparsifyWithProgress(
 		data:     data,
 	}
 	cbIndex := sparsifyCallbacks.Add(ctx)
-	defer diffIterateCallbacks.Remove(cbIndex)
+	defer sparsifyCallbacks.Remove(cbIndex)
 
 	ret := C.wrap_rbd_sparsify_with_progress(image.image, C.size_t(sparseSize), C.uintptr_t(cbIndex))
 


### PR DESCRIPTION
Instead of removing a respective progress callback, DiffIterate extent callback is attempted to be removed.  This leaks the progress callback and on top of that it's quite possible for DiffIterate to be disrupted as cbIndex is not a unique pointer but just an integer ID.


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
