### PR TITLE
version bumps - container file and workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,9 +77,9 @@ jobs:
         go_version:
         - ${{ needs.go-versions.outputs.latest }}
         include:
-        - ceph_version: "reef"
+        - ceph_version: "squid"
           go_version: ${{ needs.go-versions.outputs.prev }}
-        - ceph_version: "reef"
+        - ceph_version: "squid"
           go_version: ${{ needs.go-versions.outputs.unstable }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -1,5 +1,5 @@
 ARG CEPH_IMG=quay.io/ceph/ceph
-ARG CEPH_TAG=v16
+ARG CEPH_TAG=v19
 FROM ${CEPH_IMG}:${CEPH_TAG}
 
 # A CEPH_VERSION env var is already set in the base image.

--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -29,7 +29,7 @@ RUN true \
     && yum clean all \
     && true
 
-ARG GO_VERSION=1.21.8
+ARG GO_VERSION=1.23.7
 ENV GO_VERSION=${GO_VERSION}
 ARG GOARCH
 ENV GOARCH=${GOARCH}


### PR DESCRIPTION
Bump up the default version of the GO version and Ceph version in the container file.

Bump the workflows up to use squid instead of reef when testing alternate Go versions.


## Checklist
- [x] Infra *only*

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
