### PR TITLE
rbd: Memory allocation improvements for EncryptionLoad APIs

### DIFF
--- a/rbd/encryption.go
+++ b/rbd/encryption.go
@@ -61,30 +61,44 @@ type EncryptionOptions interface {
 }
 
 func (opts EncryptionOptionsLUKS1) allocateEncryptionOptions() cEncryptionData {
-	var cOpts C.rbd_encryption_luks1_format_options_t
 	var retData cEncryptionData
-	cOpts.alg = C.rbd_encryption_algorithm_t(opts.Alg)
+
 	// CBytes allocates memory. it will be freed when cEncryptionData.free is called
-	cOpts.passphrase = (*C.char)(C.CBytes(opts.Passphrase))
+	cPassphrase := (*C.char)(C.CBytes(opts.Passphrase))
+	cOptsSize := C.size_t(C.sizeof_rbd_encryption_luks1_format_options_t)
+	cOpts := (*C.rbd_encryption_luks1_format_options_t)(C.malloc(cOptsSize))
+	cOpts.alg = C.rbd_encryption_algorithm_t(opts.Alg)
+	cOpts.passphrase = cPassphrase
 	cOpts.passphrase_size = C.size_t(len(opts.Passphrase))
-	retData.opts = C.rbd_encryption_options_t(&cOpts)
-	retData.optsSize = C.size_t(C.sizeof_rbd_encryption_luks1_format_options_t)
-	retData.free = func() { C.free(unsafe.Pointer(cOpts.passphrase)) }
+
 	retData.format = C.RBD_ENCRYPTION_FORMAT_LUKS1
+	retData.opts = C.rbd_encryption_options_t(cOpts)
+	retData.optsSize = cOptsSize
+	retData.free = func() {
+		C.free(unsafe.Pointer(cOpts.passphrase))
+		C.free(unsafe.Pointer(cOpts))
+	}
 	return retData
 }
 
 func (opts EncryptionOptionsLUKS2) allocateEncryptionOptions() cEncryptionData {
-	var cOpts C.rbd_encryption_luks2_format_options_t
 	var retData cEncryptionData
-	cOpts.alg = C.rbd_encryption_algorithm_t(opts.Alg)
+
 	// CBytes allocates memory. it will be freed when cEncryptionData.free is called
-	cOpts.passphrase = (*C.char)(C.CBytes(opts.Passphrase))
+	cPassphrase := (*C.char)(C.CBytes(opts.Passphrase))
+	cOptsSize := C.size_t(C.sizeof_rbd_encryption_luks2_format_options_t)
+	cOpts := (*C.rbd_encryption_luks2_format_options_t)(C.malloc(cOptsSize))
+	cOpts.alg = C.rbd_encryption_algorithm_t(opts.Alg)
+	cOpts.passphrase = cPassphrase
 	cOpts.passphrase_size = C.size_t(len(opts.Passphrase))
-	retData.opts = C.rbd_encryption_options_t(&cOpts)
-	retData.optsSize = C.size_t(C.sizeof_rbd_encryption_luks2_format_options_t)
-	retData.free = func() { C.free(unsafe.Pointer(cOpts.passphrase)) }
+
 	retData.format = C.RBD_ENCRYPTION_FORMAT_LUKS2
+	retData.opts = C.rbd_encryption_options_t(cOpts)
+	retData.optsSize = cOptsSize
+	retData.free = func() {
+		C.free(unsafe.Pointer(cOpts.passphrase))
+		C.free(unsafe.Pointer(cOpts))
+	}
 	return retData
 }
 


### PR DESCRIPTION
See below for the motivation:

              This could be an Go allocated array, but doesn't hurt either.

_Originally posted by @ansiwen in https://github.com/ceph/go-ceph/pull/1061#discussion_r1949471017_
            
              So, here we still allocate Go memory, but it will be referenced in the `cEncryptionData`. ~I guess, wherever that is used, we still have the same problem.~ Ok, I checked, indeed it is used in a "safe" way, that is `cEncryptionData` is not passed directly as a C argument. But still:  I think it would be safer to `malloc` that as well and add it to the free function, because - as it happened to you this time - , it might happen again that someone falsely assumes, it is completely C allocated.

              However: We can add that in a follow-up (I can do it) if you want to merge it as is for the release.

_Originally posted by @ansiwen in https://github.com/ceph/go-ceph/pull/1061#discussion_r1949487941_
            