### PR TITLE
internal: Use a wrapper to detect server version

### DIFF
--- a/cephfs/admin/fsadmin_test.go
+++ b/cephfs/admin/fsadmin_test.go
@@ -2,12 +2,12 @@ package admin
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ceph/go-ceph/internal/admintest"
+	"github.com/ceph/go-ceph/internal/util"
 )
 
 var (
@@ -17,21 +17,8 @@ var (
 	serverVersion string
 )
 
-const (
-	cephNautilus = "nautilus"
-	cephOctopus  = "octopus"
-	cephPacfic   = "pacific"
-	cephQuincy   = "quincy"
-	cephReef     = "reef"
-	cephSquid    = "squid"
-	cephMain     = "main"
-)
-
 func init() {
-	switch vname := os.Getenv("CEPH_VERSION"); vname {
-	case cephNautilus, cephOctopus, cephPacfic, cephQuincy, cephReef, cephSquid, cephMain:
-		serverVersion = vname
-	}
+	serverVersion = util.CurrentCephVersionString()
 }
 
 func TestServerSentinel(t *testing.T) {

--- a/cephfs/admin/volume_test.go
+++ b/cephfs/admin/volume_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ceph/go-ceph/internal/util"
 )
 
 func TestListVolumes(t *testing.T) {
@@ -182,7 +184,7 @@ func TestParseDumpToIdents(t *testing.T) {
 }
 
 func TestVolumeStatus(t *testing.T) {
-	if serverVersion == cephNautilus {
+	if serverVersion == util.Nautilus {
 		t.Skipf("can only execute on octopus/pacific servers")
 	}
 	fsa := getFSAdmin(t)
@@ -193,7 +195,7 @@ func TestVolumeStatus(t *testing.T) {
 }
 
 func TestVolumeStatusInvalid(t *testing.T) {
-	if serverVersion != cephNautilus {
+	if serverVersion != util.Nautilus {
 		t.Skipf("can only excecute on nautilus servers")
 	}
 	fsa := getFSAdmin(t)

--- a/cephfs/file_test.go
+++ b/cephfs/file_test.go
@@ -6,26 +6,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ceph/go-ceph/internal/util"
 )
 
 var (
 	serverVersion string
 )
 
-const (
-	cephOctopus = "octopus"
-	cephPacfic  = "pacific"
-	cephQuincy  = "quincy"
-	cephReef    = "reef"
-	cephSquid   = "squid"
-	cephMain    = "main"
-)
-
 func init() {
-	switch vname := os.Getenv("CEPH_VERSION"); vname {
-	case cephOctopus, cephPacfic, cephQuincy, cephReef, cephSquid, cephMain:
-		serverVersion = vname
-	}
+	serverVersion = util.CurrentCephVersionString()
 }
 
 func TestFileOpen(t *testing.T) {
@@ -513,7 +503,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate space - default case, mode == 0.
 	t.Run("modeIsZero", func(t *testing.T) {
 		switch serverVersion {
-		case cephMain, cephSquid, cephReef, cephQuincy:
+		case util.Main, util.Squid, util.Reef, util.Quincy:
 			t.Skip("fallocate with mode 0 is unsupported: https://tracker.ceph.com/issues/68026")
 		}
 
@@ -533,7 +523,7 @@ func TestFallocate(t *testing.T) {
 	// Allocate space - size increases, data remains intact.
 	t.Run("increaseSize", func(t *testing.T) {
 		switch serverVersion {
-		case cephMain, cephSquid, cephReef, cephQuincy:
+		case util.Main, util.Squid, util.Reef, util.Quincy:
 			t.Skip("fallocate with mode 0 is unsupported: https://tracker.ceph.com/issues/68026")
 		}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -16,10 +16,31 @@ const (
 	CephUnknown
 )
 
+// List of known CephVersion strings
+const (
+	Nautilus = "nautilus"
+	Octopus  = "octopus"
+	Pacific  = "pacific"
+	Quincy   = "quincy"
+	Reef     = "reef"
+	Squid    = "squid"
+	Tentacle = "tentacle"
+	Main     = "main"
+)
+
 // CurrentCephVersion is the current Ceph version
 func CurrentCephVersion() CephVersion {
 	vname := os.Getenv("CEPH_VERSION")
 	return CephVersionOfString(vname)
+}
+
+// CurrentCephVersionString is the current Ceph version string
+func CurrentCephVersionString() string {
+	switch vname := os.Getenv("CEPH_VERSION"); vname {
+	case Nautilus, Octopus, Pacific, Quincy, Reef, Squid, Tentacle, Main:
+		return vname
+	}
+	return ""
 }
 
 // CephVersionOfString converts a string to CephVersion

--- a/rbd/snapshot_test.go
+++ b/rbd/snapshot_test.go
@@ -1,31 +1,20 @@
 package rbd
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ceph/go-ceph/internal/util"
 )
 
 var (
 	serverVersion string
 )
 
-const (
-	cephOctopus = "octopus"
-	cephPacfic  = "pacific"
-	cephQuincy  = "quincy"
-	cephReef    = "reef"
-	cephSquid   = "squid"
-	cephMain    = "main"
-)
-
 func init() {
-	switch vname := os.Getenv("CEPH_VERSION"); vname {
-	case cephOctopus, cephPacfic, cephQuincy, cephReef, cephSquid, cephMain:
-		serverVersion = vname
-	}
+	serverVersion = util.CurrentCephVersionString()
 }
 
 func TestCreateSnapshot(t *testing.T) {
@@ -160,7 +149,7 @@ func TestGetSnapTimestamp(t *testing.T) {
 
 	t.Run("invalidSnapID", func(t *testing.T) {
 		switch serverVersion {
-		case cephOctopus, cephPacfic:
+		case util.Octopus, util.Pacific:
 			t.Skip("hits assert due to https://tracker.ceph.com/issues/47287")
 		}
 


### PR DESCRIPTION
We have at least 3 occurrences where code is duplicated for detecting the underlying Ceph version as a string. Instead, we could have it in common and invoke the corresponding wrapper whenever required.