### PR TITLE
rbd: add ListChildrenAttributes Api

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1767,6 +1767,10 @@
         "comment": "ListChildren returns arrays with the pools and names of the images that are\nchildren of the given image. The index of the pools and images arrays can be\nused to link the two items together.\n\nImplements:\n  int rbd_list_children3(rbd_image_t image, rbd_linked_image_spec_t *images,\n                         size_t *max_images);\n"
       },
       {
+        "name": "Image.ListChildrenAttributes",
+        "comment": "ListChildrenAttributes returns an array of struct with the names and ids of the\nimages and pools and the trash of the images that are children of the given image.\n\nImplements:\n\n\tint rbd_list_children3(rbd_image_t image, rbd_linked_image_spec_t *images,\n\t                       size_t *max_images);\n"
+      },
+      {
         "name": "Image.SetSnapByID",
         "comment": "SetSnapByID updates the rbd image (not the Snapshot) such that the snapshot\nis the source of readable data.\n\nImplements:\n int rbd_snap_set_by_id(rbd_image_t image, uint64_t snap_id);\n"
       },

--- a/rbd/list_children_attributes_test.go
+++ b/rbd/list_children_attributes_test.go
@@ -1,0 +1,182 @@
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListChildrenAttributes(t *testing.T) {
+	conn := radosConnect(t)
+	defer conn.Shutdown()
+
+	poolName := GetUUID()
+	err := conn.MakePool(poolName)
+	require.NoError(t, err)
+	defer conn.DeletePool(poolName)
+
+	ioctx, err := conn.OpenIOContext(poolName)
+	require.NoError(t, err)
+	defer ioctx.Destroy()
+
+	namespace := "ns01"
+	err = NamespaceCreate(ioctx, namespace)
+	assert.NoError(t, err)
+
+	ioctx.SetNamespace(namespace)
+
+	parentName := "parent"
+	img, err := Create(ioctx, parentName, testImageSize, testImageOrder, 1)
+	assert.NoError(t, err)
+	defer img.Remove()
+
+	img, err = OpenImage(ioctx, parentName, NoSnapshot)
+	assert.NoError(t, err)
+	defer img.Close()
+
+	snapName := "snapshot"
+	snapshot, err := img.CreateSnapshot(snapName)
+	assert.NoError(t, err)
+	defer snapshot.Remove()
+
+	err = snapshot.Protect()
+	assert.NoError(t, err)
+
+	snapImg, err := OpenImage(ioctx, parentName, snapName)
+	assert.NoError(t, err)
+	defer snapImg.Close()
+
+	// ensure no children prior to clone
+	result, err := snapImg.ListChildrenAttributes()
+	assert.NoError(t, err)
+	assert.Equal(t, len(result), 0, "List should be empty before cloning")
+
+	//create first child image
+	childImage01 := "childImage01"
+	_, err = img.Clone(snapName, ioctx, childImage01, 1, testImageOrder)
+	assert.NoError(t, err)
+
+	//retrieve and validate child image properties
+	result, err = snapImg.ListChildrenAttributes()
+	assert.NoError(t, err)
+	assert.Equal(t, len(result), 1, "List should contain one child image")
+
+	assert.Equal(t, childImage01, result[0].ImageName)
+	assert.NotNil(t, result[0].ImageID)
+	assert.NotNil(t, result[0].PoolID)
+	assert.Equal(t, poolName, result[0].PoolName)
+	assert.Equal(t, namespace, result[0].PoolNamespace)
+	assert.False(t, result[0].Trash, "Newly cloned image should not be in trash")
+
+	//parent image cannot be deleted while having children attached to it
+	err = img.Remove()
+	assert.Error(t, err, "Expected an error but got nil")
+
+	childImg1, err := OpenImage(ioctx, childImage01, NoSnapshot)
+	assert.NoError(t, err)
+	defer childImg1.Close()
+
+	//trash the image and validate
+	err = childImg1.Trash(0)
+	assert.NoError(t, err, "Failed to move child image to trash")
+
+	result, err = snapImg.ListChildrenAttributes()
+	assert.NoError(t, err)
+	assert.True(t, result[0].Trash, "Child image should be marked as trashed")
+
+	//validate for multiple clones by creating second child image
+	childImage02 := "childImage02"
+	_, err = img.Clone(snapName, ioctx, childImage02, 1, testImageOrder)
+	assert.NoError(t, err)
+
+	result, err = snapImg.ListChildrenAttributes()
+	assert.NoError(t, err)
+	require.Len(t, result, 2, "List should contain two child images")
+	assert.Equal(t, childImage02, result[1].ImageName)
+
+	//the first image is trashed where as the second is not
+	expectedChildren := map[string]bool{
+		childImage01: true,
+		childImage02: false,
+	}
+
+	for _, child := range result {
+		exists := expectedChildren[child.ImageName]
+		assert.Equal(t, exists, child.Trash)
+	}
+
+	childImg2, err := OpenImage(ioctx, childImage02, NoSnapshot)
+	require.NoError(t, err, "Failed to open cloned child image")
+	defer childImg2.Close()
+
+	//flattening the image should detach it from the parent and remove it from ListChildrenAttributes
+	err = childImg2.Flatten()
+	assert.NoError(t, err, "Failed to flatten cloned child image")
+
+	result, err = snapImg.ListChildrenAttributes()
+	assert.NoError(t, err)
+	assert.Equal(t, len(result), 1, "List should not contain the second image after flattening the clone")
+	assert.NotEqual(t, childImage02, result[0].ImageName)
+}
+
+func TestCloneInDifferentPool(t *testing.T) {
+	conn := radosConnect(t)
+	defer conn.Shutdown()
+
+	//create two pools:poolA(parent) and poolB(child)
+	poolA := GetUUID()
+	err := conn.MakePool(poolA)
+	require.NoError(t, err)
+	defer conn.DeletePool(poolA)
+
+	poolB := GetUUID()
+	err = conn.MakePool(poolB)
+	require.NoError(t, err)
+	defer conn.DeletePool(poolB)
+
+	//ensure that both the pools are not the same
+	assert.NotEqual(t, poolA, poolB)
+
+	ioctxA, err := conn.OpenIOContext(poolA)
+	require.NoError(t, err)
+	defer ioctxA.Destroy()
+	ioctxB, err := conn.OpenIOContext(poolB)
+	require.NoError(t, err)
+	defer ioctxB.Destroy()
+
+	//create a parent image in poolA
+	parentName := "parent-image"
+	img, err := Create(ioctxA, parentName, testImageSize, testImageOrder, 1)
+	assert.NoError(t, err)
+
+	img, err = OpenImage(ioctxA, parentName, NoSnapshot)
+	assert.NoError(t, err)
+	defer img.Close()
+
+	snapName := "snap01"
+	snapshot, err := img.CreateSnapshot(snapName)
+	assert.NoError(t, err)
+	defer snapshot.Remove()
+
+	err = snapshot.Protect()
+	assert.NoError(t, err)
+
+	snapImg, err := OpenImage(ioctxA, parentName, snapName)
+	assert.NoError(t, err)
+	defer snapImg.Close()
+
+	//create a child image in poolB
+	childImageName := "child-image"
+	_, err = img.Clone(snapName, ioctxB, childImageName, 1, testImageOrder)
+	assert.NoError(t, err, "Failed to clone image into poolB")
+
+	//verify and validate properties of the child image
+	result, err := snapImg.ListChildrenAttributes()
+	assert.NoError(t, err)
+	require.Len(t, result, 1, "List should contain one child image")
+
+	child := result[0]
+	assert.Equal(t, childImageName, child.ImageName, "Child image name should match")
+	assert.Equal(t, poolB, child.PoolName, "Child image should be in poolB")
+}

--- a/rbd/snapshot_nautilus.go
+++ b/rbd/snapshot_nautilus.go
@@ -168,6 +168,50 @@ func (image *Image) ListChildren() (pools []string, images []string, err error) 
 	return pools, images, nil
 }
 
+// ListChildrenAttributes returns an array of struct with the names and ids of the
+// images and pools and the trash of the images that are children of the given image.
+//
+// Implements:
+//
+//	int rbd_list_children3(rbd_image_t image, rbd_linked_image_spec_t *images,
+//	                       size_t *max_images);
+func (image *Image) ListChildrenAttributes() (imgSpec []ImageSpec, err error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return nil, err
+	}
+	var (
+		csize    C.size_t
+		children []C.rbd_linked_image_spec_t
+	)
+	retry.WithSizes(16, 4096, func(size int) retry.Hint {
+		csize = C.size_t(size)
+		children = make([]C.rbd_linked_image_spec_t, csize)
+		ret := C.rbd_list_children3(
+			image.image,
+			(*C.rbd_linked_image_spec_t)(unsafe.Pointer(&children[0])),
+			&csize)
+		err = getErrorIfNegative(ret)
+		return retry.Size(int(csize)).If(err == errRange)
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer C.rbd_linked_image_spec_list_cleanup((*C.rbd_linked_image_spec_t)(unsafe.Pointer(&children[0])), csize)
+
+	imgSpec = make([]ImageSpec, csize)
+	for i, child := range children[:csize] {
+		imgSpec[i] = ImageSpec{
+			ImageName:     C.GoString(child.image_name),
+			ImageID:       C.GoString(child.image_id),
+			PoolName:      C.GoString(child.pool_name),
+			PoolNamespace: C.GoString(child.pool_namespace),
+			PoolID:        uint64(child.pool_id),
+			Trash:         bool(child.trash),
+		}
+	}
+	return imgSpec, nil
+}
+
 // SetSnapByID updates the rbd image (not the Snapshot) such that the snapshot
 // is the source of readable data.
 //


### PR DESCRIPTION
The existing `ListChildren()` API provides only basic information, specifically the pool and image names of a given image’s children. However, in many scenarios, additional metadata is required to fully understand the relationships between images.

This new API extends functionality by leveraging `rbd_list_children3(rbd_image_t image, rbd_linked_image_spec_t *images, size_t *max_images)`, which enables the retrieval of comprehensive details, including:

- Image and pool IDs
- Image and pool names
- Pool namespace
- The trash status of child images

By exposing this additional metadata, the API allows for more informed decision-making when managing child images. Furthermore, modifying the existing `ListChildren()` API would introduce backward compatibility issues, potentially breaking existing implementations. To avoid such disruptions while still providing enhanced capabilities, this new API has been introduced as a separate function.

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
