### PR TITLE
build: Bump go version to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ceph/go-ceph
 
-go 1.22
+go 1.23.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3


### PR DESCRIPTION
golang has decided to come up with an [automation](https://github.com/golang/go/issues/69095) to update `go` directive in go.mod from various repositories including x/repos following the release cadence in general. Another interesting and visible change is to explicitly specify the minor version as a suffix to the major version. Thus we are bound to update our `go` directive as we require at least x/sys.