### PR TITLE
rgwadmin: parse more fields by bucket struct

### DIFF
--- a/rgw/admin/bucket.go
+++ b/rgw/admin/bucket.go
@@ -20,16 +20,19 @@ type Bucket struct {
 		DataExtraPool string `json:"data_extra_pool"`
 		IndexPool     string `json:"index_pool"`
 	} `json:"explicit_placement"`
-	ID           string     `json:"id"`
-	Marker       string     `json:"marker"`
-	IndexType    string     `json:"index_type"`
-	Owner        string     `json:"owner"`
-	Ver          string     `json:"ver"`
-	MasterVer    string     `json:"master_ver"`
-	Mtime        string     `json:"mtime"`
-	CreationTime *time.Time `json:"creation_time"`
-	MaxMarker    string     `json:"max_marker"`
-	Usage        struct {
+	ID                string     `json:"id"`
+	Marker            string     `json:"marker"`
+	IndexType         string     `json:"index_type"`
+	Versioned         *bool      `json:"versioned"`          // pre-squid
+	VersioningEnabled *bool      `json:"versioning_enabled"` // pre-squid
+	Versioning        *string    `json:"versioning"`         // squid+
+	Owner             string     `json:"owner"`
+	Ver               string     `json:"ver"`
+	MasterVer         string     `json:"master_ver"`
+	Mtime             string     `json:"mtime"`
+	CreationTime      *time.Time `json:"creation_time"`
+	MaxMarker         string     `json:"max_marker"`
+	Usage             struct {
 		RgwMain struct {
 			Size           *uint64 `json:"size"`
 			SizeActual     *uint64 `json:"size_actual"`

--- a/rgw/admin/bucket.go
+++ b/rgw/admin/bucket.go
@@ -26,6 +26,7 @@ type Bucket struct {
 	Versioned         *bool      `json:"versioned"`          // pre-squid
 	VersioningEnabled *bool      `json:"versioning_enabled"` // pre-squid
 	Versioning        *string    `json:"versioning"`         // squid+
+	ObjectLockEnabled bool       `json:"object_lock_enabled"`
 	Owner             string     `json:"owner"`
 	Ver               string     `json:"ver"`
 	MasterVer         string     `json:"master_ver"`


### PR DESCRIPTION
The bucket's versioning information and ObjectLock status are now accessible by the Bucket struct.

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs