### PR TITLE
build: Bump go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/go-ceph
 
-go 1.21
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.0


### PR DESCRIPTION
At least one of the requires, `github.com/aws/smithy-go`, bumped its minimum go version requirement to 1.22.

> <h2> Module Highlights </h2>
>
> - github.com/aws/smithy-go: v1.22.3
> - Dependency Update: Bump minimum Go version to 1.22 per our language support policy.