### PR TITLE
workflows: update actions for new ceph org policy changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,10 +87,11 @@ jobs:
       run:  sudo bash -c 'echo "core" > /proc/sys/kernel/core_pattern'
     - name: Run tests
       run: make test-containers-test "CEPH_VERSION=${{ matrix.ceph_version }}" "GO_VERSION=${{ matrix.go_version }}" "RESULTS_DIR=$PWD/_results"
-    # Enable tmate debugging of manually-triggered workflows if the input option was provided
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+    # As an example, one can enable tmate debugging of manually-triggered
+    # workflows if the input option was provided
+    # - name: Setup tmate session
+    #  uses: mxschmitt/action-tmate@v3
+    #  if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
     - name: Clean up test containers
       if: always()
       run: make test-containers-clean "CEPH_VERSION=${{ matrix.ceph_version }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,8 @@ jobs:
     needs: go-versions
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
       with:
         go-version: ${{ needs.go-versions.outputs.latest }}
     - name: Install revive
@@ -82,7 +82,7 @@ jobs:
         - ceph_version: "reef"
           go_version: ${{ needs.go-versions.outputs.unstable }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Set cores to get stored as "core"
       run:  sudo bash -c 'echo "core" > /proc/sys/kernel/core_pattern'
     - name: Run tests

--- a/.github/workflows/report-stable.yml
+++ b/.github/workflows/report-stable.yml
@@ -12,23 +12,26 @@ jobs:
     steps:
     # Checkout with fetch-depth=0 in order to fetch (all) tags.
     # The Makefile runs git commands to pass tag info to the apiage script.
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0
     - name: Run makefile
       run: make api-report-issuetemplate  RESULTS_DIR=_results
     - name: Archive test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: "go-ceph-api-updates"
         path: |
           _results/
         retention-days: 30
       if: "!cancelled()"
-    - name: File Issue
-      uses: JasonEtco/create-an-issue@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        filename: _results/issue.md
-        update_existing: true
+    #### Disabled action ####
+    # - name: File Issue
+    #  uses: JasonEtco/create-an-issue@v2
+    #  env:
+    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #  with:
+    #    filename: _results/issue.md
+    #    update_existing: true
+    - name: Please file an issue
+      run: echo "Dear Human, Please file an issue with the following template"; cat _results/issue.md

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 14 days if no further activity occurs. Thank you for your contribution.'


### PR DESCRIPTION
Remove the use of unofficial github actions.
Pin the official github actions with the git sha id.

As per: https://lists.ceph.io/hyperkitty/list/dev@ceph.io/thread/5KWHAST62YAT4P25OO6JYMTRSGSZYPOS/



## Checklist
- [x] Infra ONLY

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
