### PR TITLE
Add a new smb admin API sub-package

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -17,8 +17,11 @@ warningCode = 0
 [rule.exported]
 [rule.if-return]
 [rule.increment-decrement]
+# The configuration approach to the following rule is pretty bonkers.
+# But we need to skip package name checks because we already have an
+# (internal!) utils package and we aint changing it now.
 [rule.var-naming]
-  arguments = [["ID", "UID"]]
+  arguments = [["ID", "UID"], [], [{skipPackageNameChecks=true}]]
 [rule.var-declaration]
 # We need to disable the package-comments check because we check all the .go
 # files in the repo individually. This appears to confuse the new

--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ test-binaries: \
 	cephfs/admin.test \
 	common/admin/manager.test \
 	common/admin/nfs.test \
+	common/admin/smb.test \
 	internal/callbacks.test \
 	internal/commands.test \
 	internal/cutil.test \

--- a/common/admin/smb/admin.go
+++ b/common/admin/smb/admin.go
@@ -1,0 +1,24 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	ccom "github.com/ceph/go-ceph/common/commands"
+)
+
+// Commander interface supports sending commands to Ceph.
+type Commander interface {
+	ccom.RadosBufferCommander
+}
+
+// Admin is used to administer ceph smb features.
+type Admin struct {
+	conn Commander
+}
+
+// NewFromConn creates an new management object from a preexisting
+// rados connection. The existing connection can be rados.Conn or any
+// type implementing the RadosCommander interface.
+func NewFromConn(conn Commander) *Admin {
+	return &Admin{conn}
+}

--- a/common/admin/smb/admin_test.go
+++ b/common/admin/smb/admin_test.go
@@ -1,0 +1,385 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tsuite "github.com/stretchr/testify/suite"
+
+	fsadmin "github.com/ceph/go-ceph/cephfs/admin"
+	"github.com/ceph/go-ceph/common/admin/manager"
+	"github.com/ceph/go-ceph/internal/admintest"
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+const modName = "smb"
+
+func TestSMBAdmin(t *testing.T) {
+	tsuite.Run(t, new(SMBAdminSuite))
+}
+
+// SMBAdminSuite is a suite of tests for the smb admin package.
+type SMBAdminSuite struct {
+	tsuite.Suite
+
+	fileSystemName string
+	vconn          *admintest.Connector
+}
+
+func (suite *SMBAdminSuite) SetupSuite() {
+	suite.vconn = admintest.NewConnector()
+	suite.disableOrch()
+	suite.enableSMB()
+	suite.waitForSMBResponsive()
+	suite.configureSubVolume()
+}
+
+func (suite *SMBAdminSuite) TearDownSuite() {
+	suite.removeSubVolume()
+	suite.disableSMB()
+}
+
+func (suite *SMBAdminSuite) enableSMB() {
+	t := suite.T()
+	t.Logf("enabling smb module")
+	mgradmin := manager.NewFromConn(suite.vconn.Get(t))
+	err := mgradmin.EnableModule(modName, true)
+	if err != nil && strings.Contains(err.Error(), "already enabled") {
+		return
+	}
+	assert.NoError(t, err)
+}
+
+func (suite *SMBAdminSuite) waitForSMBOLD() {
+	t := suite.T()
+	t.Logf("waiting for smb module")
+	time.Sleep(100 * time.Millisecond)
+	mgradmin := manager.NewFromConn(suite.vconn.Get(t))
+	for i := 0; i < 30; i++ {
+		modinfo, err := mgradmin.ListModules()
+		require.NoError(t, err)
+		for _, emod := range modinfo.EnabledModules {
+			if emod == modName {
+				// give additional time for mgr to restart(?)
+				time.Sleep(200 * time.Millisecond)
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for smb module")
+}
+
+func (suite *SMBAdminSuite) waitForSMBResponsive() {
+	// wait until smb module is responsive
+	sa := NewFromConn(suite.vconn.Get(suite.T()))
+	for i := 0; i < 30; i++ {
+		_, err := sa.Show(nil, nil)
+		if err == nil {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	suite.T().Fatalf("show command never succeeded - module not ready?")
+}
+
+func (suite *SMBAdminSuite) disableSMB() {
+	suite.T().Logf("disabling smb module")
+	mgradmin := manager.NewFromConn(suite.vconn.Get(suite.T()))
+	err := mgradmin.DisableModule("smb")
+	assert.NoError(suite.T(), err)
+	time.Sleep(500 * time.Millisecond)
+}
+
+func (suite *SMBAdminSuite) disableOrch() {
+	suite.T().Logf("disabling smb orch")
+	time.Sleep(10 * time.Millisecond)
+	// ceph config set mgr mgr/smb/update_orchestration false
+	m := map[string]any{
+		"prefix": "config set",
+		"who":    "mgr",
+		"name":   "mgr/smb/update_orchestration",
+		"value":  "false",
+		"force":  true, // needed to run this before enabling module
+	}
+	a := suite.vconn.Get(suite.T())
+	err := commands.MarshalMonCommand(a, m).NoData().End()
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *SMBAdminSuite) configureSubVolume() {
+	// set up a subvolume for use by smb commands
+	fsa := fsadmin.NewFromConn(suite.vconn.Get(suite.T()))
+	err := fsa.CreateSubVolumeGroup("cephfs", "smb", nil)
+	assert.NoError(suite.T(), err)
+	err = fsa.CreateSubVolume("cephfs", "smb", "v1", nil)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *SMBAdminSuite) removeSubVolume() {
+	fsa := fsadmin.NewFromConn(suite.vconn.Get(suite.T()))
+	err := fsa.RemoveSubVolume("cephfs", "smb", "v1")
+	assert.NoError(suite.T(), err)
+	err = fsa.RemoveSubVolumeGroup("cephfs", "smb")
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *SMBAdminSuite) SetupTest() {
+	suite.waitForSMBResponsive()
+}
+
+func (suite *SMBAdminSuite) TearDownTest() {
+	sa := NewFromConn(suite.vconn.Get(suite.T()))
+	r, err := sa.Show(nil, nil)
+	suite.Assert().NoError(err)
+	for i := range r {
+		switch res := r[i].(type) {
+		case *Cluster:
+			res.IntentValue = Removed
+		case *Share:
+			res.IntentValue = Removed
+		case *JoinAuth:
+			res.IntentValue = Removed
+		case *UsersAndGroups:
+			res.IntentValue = Removed
+		}
+	}
+	if len(r) > 0 {
+		_, err = sa.Apply(r, nil)
+		suite.Assert().NoError(err)
+	}
+}
+
+func (suite *SMBAdminSuite) TestShowEmpty() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	r, err := sa.Show(nil, nil)
+	assert.NoError(t, err)
+	assert.Len(t, r, 0)
+}
+
+func (suite *SMBAdminSuite) TestCreateCluster() {
+	cluster := NewUserCluster("clu1")
+	ug := NewLinkedUsersAndGroups(cluster).SetValues(
+		[]UserInfo{
+			{"alice", "W0nder14nd"},
+			{"billy", "p14n0m4N"},
+		},
+		[]GroupInfo{{"clients"}},
+	)
+
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	rg, err := sa.Apply([]Resource{cluster, ug}, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, rg)
+}
+
+func (suite *SMBAdminSuite) TestRemoveCluster() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	r := []Resource{
+		NewActiveDirectoryCluster("cc1", "zoid"),
+	}
+	rg, err := sa.Apply(r, nil)
+	assert.NoError(t, err)
+	assert.True(t, rg.Ok())
+
+	err = sa.RemoveCluster("cc1")
+	assert.NoError(t, err)
+}
+
+func (suite *SMBAdminSuite) TestRemoveShare() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	err := sa.RemoveShare("foo", "bar")
+	assert.NoError(t, err)
+
+	r := []Resource{
+		NewActiveDirectoryCluster("cc1", "zoid"),
+		NewShare("cc1", "zap").SetCephFS("cephfs", "smb", "v1", "/"),
+	}
+	rg, err := sa.Apply(r, nil)
+	assert.NoError(t, err)
+	assert.True(t, rg.Ok())
+
+	err = sa.RemoveShare("cc1", "zap")
+	assert.NoError(t, err)
+}
+
+func (suite *SMBAdminSuite) TestRemoveJoinAuth() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	err := sa.RemoveJoinAuth("foo")
+	assert.NoError(t, err)
+
+	r := []Resource{
+		NewJoinAuth("jauth1").SetAuth("admin", "foobar"),
+	}
+	rg, err := sa.Apply(r, nil)
+	assert.NoError(t, err)
+	assert.True(t, rg.Ok())
+
+	err = sa.RemoveJoinAuth("jauth1")
+	assert.NoError(t, err)
+}
+
+func (suite *SMBAdminSuite) TestRemoveUsersAndGroups() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	err := sa.RemoveUsersAndGroups("foo")
+	assert.NoError(t, err)
+
+	r := []Resource{
+		NewUsersAndGroups("ug1").SetValues(
+			[]UserInfo{{"foo", "s3cr3t"}},
+			[]GroupInfo{{"bloop"}},
+		),
+	}
+	rg, err := sa.Apply(r, nil)
+	assert.NoError(t, err)
+	assert.True(t, rg.Ok())
+
+	err = sa.RemoveUsersAndGroups("ug1")
+	assert.NoError(t, err)
+}
+
+func (suite *SMBAdminSuite) TestShowSelect() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	cluster := NewUserCluster("cc1")
+	ug := NewLinkedUsersAndGroups(cluster).SetValues(
+		[]UserInfo{
+			{"alice", "W0nder14nd"},
+			{"billy", "p14n0m4N"},
+		},
+		[]GroupInfo{{"clients"}},
+	)
+	share := NewShare("cc1", "ss1").SetCephFS("cephfs", "smb", "v1", "/")
+	rgroup, err := sa.Apply([]Resource{cluster, ug, share}, nil)
+	assert.NoError(t, err)
+	assert.True(t, rgroup.Ok())
+
+	t.Run("byIdentity", func(t *testing.T) {
+		matching, err := sa.Show([]ResourceRef{cluster.Identity()}, nil)
+		assert.NoError(t, err)
+		assert.Len(t, matching, 1)
+		assert.Equal(t, matching[0].Type(), ClusterType)
+	})
+
+	t.Run("byResouceID", func(t *testing.T) {
+		ref := ResourceID{ResourceType: ClusterType, ID: "cc1"}
+		matching, err := sa.Show([]ResourceRef{ref}, nil)
+		assert.NoError(t, err)
+		assert.Len(t, matching, 1)
+		assert.Equal(t, matching[0].Type(), ClusterType)
+	})
+
+	t.Run("byType", func(t *testing.T) {
+		matching, err := sa.Show([]ResourceRef{ClusterType}, nil)
+		assert.NoError(t, err)
+		assert.Len(t, matching, 1)
+		assert.Equal(t, matching[0].Type(), ClusterType)
+	})
+}
+
+func (suite *SMBAdminSuite) TestApplyErrorInvalid() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	badShare := NewShare("abc", "xyz")
+	results, err := sa.Apply([]Resource{badShare}, nil)
+	assert.Error(t, err)
+	assert.False(t, results.Success)
+}
+
+func (suite *SMBAdminSuite) TestApplyFilterBase64() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	ja1 := NewJoinAuth("jjb64").SetAuth("joiner", "bXlzZWNyZXRQYXNzd29yZA==")
+	results, err := sa.Apply(
+		[]Resource{ja1},
+		&ApplyOptions{PasswordFilter: PasswordFilterBase64},
+	)
+	assert.NoError(t, err)
+	assert.True(t, results.Ok())
+	if assert.Len(t, results.Results, 1) {
+		assert.Equal(
+			t,
+			results.Results[0].Resource().(*JoinAuth).Auth.Password,
+			"bXlzZWNyZXRQYXNzd29yZA==",
+		)
+	}
+}
+
+func (suite *SMBAdminSuite) TestApplyFilterMixed() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	ja1 := NewJoinAuth("jjb64").SetAuth("joiner", "bXlzZWNyZXRQYXNzd29yZA==")
+	results, err := sa.Apply(
+		[]Resource{ja1},
+		&ApplyOptions{
+			PasswordFilter:    PasswordFilterBase64,
+			PasswordFilterOut: PasswordFilterNone,
+		},
+	)
+	assert.NoError(t, err)
+	assert.True(t, results.Ok())
+	if assert.Len(t, results.Results, 1) {
+		assert.Equal(
+			t,
+			results.Results[0].Resource().(*JoinAuth).Auth.Password,
+			"mysecretPassword",
+		)
+	}
+}
+
+func (suite *SMBAdminSuite) TestApplyFilterShowFilter() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	ja1 := NewJoinAuth("jjb64").SetAuth("joiner", "bXlzZWNyZXRQYXNzd29yZA==")
+	results, err := sa.Apply(
+		[]Resource{ja1},
+		&ApplyOptions{
+			PasswordFilter:    PasswordFilterBase64,
+			PasswordFilterOut: PasswordFilterHidden,
+		},
+	)
+	assert.NoError(t, err)
+	assert.True(t, results.Ok())
+
+	t.Run("showHidden", func(t *testing.T) {
+		res, err := sa.Show(
+			[]ResourceRef{ja1.Identity()},
+			&ShowOptions{PasswordFilter: PasswordFilterHidden},
+		)
+		assert.NoError(t, err)
+		if assert.Len(t, res, 1) {
+			assert.Equal(t, res[0].(*JoinAuth).Auth.Password, "****************")
+		}
+	})
+	t.Run("showBase64", func(t *testing.T) {
+		res, err := sa.Show(
+			[]ResourceRef{ja1.Identity()},
+			&ShowOptions{PasswordFilter: PasswordFilterBase64},
+		)
+		assert.NoError(t, err)
+		if assert.Len(t, res, 1) {
+			assert.Equal(t, res[0].(*JoinAuth).Auth.Password, "bXlzZWNyZXRQYXNzd29yZA==")
+		}
+	})
+	t.Run("showFilterNone", func(t *testing.T) {
+		res, err := sa.Show(
+			[]ResourceRef{ja1.Identity()},
+			&ShowOptions{PasswordFilter: PasswordFilterNone},
+		)
+		assert.NoError(t, err)
+		if assert.Len(t, res, 1) {
+			assert.Equal(t, res[0].(*JoinAuth).Auth.Password, "mysecretPassword")
+		}
+	})
+}

--- a/common/admin/smb/cluster.go
+++ b/common/admin/smb/cluster.go
@@ -1,0 +1,194 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// JoinAuthSource identifies a Join Auth resource that will be used
+// as a source of authentication parameters to join a cluster to
+// a domain.
+type JoinAuthSource struct {
+	SourceType SourceType `json:"source_type"`
+	Ref        string     `json:"ref"`
+}
+
+// UserGroupSource identifies a Users and Groups resource that will be
+// used as a source of user and group information on the SMB cluster.
+type UserGroupSource struct {
+	SourceType SourceType `json:"source_type"`
+	Ref        string     `json:"ref"`
+}
+
+// DomainSettings are used to configure domain related settings for a
+// cluster using active directory authentication.
+type DomainSettings struct {
+	// Realm identifies the AD/Kerberos Realm to use.
+	Realm string `json:"realm"`
+	// JoinSources should contain one or more JoinAuthSource that
+	// the cluster may use to join a domain.
+	JoinSources []JoinAuthSource `json:"join_sources"`
+}
+
+// Placement is passed to cephadm to determine where cluster services
+// will be run.
+type Placement map[string]any
+
+// SimplePlacement returns a placement with common placement parameters - count
+// and label - specified.
+func SimplePlacement(count int, label string) Placement {
+	p := Placement{}
+	if count > 0 {
+		p["count"] = count
+	}
+	if label != "" {
+		p["label"] = label
+	}
+	return p
+}
+
+// PublicAddress used by a cluster with integrated Samba clustering enabled.
+type PublicAddress struct {
+	Address     string
+	Destination []string
+}
+
+// Cluster configures an SMB Cluster resource that is managed within a
+// Ceph cluster.
+type Cluster struct {
+	IntentValue       Intent            `json:"intent"`
+	ClusterID         string            `json:"cluster_id"`
+	AuthMode          ClusterAuthMode   `json:"auth_mode"`
+	DomainSettings    *DomainSettings   `json:"domain_settings,omitempty"`
+	UserGroupSettings []UserGroupSource `json:"user_group_settings,omitempty"`
+	CustomDNS         []string          `json:"custom_dns,omitempty"`
+	Placement         Placement         `json:"placement,omitempty"`
+	Clustering        Clustering        `json:"clustering,omitempty"`
+	PublicAddrs       []PublicAddress   `json:"public_addrs,omitempty"`
+}
+
+// Type returns a ResourceType value.
+func (*Cluster) Type() ResourceType {
+	return ClusterType
+}
+
+// Intent controls if a resource is to be created/updated or removed.
+func (cluster *Cluster) Intent() Intent {
+	return cluster.IntentValue
+}
+
+// Identity returns a ResourceRef identifying this cluster.
+func (cluster *Cluster) Identity() ResourceRef {
+	return ResourceID{
+		ResourceType: cluster.Type(),
+		ID:           cluster.ClusterID,
+	}
+}
+
+// MarshalJSON supports marshalling a cluster to JSON.
+func (cluster *Cluster) MarshalJSON() ([]byte, error) {
+	type vCluster Cluster
+	type wCluster struct {
+		ResourceType ResourceType `json:"resource_type"`
+		vCluster
+	}
+	return json.Marshal(wCluster{
+		ResourceType: cluster.Type(),
+		vCluster:     vCluster(*cluster),
+	})
+}
+
+// Validate returns an error describing an issue with the resource or
+// nil if the resource object is valid.
+func (cluster *Cluster) Validate() error {
+	var minimal bool
+	switch cluster.IntentValue {
+	case Present:
+	case Removed:
+		minimal = true
+	default:
+		return fmt.Errorf("missing intent")
+	}
+	if cluster.ClusterID == "" {
+		return fmt.Errorf("missing ClusterID")
+	}
+	if minimal {
+		return nil // minimal checks have been done, return early
+	}
+
+	switch cluster.AuthMode {
+	case ActiveDirectoryAuth:
+		if cluster.DomainSettings == nil {
+			return fmt.Errorf(
+				"missing domain settings for %v cluster", ActiveDirectoryAuth)
+		}
+	case UserAuth:
+		if len(cluster.UserGroupSettings) == 0 {
+			return fmt.Errorf(
+				"missing user and group settings for %v cluster",
+				UserAuth)
+		}
+	default:
+		return fmt.Errorf("invalid AuthMode: %#v", cluster.AuthMode)
+	}
+	return nil
+}
+
+// SetPlacement modifies a cluster's placment settings.
+func (cluster *Cluster) SetPlacement(p Placement) *Cluster {
+	cluster.Placement = p
+	return cluster
+}
+
+// NewUserCluster returns a new Cluster with default values set to
+// create/update a cluster with local users-and-groups defined.
+// In addition to the cluster name, this function accepts zero or more
+// ID values naming ceph.smb.usersgroups resources.
+func NewUserCluster(clusterID string, ids ...string) *Cluster {
+	ugs := make([]UserGroupSource, len(ids))
+	for i := range ids {
+		ugs[i] = UserGroupSource{
+			SourceType: ResourceSource,
+			Ref:        ids[i],
+		}
+	}
+	return &Cluster{
+		IntentValue:       Present,
+		ClusterID:         clusterID,
+		AuthMode:          UserAuth,
+		UserGroupSettings: ugs,
+	}
+}
+
+// NewActiveDirectoryCluster returns a new Cluster with default values set to
+// create/update a cluster with active directory authentication.
+// In addition to the cluster name, this function accepts the name of the
+// domain/realm and zero or more ID values naming ceph.smb.join.auth resources.
+func NewActiveDirectoryCluster(
+	clusterID string, realm string, ids ...string) *Cluster {
+
+	jss := make([]JoinAuthSource, len(ids))
+	for i := range ids {
+		jss[i] = JoinAuthSource{
+			SourceType: ResourceSource,
+			Ref:        ids[i],
+		}
+	}
+	return &Cluster{
+		IntentValue: Present,
+		ClusterID:   clusterID,
+		AuthMode:    ActiveDirectoryAuth,
+		DomainSettings: &DomainSettings{
+			Realm:       realm,
+			JoinSources: jss,
+		},
+	}
+}
+
+// NewClusterToRemove return a new Cluster with default values set to remove a
+// cluster from management.
+func NewClusterToRemove(clusterID string) *Cluster {
+	return &Cluster{IntentValue: Removed, ClusterID: clusterID}
+}

--- a/common/admin/smb/cluster_test.go
+++ b/common/admin/smb/cluster_test.go
@@ -1,0 +1,146 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterIdentity(t *testing.T) {
+	cluster := NewUserCluster("c1")
+	assert.Equal(t, cluster.Type(), ClusterType)
+	cid := cluster.Identity()
+	assert.Equal(t, cid.Type(), ClusterType)
+	assert.Equal(t, cid.String(), "ceph.smb.cluster.c1")
+	assert.Equal(t, cluster.Intent(), Present)
+}
+
+func TestClusterValidate(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		c := &Cluster{}
+		assert.ErrorContains(t, c.Validate(), "intent")
+	})
+	t.Run("missingID", func(t *testing.T) {
+		c := &Cluster{IntentValue: Present}
+		assert.ErrorContains(t, c.Validate(), "ClusterID")
+	})
+	t.Run("intentRemoved", func(t *testing.T) {
+		c := &Cluster{IntentValue: Removed, ClusterID: "fred"}
+		assert.NoError(t, c.Validate())
+	})
+
+	// from this point on we're going to progressively add to
+	// c1 until it is valid
+	c1 := &Cluster{
+		IntentValue: Present,
+		ClusterID:   "bob",
+	}
+	t.Run("missingAuthMode", func(t *testing.T) {
+		assert.ErrorContains(t, c1.Validate(), "AuthMode")
+	})
+	c1.AuthMode = ActiveDirectoryAuth
+	t.Run("missingDomainSettings", func(t *testing.T) {
+		assert.ErrorContains(t, c1.Validate(), "domain")
+	})
+	c1.AuthMode = UserAuth
+	t.Run("missingUserGroupSettings", func(t *testing.T) {
+		assert.ErrorContains(t, c1.Validate(), "user")
+	})
+
+	c1.UserGroupSettings = []UserGroupSource{{ResourceSource, "foo"}}
+	t.Run("ok", func(t *testing.T) {
+		assert.NoError(t, c1.Validate())
+	})
+}
+
+func TestClusterNewActiveDirectory(t *testing.T) {
+	// ensure that the new method for ad clusters creates
+	// the correct defaults
+	cluster := NewActiveDirectoryCluster("davey", "cool.example.com", "j1", "j2")
+	assert.Equal(t, cluster.IntentValue, Present)
+	assert.Equal(t, cluster.ClusterID, "davey")
+	assert.Equal(t, cluster.AuthMode, ActiveDirectoryAuth)
+	assert.Equal(t, cluster.DomainSettings.Realm, "cool.example.com")
+	assert.Len(t, cluster.DomainSettings.JoinSources, 2)
+	assert.Equal(t, cluster.DomainSettings.JoinSources[0].Ref, "j1")
+	assert.Equal(t, cluster.DomainSettings.JoinSources[1].Ref, "j2")
+}
+
+func TestClusterNewToRemove(t *testing.T) {
+	rc := NewClusterToRemove("nope")
+	assert.Equal(t, rc.Intent(), Removed)
+	assert.Equal(t, rc.ClusterID, "nope")
+}
+
+func TestMarshalCluster(t *testing.T) {
+	cluster := NewUserCluster("c1")
+	_, err := json.Marshal(cluster)
+	assert.NoError(t, err)
+}
+
+func TestMarshalUnmarshalCluster(t *testing.T) {
+	c := NewUserCluster("joey", "pibb")
+	assert.NoError(t, c.Validate())
+	j, err := json.Marshal(c)
+	assert.NoError(t, err)
+	c2 := &Cluster{}
+	err = json.Unmarshal(j, c2)
+	assert.NoError(t, err)
+	assert.NoError(t, c2.Validate())
+	assert.EqualValues(t, c.ClusterID, c2.ClusterID)
+	assert.EqualValues(t, c.IntentValue, c2.IntentValue)
+	assert.EqualValues(t, c.UserGroupSettings, c2.UserGroupSettings)
+}
+
+func TestMarshalUnmarshalClusterLinkedUsers(t *testing.T) {
+	c := NewUserCluster("ceeone")
+	ug := NewLinkedUsersAndGroups(c).SetValues(
+		[]UserInfo{
+			{"bob", "M4r13y"},
+			{"billy", "p14n0m4N"},
+		},
+		[]GroupInfo{{"clients"}},
+	)
+	rg := resourceGroup{Resources: []Resource{c, ug}}
+	assert.NoError(t, ValidateResources(rg.Resources))
+	j, err := json.Marshal(rg)
+	assert.NoError(t, err)
+
+	rg = resourceGroup{}
+	err = json.Unmarshal(j, &rg)
+	assert.NoError(t, err)
+	assert.Len(t, rg.Resources, 2)
+	assert.Equal(t, rg.Resources[0].Type(), ClusterType)
+	assert.Equal(t, rg.Resources[1].Type(), UsersAndGroupsType)
+}
+
+func TestClusterSimplePlacement(t *testing.T) {
+	t.Run("countOnly", func(t *testing.T) {
+		p := SimplePlacement(3, "") // count of 3, no label
+		c := NewUserCluster("joey", "pibb").SetPlacement(p)
+		assert.Len(t, c.Placement, 1)
+		assert.EqualValues(t, c.Placement["count"], 3)
+	})
+	t.Run("labelOnly", func(t *testing.T) {
+		p := SimplePlacement(0, "ilovesmb") // count of 3, no label
+		c := NewUserCluster("joey", "pibb").SetPlacement(p)
+		assert.Len(t, c.Placement, 1)
+		assert.EqualValues(t, c.Placement["label"], "ilovesmb")
+	})
+	t.Run("marshalCountAndLabel", func(t *testing.T) {
+		p := SimplePlacement(3, "ilovesmb") // count of 3, no label
+		c := NewUserCluster("joey", "pibb").SetPlacement(p)
+		j, err := json.Marshal(c)
+		assert.NoError(t, err)
+
+		c2 := &Cluster{}
+		err = json.Unmarshal(j, c2)
+		assert.NoError(t, err)
+		assert.Len(t, c2.Placement, 2)
+		assert.EqualValues(t, c.Placement["count"], 3)
+		assert.EqualValues(t, c.Placement["label"], "ilovesmb")
+	})
+}

--- a/common/admin/smb/doc.go
+++ b/common/admin/smb/doc.go
@@ -1,5 +1,16 @@
 /*
 Package smb from common/admin contains a set of APIs used to interact
 with and administer SMB support for ceph clusters.
+
+The Ceph smb mgr module is based on the concept of resources. Resource
+descriptions are used to create, update, or delete configuration state in
+the Ceph cluster and the Ceph cluster will attempt to configure SMB Servers
+based on these resources.
+
+Resource types include Cluster, JoinAuth, UsersAndGroups, and Share. To
+modify the state on the Ceph cluster use the Apply function. To query
+the state of the resources on the Ceph cluster use the Show function.
+Resources that are to be deleted should have an Intent value of Removed.
+Resources being updated or created must have an Intent value of Present.
 */
 package smb

--- a/common/admin/smb/doc.go
+++ b/common/admin/smb/doc.go
@@ -1,0 +1,5 @@
+/*
+Package smb from common/admin contains a set of APIs used to interact
+with and administer SMB support for ceph clusters.
+*/
+package smb

--- a/common/admin/smb/enums.go
+++ b/common/admin/smb/enums.go
@@ -1,0 +1,117 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+// Intent indicates how a resource description should be processed.
+type Intent string
+
+const (
+	// Present resources will be created or updated.
+	Present = Intent("present")
+	// Removed resources will be removed or ignored.
+	Removed = Intent("removed")
+)
+
+// ResourceType values are used to identify the type of a resource.
+type ResourceType string
+
+const (
+	// ClusterType resources represent SMB clusters.
+	ClusterType = ResourceType("ceph.smb.cluster")
+	// ShareType resources represent SMB shares.
+	ShareType = ResourceType("ceph.smb.share")
+	// JoinAuthType resources contain information used to join a domain.
+	JoinAuthType = ResourceType("ceph.smb.join.auth")
+	// UsersAndGroupsType resources contain data used to define users and groups.
+	UsersAndGroupsType = ResourceType("ceph.smb.usersgroups")
+)
+
+// SourceType indicates how a Cluster resource refers to another resource it
+// needs. Currently only ResourceSource is available.
+type SourceType string
+
+const (
+	// ResourceSource indicates that another resource is being referenced.
+	ResourceSource = SourceType("resource")
+)
+
+// ClusterAuthMode indicates how a Cluster should authenticate users.
+type ClusterAuthMode string
+
+const (
+	// ActiveDirectoryAuth indicates a cluster will use an active directory domain.
+	ActiveDirectoryAuth = ClusterAuthMode("active-directory")
+	// UserAuth indicates a cluster will use locally defined users and groups.
+	UserAuth = ClusterAuthMode("user")
+)
+
+// Clustering indicates how an abstract cluster should be managed.
+type Clustering string
+
+const (
+	// DefaultClustering indicates SMB clustering should be enabled based on
+	// the placement value.
+	DefaultClustering = Clustering("default")
+	// NeverClustering indicates SMB clustering should never be enabled.
+	NeverClustering = Clustering("never")
+	// AlwaysClustering indicates SMB clustering should always be enabled.
+	AlwaysClustering = Clustering("always")
+)
+
+// AccessCategory determines if share login controls applies to a user
+// or group.
+type AccessCategory string
+
+const (
+	// UserAccess indicates a share login control applies to a user.
+	UserAccess = AccessCategory("user")
+	// GroupAccess indicates a share login control applies to a group.
+	GroupAccess = AccessCategory("group")
+)
+
+// AccessMode determines what kind of access a share login control will
+// grant.
+type AccessMode string
+
+const (
+	// ReadAccess grants read-only access to a share.
+	ReadAccess = AccessMode("read")
+	// ReadWriteAccess grants read-write access to a share.
+	ReadWriteAccess = AccessMode("read-write")
+	// AdminAccess grants administrative access to a share.
+	AdminAccess = AccessMode("admin")
+	// NoneAccess denies access to a share.
+	NoneAccess = AccessMode("none")
+)
+
+// CephFSProvider indicates what method will be used to bridge smb services to
+// CephFS.
+type CephFSProvider string
+
+const (
+	// SambaVFSProvider sets the default VFS based provider.
+	SambaVFSProvider = CephFSProvider("samba-vfs")
+	// SambaVFSNewProvider sets the new Ceph module VFS based provider.
+	SambaVFSNewProvider = CephFSProvider("samba-vfs/new")
+	// SambaVFSClassicProvider sets the older Ceph module VFS based provider.
+	SambaVFSClassicProvider = CephFSProvider("samba-vfs/classic")
+	// SambaVFSProxiedProvider sets the new Ceph module VFS based provider with CephFS proxy server support.
+	SambaVFSProxiedProvider = CephFSProvider("samba-vfs/proxied")
+)
+
+// PasswordFilter allows password values to be hidden or obfuscated when
+// sent to or fetched from the smb module.
+type PasswordFilter string
+
+const (
+	// PasswordFilterUnset specifies no password filter.
+	PasswordFilterUnset = PasswordFilter("")
+	// PasswordFilterNone specifies no password filtering should be done.
+	PasswordFilterNone = PasswordFilter("none")
+	// PasswordFilterBase64 specifies passwords should be converted from/to
+	// base64 encoding.
+	PasswordFilterBase64 = PasswordFilter("base64")
+	// PasswordFilterHidden specifies passwords should be replaced by opaque
+	// placeholder values.
+	PasswordFilterHidden = PasswordFilter("hidden")
+)

--- a/common/admin/smb/join_auth.go
+++ b/common/admin/smb/join_auth.go
@@ -1,0 +1,127 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// JoinAuthValues contains the username and password an SMB server will
+// use to join a domain.
+type JoinAuthValues struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// JoinAuth is a resource containing the parameters needed to join an SMB
+// server to a domain.
+type JoinAuth struct {
+	IntentValue     Intent          `json:"intent"`
+	AuthID          string          `json:"auth_id"`
+	Auth            *JoinAuthValues `json:"auth,omitempty"`
+	LinkedToCluster string          `json:"linked_to_cluster,omitempty"`
+}
+
+// Type returns a ResourceType value.
+func (*JoinAuth) Type() ResourceType {
+	return JoinAuthType
+}
+
+// Intent controls if a resource is to be created/updated or removed.
+func (ja *JoinAuth) Intent() Intent {
+	return ja.IntentValue
+}
+
+// Identity returns a ResourceRef identifying this joinauth resource.
+func (ja *JoinAuth) Identity() ResourceRef {
+	return ResourceID{
+		ResourceType: ja.Type(),
+		ID:           ja.AuthID,
+	}
+}
+
+// Validate returns an error describing an issue with the resource or nil if
+// the resource object is valid.
+func (ja *JoinAuth) Validate() error {
+	var minimal bool
+	switch ja.IntentValue {
+	case Present:
+	case Removed:
+		minimal = true
+	default:
+		return fmt.Errorf("missing intent")
+	}
+	if ja.AuthID == "" {
+		return fmt.Errorf("missing AuthID")
+	}
+	if minimal {
+		return nil // minimal checks have been done, return early
+	}
+
+	if ja.Auth == nil {
+		return fmt.Errorf("missing Auth parameters")
+	}
+	if ja.Auth.Username == "" {
+		return fmt.Errorf("missing Username")
+	}
+	if ja.Auth.Password == "" {
+		return fmt.Errorf("missing Password")
+	}
+	return nil
+}
+
+// MarshalJSON supports marshalling a cluster to JSON.
+func (ja *JoinAuth) MarshalJSON() ([]byte, error) {
+	type vJoinAuth JoinAuth
+	type wJoinAuth struct {
+		ResourceType ResourceType `json:"resource_type"`
+		vJoinAuth
+	}
+	return json.Marshal(wJoinAuth{
+		ResourceType: ja.Type(),
+		vJoinAuth:    vJoinAuth(*ja),
+	})
+}
+
+// SetAuth modifies a JoinAuth's authentication values.
+func (ja *JoinAuth) SetAuth(un, pw string) *JoinAuth {
+	if ja.Auth == nil {
+		ja.Auth = &JoinAuthValues{}
+	}
+	ja.Auth.Username = un
+	ja.Auth.Password = pw
+	return ja
+}
+
+// NewJoinAuth returns a new JoinAuth with default values.
+func NewJoinAuth(authID string) *JoinAuth {
+	return &JoinAuth{
+		IntentValue: Present,
+		AuthID:      authID,
+		Auth:        &JoinAuthValues{},
+	}
+}
+
+// NewLinkedJoinAuth returns a new JoinAuth with default values that link the
+// resource to a particular cluster. Linked resources can only be used by the
+// cluster they link to and are automatically deleted when the linked cluster
+// is deleted.
+func NewLinkedJoinAuth(cluster *Cluster) *JoinAuth {
+	ja := NewJoinAuth(randName(cluster.ClusterID))
+	ja.LinkedToCluster = cluster.ClusterID
+	cluster.DomainSettings.JoinSources = append(
+		cluster.DomainSettings.JoinSources,
+		JoinAuthSource{SourceType: ResourceSource, Ref: ja.AuthID},
+	)
+	return ja
+}
+
+// NewJoinAuthToRemove returns a new JoinAuth with default values set to remove
+// the join auth resource from management.
+func NewJoinAuthToRemove(authID string) *JoinAuth {
+	return &JoinAuth{
+		IntentValue: Removed,
+		AuthID:      authID,
+	}
+}

--- a/common/admin/smb/join_auth_test.go
+++ b/common/admin/smb/join_auth_test.go
@@ -1,0 +1,103 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinAuthIdentity(t *testing.T) {
+	ja := NewJoinAuth("ja1")
+	assert.Equal(t, ja.Type(), JoinAuthType)
+	jid := ja.Identity()
+	assert.Equal(t, jid.Type(), JoinAuthType)
+	assert.Equal(t, jid.String(), "ceph.smb.join.auth.ja1")
+	assert.Equal(t, ja.Intent(), Present)
+}
+
+func TestJoinAuthValidate(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ja := &JoinAuth{}
+		assert.ErrorContains(t, ja.Validate(), "intent")
+	})
+	t.Run("missingID", func(t *testing.T) {
+		ja := &JoinAuth{IntentValue: Present}
+		assert.ErrorContains(t, ja.Validate(), "AuthID")
+	})
+	t.Run("intentRemoved", func(t *testing.T) {
+		ja := &JoinAuth{IntentValue: Removed, AuthID: "fred"}
+		assert.NoError(t, ja.Validate())
+	})
+
+	// from this point on we're going to progressively add to
+	// ja1 until it is valid
+	ja1 := &JoinAuth{
+		IntentValue: Present,
+		AuthID:      "jalopy",
+	}
+	t.Run("missingAuth", func(t *testing.T) {
+		assert.ErrorContains(t, ja1.Validate(), "Auth")
+	})
+
+	ja1.Auth = &JoinAuthValues{}
+	t.Run("missingUsername", func(t *testing.T) {
+		assert.ErrorContains(t, ja1.Validate(), "Username")
+	})
+
+	ja1.Auth.Username = "admin"
+	t.Run("missingPassword", func(t *testing.T) {
+		assert.ErrorContains(t, ja1.Validate(), "Password")
+	})
+
+	ja1.Auth.Password = "Passw0rd"
+	t.Run("ok", func(t *testing.T) {
+		assert.NoError(t, ja1.Validate())
+	})
+}
+
+func TestJoinAuthNewAndSetAuth(t *testing.T) {
+	ja := NewJoinAuth("jam").SetAuth("admin", "s00per")
+	assert.Equal(t, ja.Intent(), Present)
+	assert.Equal(t, ja.AuthID, "jam")
+	assert.Equal(t, ja.Auth.Username, "admin")
+	assert.Equal(t, ja.Auth.Password, "s00per")
+	assert.Equal(t, ja.LinkedToCluster, "")
+}
+
+func TestJoinAuthNewToRemove(t *testing.T) {
+	rc := NewJoinAuthToRemove("nope")
+	assert.Equal(t, rc.Intent(), Removed)
+	assert.Equal(t, rc.AuthID, "nope")
+}
+
+func TestJoinAuthNewLinked(t *testing.T) {
+	c := NewActiveDirectoryCluster("c1", "test.example.net")
+	ja := NewLinkedJoinAuth(c).SetAuth("admin", "3sc4l4t3")
+	assert.NoError(t, ja.Validate())
+	assert.Equal(t, ja.LinkedToCluster, "c1")
+	assert.Len(t, c.DomainSettings.JoinSources, 1)
+	assert.Equal(t, c.DomainSettings.JoinSources[0].Ref, ja.AuthID)
+}
+
+func TestJoinAuthMarshalUnmarshal(t *testing.T) {
+	ja := NewJoinAuth("jjjj").SetAuth("admin", "3sc4l4t3")
+	j, err := json.Marshal(ja)
+	assert.NoError(t, err)
+	ja2 := &JoinAuth{}
+	err = json.Unmarshal(j, ja2)
+	assert.NoError(t, err)
+	assert.Equal(t, ja.AuthID, ja2.AuthID)
+	assert.Equal(t, ja.Auth.Username, ja2.Auth.Username)
+	assert.Equal(t, ja.Auth.Password, ja2.Auth.Password)
+}
+
+func TestJoinAuthSetAuth(t *testing.T) {
+	ja := &JoinAuth{IntentValue: Present, AuthID: "abc"}
+	ja.SetAuth("admin", "c00lt1m3")
+	assert.NotNil(t, ja.Auth)
+	assert.EqualValues(t, ja.Auth.Username, "admin")
+	assert.EqualValues(t, ja.Auth.Password, "c00lt1m3")
+}

--- a/common/admin/smb/ref.go
+++ b/common/admin/smb/ref.go
@@ -1,0 +1,62 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"fmt"
+)
+
+// ResourceRef provides a structured interface to refer to resources.
+type ResourceRef interface {
+	Type() ResourceType
+	String() string
+}
+
+// ------------------------------------------------
+// Give the ResourceType the methods needed to make it also
+// a ResourceRef.
+
+// Type returns a ResourceType value.
+func (rt ResourceType) Type() ResourceType {
+	// brought to you by the dept. of redundancy dept.
+	return rt
+}
+
+// String returns a string value referring to a resource.
+func (rt ResourceType) String() string {
+	return string(rt)
+}
+
+// ------------------------------------------------
+
+// ResourceID refers to a resource via its ResourceType value and a string ID.
+type ResourceID struct {
+	ResourceType ResourceType
+	ID           string
+}
+
+// Type returns a ResourceType value.
+func (r ResourceID) Type() ResourceType { return r.ResourceType }
+
+// String returns a string value referring to a resource ID.
+func (r ResourceID) String() string {
+	return fmt.Sprintf("%s.%s", r.ResourceType, r.ID)
+}
+
+// ------------------------------------------------
+
+// ChildResourceID refers to a resource via its ResourceType value, the ID of
+// a parent resource (typically a cluster) and a string ID for the child.
+type ChildResourceID struct {
+	ResourceType ResourceType
+	ParentID     string
+	ID           string
+}
+
+// Type returns a ResourceType value.
+func (c ChildResourceID) Type() ResourceType { return c.ResourceType }
+
+// String returns a string value referring to a child resource ID.
+func (c ChildResourceID) String() string {
+	return fmt.Sprintf("%s.%s.%s", c.ResourceType, c.ParentID, c.ID)
+}

--- a/common/admin/smb/resources.go
+++ b/common/admin/smb/resources.go
@@ -1,0 +1,266 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+// ErrUnknownResourceType indicates that JSON values contained a resource
+// type value unknown to this library.
+var ErrUnknownResourceType = errors.New("unknown resource type")
+
+// Resource is an interface provided for working with abstract resource
+// description structures in the Ceph smb module.
+type Resource interface {
+	// Type returns the ResourceType enum value for the resource.
+	Type() ResourceType
+	// Identity returns a resource reference for the resource.
+	Identity() ResourceRef
+	// Intent returns the intent value for the resource.
+	Intent() Intent
+	// Validate returns an error if the resource is not well-formed or
+	// incomplete.
+	Validate() error
+}
+
+type resourceGroup struct {
+	Resources []Resource `json:"resources"`
+}
+
+func (g *resourceGroup) UnmarshalJSON(data []byte) error {
+	var stub stubResource
+	if err := json.Unmarshal(data, &stub); err == nil &&
+		validResourceType(stub.ResourceType) {
+		// single resource
+		var entry resourceEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			return err
+		}
+		g.Resources = []Resource{entry.r}
+		return nil
+	}
+
+	var vg struct {
+		Resources []resourceEntry `json:"resources"`
+	}
+	if err := json.Unmarshal(data, &vg); err != nil {
+		return err
+	}
+	g.Resources = make([]Resource, len(vg.Resources))
+	for i := range vg.Resources {
+		g.Resources[i] = vg.Resources[i].r
+	}
+	return nil
+}
+
+type stubResource struct {
+	ResourceType ResourceType `json:"resource_type"`
+	IntentValue  Intent       `json:"intent"`
+}
+
+type resourceEntry struct {
+	stubResource
+	r Resource
+}
+
+func (e *resourceEntry) UnmarshalJSON(data []byte) error {
+	stub := stubResource{}
+	if err := json.Unmarshal(data, &stub); err != nil {
+		return err
+	}
+	e.stubResource = stub
+
+	switch stub.ResourceType {
+	case ClusterType:
+		e.r = new(Cluster)
+	case ShareType:
+		e.r = new(Share)
+	case JoinAuthType:
+		e.r = new(JoinAuth)
+	case UsersAndGroupsType:
+		e.r = new(UsersAndGroups)
+	default:
+		return fmt.Errorf("%w: %s", ErrUnknownResourceType, stub.ResourceType)
+	}
+
+	return json.Unmarshal(data, e.r)
+}
+
+func validResourceType(v ResourceType) bool {
+	switch v {
+	case ClusterType, ShareType, JoinAuthType, UsersAndGroupsType:
+		return true
+	}
+	return false
+}
+
+var rl = []rune("bcdfghjklmnpqrstvwxyz")
+
+func randName(prefix string) string {
+	// max len = 18; suffix len = 8
+	suffix := make([]rune, 8)
+	for i := range suffix {
+		suffix[i] = rl[rand.Intn(len(rl))]
+	}
+	n := len(prefix)
+	if n > 10 {
+		n = 10
+	}
+	return prefix[:n] + string(suffix)
+}
+
+// ShowOptions controls optional behavior of the Show function.
+type ShowOptions struct {
+	// PasswordFilter can be used to filter/obfuscate password values
+	// stored on the Ceph cluster.
+	PasswordFilter PasswordFilter
+}
+
+// Show smb module resource descriptions stored on the Ceph cluster.
+// If any values are provided in the refs slice, the function will query
+// only resources matching those references. These may be all matching
+// resources of a type or more specific references with IDs. The opts value
+// can be nil for default behavior or supplied to customize the query results.
+// Currently, ShowOptions can be used to filter password values.
+//
+// Similar To:
+//
+//	ceph smb show
+func (a *Admin) Show(refs []ResourceRef, opts *ShowOptions) (
+	[]Resource, error) {
+
+	rnames := make([]string, len(refs))
+	for i := range refs {
+		rnames[i] = refs[i].String()
+	}
+	m := map[string]any{
+		"prefix":         "smb show",
+		"format":         "json",
+		"resource_names": rnames,
+		"results":        "full",
+	}
+	if opts != nil && opts.PasswordFilter != PasswordFilterUnset {
+		m["password_filter"] = string(opts.PasswordFilter)
+	}
+	g := resourceGroup{}
+	c := commands.MarshalMgrCommand(a.conn, m)
+	if err := c.NoStatus().Unmarshal(&g).End(); err != nil {
+		return nil, err
+	}
+	return g.Resources, nil
+}
+
+// ApplyOptions controls optional behavior of the Apply function.
+type ApplyOptions struct {
+	// PasswordFilter can be used to filter/obfuscate password values
+	// sent to the Ceph cluster.
+	PasswordFilter PasswordFilter
+	// PasswordFilterOut can be used to filter/obfuscate password values
+	// returned from the Ceph cluster.
+	PasswordFilterOut PasswordFilter
+}
+
+// Apply changes to the resource descriptions stored on the Ceph cluster.
+// Supply one or more Resource objects in the slice and these resources will
+// be created, updated, or removed based on the Resource's parameters.
+// An Intent() of Present will create or update a resource.
+// An Intent() of Removed will remove a matching resource or be a no-op if nothing
+// is matched.
+// The opts value can be nil for default behavior or supplied to customize the
+// way the command processes inputs and outputs. Currently, the password values
+// supplied in the objects and returned in the result can be filtered depending
+// on the fields in the ApplyOptions structure.
+//
+// Similar To:
+//
+//	ceph smb apply -i -
+func (a *Admin) Apply(resources []Resource, opts *ApplyOptions) (
+	ResultGroup, error) {
+
+	rg := ResultGroup{}
+	if err := ValidateResources(resources); err != nil {
+		return rg, err
+	}
+	buf, err := json.Marshal(resourceGroup{Resources: resources})
+	if err != nil {
+		return rg, err
+	}
+	m := map[string]string{
+		"prefix": "smb apply",
+		"format": "json",
+	}
+	if opts != nil && opts.PasswordFilter != PasswordFilterUnset {
+		m["password_filter"] = string(opts.PasswordFilter)
+	}
+	if opts != nil && opts.PasswordFilterOut != PasswordFilterUnset {
+		m["password_filter_out"] = string(opts.PasswordFilterOut)
+	}
+	c := commands.MarshalMgrCommandWithBuffer(a.conn, m, buf)
+	if err := c.NoStatus().Unmarshal(&rg).End(); err != nil {
+		return rg, err
+	}
+	return rg, nil
+}
+
+// ValidateResources returns an error if any resource in the supplied slice
+// is invalid. It returns nil if all resources are valid. The first invalid
+// resource will be identified and described in the resulting error.
+func ValidateResources(resources []Resource) error {
+	for i, res := range resources {
+		if err := res.Validate(); err != nil {
+			return fmt.Errorf("Resource #%d: %s: %w", i, res.Identity(), err)
+		}
+	}
+	return nil
+}
+
+// errorMerge is a helper function for combining a lower level error from
+// the api with a resultGroup, treating the result group as an error if it
+// is not successful.
+func errorMerge(results ResultGroup, err error) error {
+	if err != nil {
+		return err
+	}
+	if !results.Ok() {
+		return results
+	}
+	return nil
+}
+
+// RemoveCluster will remove a Cluster resource with a matching ID value
+// from the Ceph cluster. This is a convenience function that creates a
+// Cluster resource to remove and then applies it in one step.
+func (a *Admin) RemoveCluster(clusterID string) error {
+	rl := []Resource{NewClusterToRemove(clusterID)}
+	return errorMerge(a.Apply(rl, nil))
+}
+
+// RemoveShare will remove a Share resource with matching ID values from
+// the Ceph cluster. This is a convenience function that creates a Share
+// resource to remove and then applies it in one step.
+func (a *Admin) RemoveShare(clusterID, shareID string) error {
+	rl := []Resource{NewShareToRemove(clusterID, shareID)}
+	return errorMerge(a.Apply(rl, nil))
+}
+
+// RemoveJoinAuth will remove a JoinAuth resource with a matching ID value
+// from the Ceph cluster. This is a convenience function that creates a
+// JoinAuth resource to remove and then applies it in one step.
+func (a *Admin) RemoveJoinAuth(authID string) error {
+	rl := []Resource{NewJoinAuthToRemove(authID)}
+	return errorMerge(a.Apply(rl, nil))
+}
+
+// RemoveUsersAndGroups will remove a UsersAndGroups resource with a matching
+// ID value from the Ceph cluster. This is a convenience function that creates
+// a UsersAndGroups resource to remove and then applies it in one step.
+func (a *Admin) RemoveUsersAndGroups(ugID string) error {
+	rl := []Resource{NewUsersAndGroupsToRemove(ugID)}
+	return errorMerge(a.Apply(rl, nil))
+}

--- a/common/admin/smb/resources_test.go
+++ b/common/admin/smb/resources_test.go
@@ -1,0 +1,274 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var smbSample1 = `
+{
+  "resources": [
+    {
+      "resource_type": "ceph.smb.cluster",
+      "cluster_id": "cluster1",
+      "auth_mode": "active-directory",
+      "domain_settings": {
+        "realm": "DOMAIN1.SINK.TEST",
+        "join_sources": [
+          {"source_type": "resource", "ref": "join1-admin"}
+        ]
+      },
+      "custom_dns": ["192.168.76.210"],
+      "placement": {
+        "count": 1,
+        "label": "ilovesmb"
+      }
+    },
+    {
+      "resource_type": "ceph.smb.join.auth",
+      "cluster_id": "join1-admin",
+      "auth": {
+        "username": "Administrator",
+        "password": "Passw0rd"
+      }
+    },
+    {
+      "resource_type": "ceph.smb.share",
+      "cluster_id": "cluster1",
+      "share_id": "share1",
+      "cephfs": {
+        "volume": "cephfs",
+        "path": "/"
+      }
+    },
+    {
+      "resource_type": "ceph.smb.share",
+      "cluster_id": "cluster1",
+      "share_id": "share2",
+      "name": "Sub Volume",
+      "cephfs": {
+        "volume": "cephfs",
+        "subvolumegroup": "g1",
+        "subvolume": "sv1",
+        "path": "/"
+      }
+    }
+  ]
+}
+`
+
+func TestUnmarshalResources(t *testing.T) {
+	g := new(resourceGroup)
+	b := []byte(smbSample1)
+	assert.NoError(t, json.Unmarshal(b, g))
+	assert.Len(t, g.Resources, 4)
+	_, ok := g.Resources[0].(*Cluster)
+	assert.True(t, ok)
+	_, ok = g.Resources[2].(*Share)
+	assert.True(t, ok)
+	_, ok = g.Resources[3].(*Share)
+	assert.True(t, ok)
+}
+
+var smbSampleBad1 = `
+{
+  "resources": [
+    {
+      "resource_type": "ceph.smb.cluster",
+      "cluster_id": "cluster1",
+      "auth_mode": "active-directory",
+      "domain_settings": {
+        "realm": "DOMAIN1.SINK.TEST",
+        "join_sources": [
+          {"source_type": "resource", "ref": "join1-admin"}
+        ]
+      },
+      "custom_dns": ["192.168.76.210"],
+      "placement": {
+        "count": 1,
+        "label": "ilovesmb"
+      }
+    },
+    {
+      "resource_type": "ceph.smb.fish",
+      "fish_id": "flounder",
+      "size": 100
+    }
+  ]
+}
+`
+
+func TestResourcesUnmarshalError(t *testing.T) {
+	g := resourceGroup{}
+	err := json.Unmarshal([]byte(smbSampleBad1), &g)
+	assert.Error(t, err)
+}
+
+func TestValidateResources(t *testing.T) {
+	good := NewUsersAndGroupsToRemove("bread")
+	bad1 := NewShare("zzz", "nofs")
+	bad2 := &Cluster{}
+
+	t.Run("allGood", func(t *testing.T) {
+		assert.NoError(t, ValidateResources([]Resource{good}))
+	})
+	t.Run("oneBad", func(t *testing.T) {
+		assert.ErrorContains(t, ValidateResources([]Resource{bad1}), "#0")
+	})
+	t.Run("twoBad", func(t *testing.T) {
+		assert.ErrorContains(t, ValidateResources([]Resource{bad1, bad2}), "#0")
+	})
+	t.Run("goodBad", func(t *testing.T) {
+		assert.ErrorContains(t, ValidateResources([]Resource{good, bad2}), "#1")
+	})
+}
+
+func TestResourceRef(t *testing.T) {
+	t.Run("resourceType", func(t *testing.T) {
+		var ref ResourceRef = ClusterType
+		assert.Equal(t, ref.Type(), ClusterType)
+		assert.Equal(t, ref.String(), "ceph.smb.cluster")
+	})
+	t.Run("resourceIDCluster", func(t *testing.T) {
+		var ref ResourceRef = ResourceID{ClusterType, "bob"}
+		assert.Equal(t, ref.Type(), ClusterType)
+		assert.Equal(t, ref.String(), "ceph.smb.cluster.bob")
+	})
+	t.Run("resourceIDShare", func(t *testing.T) {
+		// Create a Share ResourceRef with only one ID - in string form this is
+		// ceph.smb.share.bob (a cluster ID, but no share ID) in the show command
+		// this would match all shares in cluster
+		var ref ResourceRef = ResourceID{ShareType, "bob"}
+		assert.Equal(t, ref.Type(), ShareType)
+		assert.Equal(t, ref.String(), "ceph.smb.share.bob")
+	})
+	t.Run("childResourceID", func(t *testing.T) {
+		// Create a Share ResourceRef with both the cluster and share id values.
+		// This would identify a single share
+		var ref ResourceRef = ChildResourceID{ShareType, "bob", "share1"}
+		assert.Equal(t, ref.Type(), ShareType)
+		assert.Equal(t, ref.String(), "ceph.smb.share.bob.share1")
+	})
+}
+
+func TestRandName(t *testing.T) {
+	t.Run("cluster", func(t *testing.T) {
+		n := randName("cluster")
+		assert.Len(t, n, 15)
+		assert.Contains(t, n, "cluster")
+	})
+	t.Run("c", func(t *testing.T) {
+		n := randName("c")
+		assert.Len(t, n, 9)
+		assert.Contains(t, n, "c")
+	})
+	t.Run("clustersthatmuster", func(t *testing.T) {
+		n := randName("clustersthatmuster")
+		assert.Len(t, n, 18)
+		assert.Contains(t, n, "clustersth")
+	})
+}
+
+func TestErrorMerge(t *testing.T) {
+	var e error
+	results := ResultGroup{
+		Success: true,
+		Results: []*Result{
+			{
+				success:  true,
+				resource: NewClusterToRemove("blat"),
+			},
+		},
+	}
+	assert.NoError(t, errorMerge(results, e))
+
+	results.Results[0].success = false
+	results.Results[0].message = "bad mood"
+	results.Success = false
+	assert.ErrorContains(t, errorMerge(results, e), "bad mood")
+
+	e = fmt.Errorf("bigbad")
+	assert.ErrorContains(t, errorMerge(results, e), "bigbad")
+}
+
+type phoneyConn struct {
+	mgrCommand                func(buf [][]byte) ([]byte, string, error)
+	mgrCommandWithInputBuffer func([][]byte, []byte) ([]byte, string, error)
+	monCommand                func(buf []byte) ([]byte, string, error)
+	monCommandWithInputBuffer func([]byte, []byte) ([]byte, string, error)
+}
+
+func (p *phoneyConn) MgrCommand(buf [][]byte) ([]byte, string, error) {
+	return p.mgrCommand(buf)
+}
+func (p *phoneyConn) MgrCommandWithInputBuffer(cbuf [][]byte, dbuf []byte) ([]byte, string, error) {
+	return p.mgrCommandWithInputBuffer(cbuf, dbuf)
+}
+func (p *phoneyConn) MonCommand(buf []byte) ([]byte, string, error) {
+	return p.monCommand(buf)
+}
+func (p *phoneyConn) MonCommandWithInputBuffer(cbuf []byte, dbuf []byte) ([]byte, string, error) {
+	return p.monCommandWithInputBuffer(cbuf, dbuf)
+}
+
+func TestPhonyApplyError(t *testing.T) {
+	sa := NewFromConn(&phoneyConn{
+		mgrCommandWithInputBuffer: func(_ [][]byte, _ []byte) ([]byte, string, error) {
+			return []byte("ERROR!"), "FAIL", nil
+		},
+	})
+	ja1 := NewJoinAuth("ja1").SetAuth("joiner", "xyz")
+	_, err := sa.Apply([]Resource{ja1}, nil)
+	assert.Error(t, err)
+}
+
+func TestPhonyShowError(t *testing.T) {
+	sa := NewFromConn(&phoneyConn{
+		mgrCommand: func(_ [][]byte) ([]byte, string, error) {
+			return []byte("ERROR!"), "FAIL", nil
+		},
+	})
+	_, err := sa.Show(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestPhonyShowJSONError(t *testing.T) {
+	sa := NewFromConn(&phoneyConn{
+		mgrCommand: func(_ [][]byte) ([]byte, string, error) {
+			r := `
+{"resources: [
+  {
+    "resource_type": "ceph.smb.rubber.duck",
+    "color": "yellow",
+    "squeak": true
+  }
+]}
+`
+			return []byte(r), "", nil
+		},
+	})
+	_, err := sa.Show(nil, nil)
+	assert.Error(t, err)
+}
+
+func TestPhonyShowJSONSingle(t *testing.T) {
+	sa := NewFromConn(&phoneyConn{
+		mgrCommand: func(_ [][]byte) ([]byte, string, error) {
+			r := `
+{
+"resource_type": "ceph.smb.join.auth",
+"auth_id": "adj1",
+"auth": {"username": "bob", "password": "myBIGsecret"}
+}
+`
+			return []byte(r), "", nil
+		},
+	})
+	_, err := sa.Show(nil, nil)
+	assert.NoError(t, err)
+}

--- a/common/admin/smb/result.go
+++ b/common/admin/smb/result.go
@@ -1,0 +1,115 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// resultCommon holds common fields in result JSON.
+type resultCommon struct {
+	Resource resourceEntry `json:"resource"`
+	Message  string        `json:"msg"`
+	Success  bool          `json:"success"`
+	State    string        `json:"state"`
+}
+
+// Result represents the result of applying a new/changed resource.
+type Result struct {
+	resource Resource
+	message  string
+	success  bool
+
+	state  string
+	status map[string]any
+}
+
+// UnmarshalJSON support unmarshalling JSON to a Result.
+func (r *Result) UnmarshalJSON(data []byte) error {
+	rc := &resultCommon{}
+	if err := json.Unmarshal(data, &rc); err != nil {
+		return err
+	}
+	r.resource = rc.Resource.r
+	r.message = rc.Message
+	r.success = rc.Success
+	r.state = rc.State
+	r.status = map[string]any{}
+	// stash extra stuff that may be in the result
+	return json.Unmarshal(data, &r.status)
+}
+
+// Ok returns true if the resource modification was a success.
+func (r *Result) Ok() bool {
+	return r.success
+}
+
+// Resource returns the resource changed.
+func (r *Result) Resource() Resource {
+	return r.resource
+}
+
+// Message returns an optional string describing the modification state.
+func (r *Result) Message() string {
+	return r.message
+}
+
+// Error supports treating a failed result as a Go error.
+func (r *Result) Error() string {
+	if r.success {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", r.resource.Identity(), r.message)
+}
+
+// State returns a short string describing the state of the resource.
+func (r *Result) State() string {
+	return r.state
+}
+
+// Dump additional fields returned with the result.
+func (r *Result) Dump() map[string]any {
+	return r.status
+}
+
+// ResultGroup contains a series of Results and summarizes if a modifcation was
+// a success overall.
+type ResultGroup struct {
+	Success bool      `json:"success"`
+	Results []*Result `json:"results"`
+}
+
+// Ok returns true if all the resource modifications were successful.
+func (rgroup ResultGroup) Ok() bool {
+	return rgroup.Success
+}
+
+// ErrorResults returns a slice of results containing items that were not
+// successful.
+func (rgroup ResultGroup) ErrorResults() []*Result {
+	errs := []*Result{}
+	for _, result := range rgroup.Results {
+		if !result.Ok() {
+			errs = append(errs, result)
+		}
+	}
+	return errs
+}
+
+// Error supports treating a failed ResultGroup as a Go error.
+func (rgroup ResultGroup) Error() string {
+	errs := rgroup.ErrorResults()
+	if len(errs) == 0 {
+		return ""
+	}
+	ec := ""
+	for i, err := range errs {
+		sep := "; "
+		if i == 0 {
+			sep = ""
+		}
+		ec = fmt.Sprintf("%s%s%s", ec, sep, err.Error())
+	}
+	return fmt.Sprintf("%d resource errors: %s", len(errs), ec)
+}

--- a/common/admin/smb/result_test.go
+++ b/common/admin/smb/result_test.go
@@ -1,0 +1,352 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var resultSampleBad1 = `
+{
+  "resource": "nope",
+  "fate": "present",
+  "very": false
+}
+`
+
+func TestResultInvalidJSON(t *testing.T) {
+	result := &Result{}
+	err := json.Unmarshal([]byte(resultSampleBad1), result)
+	assert.Error(t, err)
+}
+
+var resultSample1 = `
+{
+  "resource": {
+    "resource_type": "ceph.smb.share",
+    "cluster_id": "bz1",
+    "share_id": "bt4",
+    "intent": "present",
+    "name": "bt4",
+    "readonly": false,
+    "browseable": true,
+    "cephfs": {
+      "volume": "cephfs",
+      "path": "/",
+      "subvolumegroup": "g1",
+      "subvolume": "t2",
+      "provider": "samba-vfs"
+    }
+  },
+  "state": "present",
+  "success": true
+}
+`
+
+func TestResultUnmarshal(t *testing.T) {
+	result := &Result{}
+	err := json.Unmarshal([]byte(resultSample1), result)
+	assert.NoError(t, err)
+
+	assert.True(t, result.Ok())
+	assert.Equal(t, result.State(), "present")
+	assert.Equal(t, result.Resource().Type(), ShareType)
+	assert.Equal(t, result.Message(), "")
+	assert.Equal(t, result.Error(), "")
+}
+
+var resultSample2 = `
+{
+  "resource": {
+    "resource_type": "ceph.smb.share",
+    "cluster_id": "nevah1",
+    "share_id": "bt4",
+    "intent": "present",
+    "name": "bt4",
+    "readonly": false,
+    "browseable": true,
+    "cephfs": {
+      "volume": "cephfs",
+      "path": "/",
+      "subvolumegroup": "g1",
+      "subvolume": "t2",
+      "provider": "samba-vfs"
+    }
+  },
+  "cluster_id": "nevah1",
+  "msg": "no matching cluster id",
+  "success": false
+}
+`
+
+func TestResultUnmarshal2(t *testing.T) {
+	result := &Result{}
+	err := json.Unmarshal([]byte(resultSample2), result)
+	assert.NoError(t, err)
+
+	assert.False(t, result.Ok())
+	assert.Equal(t, result.State(), "")
+	assert.Equal(t, result.Resource().Type(), ShareType)
+	assert.Equal(t, result.Message(), "no matching cluster id")
+
+	var e error = result
+	assert.ErrorContains(t, e, "no matching")
+	if assert.Contains(t, result.Dump(), "cluster_id") {
+		assert.Equal(t, result.Dump()["cluster_id"], "nevah1")
+	}
+}
+
+var resultGroupSample1 = `
+{
+  "results": [
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "nevah1",
+        "share_id": "bt4",
+        "intent": "present",
+        "name": "bt4",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/",
+          "subvolumegroup": "g1",
+          "subvolume": "t2",
+          "provider": "samba-vfs"
+        }
+      },
+      "cluster_id": "nevah1",
+      "msg": "no matching cluster id",
+      "success": false
+    }
+  ],
+  "success": false
+}
+`
+
+func TestResultGroupUnmashal(t *testing.T) {
+	rgroup := ResultGroup{}
+	err := json.Unmarshal([]byte(resultGroupSample1), &rgroup)
+	assert.NoError(t, err)
+
+	assert.False(t, rgroup.Ok())
+	assert.Len(t, rgroup.Results, 1)
+	assert.Len(t, rgroup.ErrorResults(), 1)
+
+	var e error = rgroup
+	assert.ErrorContains(t, e, "1 resource")
+}
+
+var resultGroupSample2 = `
+{
+  "results": [
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "bz1",
+        "share_id": "bt4",
+        "intent": "present",
+        "name": "bt4",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/",
+          "subvolumegroup": "g1",
+          "subvolume": "t2",
+          "provider": "samba-vfs"
+        }
+      },
+      "state": "present",
+      "success": true
+    }
+  ],
+  "success": true
+}
+`
+
+func TestResultGroupUnmashal2(t *testing.T) {
+	rgroup := ResultGroup{}
+	err := json.Unmarshal([]byte(resultGroupSample2), &rgroup)
+	assert.NoError(t, err)
+
+	assert.True(t, rgroup.Ok())
+	assert.Len(t, rgroup.Results, 1)
+	assert.Len(t, rgroup.ErrorResults(), 0)
+
+	assert.Equal(t, rgroup.Error(), "")
+}
+
+var resultGroupSample3 = `
+{
+  "results": [
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "cluster1",
+        "share_id": "share1",
+        "intent": "present",
+        "name": "Share One",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/",
+          "subvolumegroup": "g1",
+          "subvolume": "sv1",
+          "provider": "samba-vfs"
+        }
+      },
+      "state": "created",
+      "success": true
+    },
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "cluster1",
+        "share_id": "share2",
+        "intent": "present",
+        "name": "Share Two",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/",
+          "subvolumegroup": "g1",
+          "subvolume": "sv2",
+          "provider": "samba-vfs"
+        }
+      },
+      "state": "created",
+      "success": true
+    },
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "cluster1",
+        "share_id": "share3",
+        "intent": "present",
+        "name": "Share Three",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/",
+          "subvolumegroup": "g1",
+          "subvolume": "sv3",
+          "provider": "samba-vfs"
+        }
+      },
+      "state": "created",
+      "success": true
+    }
+  ],
+  "success": true
+}
+`
+
+func TestResultGroupUnmashal3(t *testing.T) {
+	rgroup := ResultGroup{}
+	err := json.Unmarshal([]byte(resultGroupSample3), &rgroup)
+	assert.NoError(t, err)
+
+	assert.True(t, rgroup.Ok())
+	assert.Len(t, rgroup.Results, 3)
+	assert.Len(t, rgroup.ErrorResults(), 0)
+	assert.EqualValues(t,
+		rgroup.Results[0].Resource().Identity().String(),
+		"ceph.smb.share.cluster1.share1")
+	assert.EqualValues(t, rgroup.Results[0].State(), "created")
+
+	assert.Equal(t, rgroup.Error(), "")
+}
+
+var resultGroupSample4 = `
+{
+  "results": [
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "cluster1",
+        "share_id": "share1",
+        "intent": "present",
+        "name": "Share One",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/zim",
+          "subvolumegroup": "g1",
+          "subvolume": "sv1",
+          "provider": "samba-vfs"
+        }
+      },
+      "msg": "path is not a valid directory in volume",
+      "success": false
+    },
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "cluster1",
+        "share_id": "share2",
+        "intent": "present",
+        "name": "Share Two",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/zam",
+          "subvolumegroup": "g1",
+          "subvolume": "sv2",
+          "provider": "samba-vfs"
+        }
+      },
+      "msg": "path is not a valid directory in volume",
+      "success": false
+    },
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "cluster1",
+        "share_id": "share3",
+        "intent": "present",
+        "name": "Share Three",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/",
+          "subvolumegroup": "g1",
+          "subvolume": "sv3",
+          "provider": "samba-vfs"
+        }
+      },
+      "checked": true,
+      "success": true
+    }
+  ],
+  "success": false
+}
+`
+
+func TestResultGroupUnmashal4(t *testing.T) {
+	rgroup := ResultGroup{}
+	err := json.Unmarshal([]byte(resultGroupSample4), &rgroup)
+	assert.NoError(t, err)
+
+	assert.False(t, rgroup.Ok())
+	assert.Len(t, rgroup.Results, 3)
+	assert.Len(t, rgroup.ErrorResults(), 2)
+	tr := rgroup.ErrorResults()[0]
+	assert.EqualValues(t,
+		tr.Resource().Identity().String(),
+		"ceph.smb.share.cluster1.share1")
+	assert.EqualValues(t, tr.State(), "")
+	assert.EqualValues(t, tr.Message(), "path is not a valid directory in volume")
+
+	assert.Contains(t, rgroup.Error(), "2 resource errors:")
+}

--- a/common/admin/smb/share.go
+++ b/common/admin/smb/share.go
@@ -1,0 +1,159 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// CephFSSource defines parameters that connect an SMB Share to a path
+// or subvolume in CephFS.
+type CephFSSource struct {
+	Volume         string         `json:"volume"`
+	SubVolumeGroup string         `json:"subvolumegroup,omitempty"`
+	SubVolume      string         `json:"subvolume,omitempty"`
+	Path           string         `json:"path"`
+	Provider       CephFSProvider `json:"provider,omitempty"`
+}
+
+// ShareAccess defines parameters that control the ability to log in to a share
+// with particular access levels.
+type ShareAccess struct {
+	Name     string         `json:"name"`
+	Category AccessCategory `json:"category"`
+	Access   AccessMode     `json:"access"`
+}
+
+// Validate returns an error describing an issue with the share access object
+// or nil if the object is valid.
+func (sa *ShareAccess) Validate() error {
+	if sa.Name == "" {
+		return fmt.Errorf("missing Name")
+	}
+	switch sa.Category {
+	case "", UserAccess, GroupAccess:
+	default:
+		return fmt.Errorf("invalid Category")
+	}
+	switch sa.Access {
+	case "", ReadAccess, ReadWriteAccess, AdminAccess:
+	default:
+		return fmt.Errorf("invalid Access mode")
+	}
+	return nil
+}
+
+// Share is a resource representing SMB Shares that will be configured on
+// the SMB servers hosted in the Ceph cluster.
+type Share struct {
+	IntentValue    Intent        `json:"intent"`
+	ClusterID      string        `json:"cluster_id"`
+	ShareID        string        `json:"share_id"`
+	Name           string        `json:"name"`
+	ReadOnly       bool          `json:"readonly"`
+	Browseable     bool          `json:"browseable"`
+	CephFS         *CephFSSource `json:"cephfs,omitempty"`
+	RestrictAccess bool          `json:"restrict_access"`
+	LoginControl   []ShareAccess `json:"login_control,omitempty"`
+}
+
+// Type returns a ResourceType value.
+func (*Share) Type() ResourceType {
+	return ShareType
+}
+
+// Intent controls if a resource is to be created/updated or removed.
+func (share *Share) Intent() Intent {
+	return share.IntentValue
+}
+
+// Identity returns a ResourceRef identifying this share resource.
+func (share *Share) Identity() ResourceRef {
+	return ChildResourceID{
+		ResourceType: share.Type(),
+		ParentID:     share.ClusterID,
+		ID:           share.ShareID,
+	}
+}
+
+// MarshalJSON supports marshalling a Share resource to JSON.
+func (share *Share) MarshalJSON() ([]byte, error) {
+	type vShare Share
+	type wShare struct {
+		ResourceType ResourceType `json:"resource_type"`
+		vShare
+	}
+	return json.Marshal(wShare{
+		ResourceType: share.Type(),
+		vShare:       vShare(*share),
+	})
+}
+
+// Validate returns an error describing an issue with the resource or nil if
+// the resource object is valid.
+func (share *Share) Validate() error {
+	var minimal bool
+	switch share.IntentValue {
+	case Present:
+	case Removed:
+		minimal = true
+	default:
+		return fmt.Errorf("missing IntentValue")
+	}
+	if share.ClusterID == "" {
+		return fmt.Errorf("missing ClusterID")
+	}
+	if share.ShareID == "" {
+		return fmt.Errorf("missing ShareID")
+	}
+	if minimal {
+		return nil // minimal checks have been done, return early
+	}
+
+	if share.CephFS == nil {
+		return fmt.Errorf("missing CephFS configuration")
+	}
+	if share.CephFS.Volume == "" {
+		return fmt.Errorf("missing CephFS Volume")
+	}
+	for _, sa := range share.LoginControl {
+		if err := sa.Validate(); err != nil {
+			return fmt.Errorf("invalid LoginControl value: %w", err)
+		}
+	}
+	return nil
+}
+
+// SetCephFS modifies a Share resource's CephFS storage parameters.
+func (share *Share) SetCephFS(
+	volume, subvolumegroup, subvolume, path string) *Share {
+
+	if share.CephFS == nil {
+		share.CephFS = &CephFSSource{}
+	}
+	share.CephFS.Volume = volume
+	share.CephFS.SubVolumeGroup = subvolumegroup
+	share.CephFS.SubVolume = subvolume
+	share.CephFS.Path = path
+	return share
+}
+
+// NewShare returns a new Share resource object with default values.
+func NewShare(clusterID, shareID string) *Share {
+	return &Share{
+		IntentValue: Present,
+		ClusterID:   clusterID,
+		ShareID:     shareID,
+	}
+}
+
+// NewShareToRemove returns a new Share resource object with default values set
+// to remove the share from management.
+func NewShareToRemove(clusterID, shareID string) *Share {
+	return &Share{
+		IntentValue: Removed,
+		ClusterID:   clusterID,
+		ShareID:     shareID,
+	}
+}

--- a/common/admin/smb/share_test.go
+++ b/common/admin/smb/share_test.go
@@ -1,0 +1,89 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShareIdentity(t *testing.T) {
+	share := NewShare("c1", "ss1")
+	assert.Equal(t, share.Type(), ShareType)
+	shid := share.Identity()
+	assert.Equal(t, shid.Type(), ShareType)
+	assert.Equal(t, shid.String(), "ceph.smb.share.c1.ss1")
+	assert.Equal(t, share.Intent(), Present)
+}
+
+func TestShareValidate(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		s := &Share{}
+		assert.ErrorContains(t, s.Validate(), "Intent")
+	})
+	t.Run("missingID", func(t *testing.T) {
+		s := &Share{IntentValue: Present}
+		assert.ErrorContains(t, s.Validate(), "ClusterID")
+	})
+	t.Run("missingID2", func(t *testing.T) {
+		s := &Share{IntentValue: Present, ClusterID: "c1"}
+		assert.ErrorContains(t, s.Validate(), "ShareID")
+	})
+	t.Run("intentRemoved", func(t *testing.T) {
+		s := &Share{IntentValue: Removed, ClusterID: "c1", ShareID: "s1"}
+		assert.NoError(t, s.Validate())
+	})
+
+	// from this point on we're going to progressively add to
+	// s1 until it is valid
+	s1 := &Share{
+		IntentValue: Present,
+		ClusterID:   "c1",
+		ShareID:     "ss1",
+	}
+	t.Run("missingCephFS", func(t *testing.T) {
+		assert.ErrorContains(t, s1.Validate(), "CephFS")
+	})
+	s1.CephFS = &CephFSSource{}
+	t.Run("missingCephFSVolume", func(t *testing.T) {
+		assert.ErrorContains(t, s1.Validate(), "Volume")
+	})
+	s1.CephFS.Volume = "cephfs"
+	t.Run("ok", func(t *testing.T) {
+		assert.NoError(t, s1.Validate())
+	})
+
+	s1.RestrictAccess = true
+	s1.LoginControl = []ShareAccess{{}}
+	t.Run("loginControlName", func(t *testing.T) {
+		assert.ErrorContains(t, s1.Validate(), "Name")
+	})
+	s1.LoginControl = []ShareAccess{{Name: "abc", Category: AccessCategory("x")}}
+	t.Run("loginControlCategory", func(t *testing.T) {
+		assert.ErrorContains(t, s1.Validate(), "Category")
+	})
+	s1.LoginControl = []ShareAccess{{Name: "abc", Access: AccessMode("x")}}
+	t.Run("loginControlAccess", func(t *testing.T) {
+		assert.ErrorContains(t, s1.Validate(), "Access")
+	})
+	s1.LoginControl = []ShareAccess{{Name: "abc"}}
+	t.Run("loginControlOk", func(t *testing.T) {
+		assert.NoError(t, s1.Validate())
+	})
+}
+
+func TestShareMarshalUnmarshal(t *testing.T) {
+	share := NewShare("c1", "ss1").SetCephFS("cephfs", "g1", "v1", "/")
+	j, err := json.Marshal(share)
+	assert.NoError(t, err)
+
+	share2 := &Share{}
+	err = json.Unmarshal(j, share2)
+	assert.NoError(t, err)
+	assert.Equal(t, share.ClusterID, share2.ClusterID)
+	assert.Equal(t, share.ShareID, share2.ShareID)
+	assert.EqualValues(t, share.IntentValue, share2.IntentValue)
+	assert.EqualValues(t, share.CephFS, share2.CephFS)
+}

--- a/common/admin/smb/users_groups.go
+++ b/common/admin/smb/users_groups.go
@@ -1,0 +1,139 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// UserInfo defines a user account managed by an SMB server instance.
+type UserInfo struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}
+
+// GroupInfo defines a group managed by an SMB server instance.
+type GroupInfo struct {
+	Name string `json:"name"`
+}
+
+// UsersAndGroupsValues contains user and group definitions managed by
+// an SMB server instance.
+type UsersAndGroupsValues struct {
+	Users  []UserInfo  `json:"users,omitempty"`
+	Groups []GroupInfo `json:"groups,omitempty"`
+}
+
+// UsersAndGroups is a resource containing user and group definitions that
+// are managed by an SMB server instances that do not use active directory
+// domains.
+type UsersAndGroups struct {
+	IntentValue     Intent                `json:"intent"`
+	UsersGroupsID   string                `json:"users_groups_id"`
+	Values          *UsersAndGroupsValues `json:"values,omitempty"`
+	LinkedToCluster string                `json:"linked_to_cluster,omitempty"`
+}
+
+// Type returns a ResourceType value.
+func (*UsersAndGroups) Type() ResourceType {
+	return UsersAndGroupsType
+}
+
+// Intent controls if a resource is to be created/updated or removed.
+func (ug *UsersAndGroups) Intent() Intent {
+	return ug.IntentValue
+}
+
+// Identity returns a ResourceRef identifying this users and groups resource.
+func (ug *UsersAndGroups) Identity() ResourceRef {
+	return ResourceID{
+		ResourceType: ug.Type(),
+		ID:           ug.UsersGroupsID,
+	}
+}
+
+// Validate returns an error describing an issue with the resource or nil if
+// the resource object is valid.
+func (ug *UsersAndGroups) Validate() error {
+	var minimal bool
+	switch ug.IntentValue {
+	case Present:
+	case Removed:
+		minimal = true
+	default:
+		return fmt.Errorf("missing intent")
+	}
+	if ug.UsersGroupsID == "" {
+		return fmt.Errorf("missing UsersGroupsID")
+	}
+	if minimal {
+		return nil // minimal checks have been done, return early
+	}
+
+	if ug.Values == nil {
+		return fmt.Errorf("missing Values parameter")
+	}
+	if len(ug.Values.Users) < 1 {
+		return fmt.Errorf("no Users defined")
+	}
+	return nil
+}
+
+// MarshalJSON supports marshalling a UsersAndGroups resource to JSON.
+func (ug *UsersAndGroups) MarshalJSON() ([]byte, error) {
+	type vUsersAndGroups UsersAndGroups
+	type wUsersAndGroups struct {
+		ResourceType ResourceType `json:"resource_type"`
+		vUsersAndGroups
+	}
+	return json.Marshal(wUsersAndGroups{
+		ResourceType:    ug.Type(),
+		vUsersAndGroups: vUsersAndGroups(*ug),
+	})
+}
+
+// SetValues modifies a UsersAndGroups resource's users list and groups list.
+func (ug *UsersAndGroups) SetValues(
+	users []UserInfo, groups []GroupInfo) *UsersAndGroups {
+
+	if ug.Values == nil {
+		ug.Values = &UsersAndGroupsValues{}
+	}
+	ug.Values.Users = users
+	ug.Values.Groups = groups
+	return ug
+}
+
+// NewUsersAndGroups returns a new UsersAndGroups resource object with default
+// values.
+func NewUsersAndGroups(ugID string) *UsersAndGroups {
+	return &UsersAndGroups{
+		IntentValue:   Present,
+		UsersGroupsID: ugID,
+		Values:        &UsersAndGroupsValues{},
+	}
+}
+
+// NewLinkedUsersAndGroups returns a new UsersAndGroups resource object with
+// default values that link the resource to a particular cluster. Linked
+// resources can only be used by the cluster they link to and are automatically
+// deleted when the linked cluster is deleted.
+func NewLinkedUsersAndGroups(cluster *Cluster) *UsersAndGroups {
+	ug := NewUsersAndGroups(randName(cluster.ClusterID))
+	ug.LinkedToCluster = cluster.ClusterID
+	cluster.UserGroupSettings = append(
+		cluster.UserGroupSettings,
+		UserGroupSource{SourceType: ResourceSource, Ref: ug.UsersGroupsID},
+	)
+	return ug
+}
+
+// NewUsersAndGroupsToRemove returns a new UsersAndGroups resource object with
+// default values set to remove the users and groups resource from management.
+func NewUsersAndGroupsToRemove(ugID string) *UsersAndGroups {
+	return &UsersAndGroups{
+		IntentValue:   Removed,
+		UsersGroupsID: ugID,
+	}
+}

--- a/common/admin/smb/users_groups_test.go
+++ b/common/admin/smb/users_groups_test.go
@@ -1,0 +1,132 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsersAndGroupsIdentity(t *testing.T) {
+	ug := NewUsersAndGroups("ug1")
+	assert.Equal(t, ug.Type(), UsersAndGroupsType)
+	ugid := ug.Identity()
+	assert.Equal(t, ugid.Type(), UsersAndGroupsType)
+	assert.Equal(t, ugid.String(), "ceph.smb.usersgroups.ug1")
+	assert.Equal(t, ug.Intent(), Present)
+}
+
+func TestUsersAndGroupsValidate(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		ug := &UsersAndGroups{}
+		assert.ErrorContains(t, ug.Validate(), "intent")
+	})
+	t.Run("missingID", func(t *testing.T) {
+		ug := &UsersAndGroups{IntentValue: Present}
+		assert.ErrorContains(t, ug.Validate(), "UsersGroupsID")
+	})
+	t.Run("intentRemoved", func(t *testing.T) {
+		ug := &UsersAndGroups{IntentValue: Removed, UsersGroupsID: "boop"}
+		assert.NoError(t, ug.Validate())
+	})
+
+	// from this point on we're going to progressively add to
+	// ug1 until it is valid
+	ug1 := &UsersAndGroups{
+		IntentValue:   Present,
+		UsersGroupsID: "hugh1",
+	}
+	t.Run("missingUsersAndGroupsValues", func(t *testing.T) {
+		assert.ErrorContains(t, ug1.Validate(), "Values")
+	})
+
+	ug1.Values = &UsersAndGroupsValues{}
+	t.Run("missingUsersSlice", func(t *testing.T) {
+		assert.ErrorContains(t, ug1.Validate(), "Users")
+	})
+
+	ug1.Values.Users = []UserInfo{
+		{Name: "alice", Password: "l3tm31n"},
+		{Name: "bob", Password: "1122334455"},
+	}
+	t.Run("ok", func(t *testing.T) {
+		assert.NoError(t, ug1.Validate())
+	})
+}
+
+func TestUsersAndGroupsNewSetVals(t *testing.T) {
+	ug := NewUsersAndGroups("hug1").SetValues(
+		[]UserInfo{
+			{Name: "alice", Password: "l3tm31n"},
+			{Name: "bob", Password: "1122334455"},
+		},
+		[]GroupInfo{
+			{Name: "itstaff"},
+		},
+	)
+	assert.Equal(t, ug.Intent(), Present)
+	assert.Equal(t, ug.UsersGroupsID, "hug1")
+	assert.Len(t, ug.Values.Users, 2)
+	assert.Len(t, ug.Values.Groups, 1)
+	assert.Equal(t, ug.LinkedToCluster, "")
+}
+
+func TestUsersAndGroupsNewToRemove(t *testing.T) {
+	rc := NewUsersAndGroupsToRemove("nope")
+	assert.Equal(t, rc.Intent(), Removed)
+	assert.Equal(t, rc.UsersGroupsID, "nope")
+}
+
+func TestUsersAndGroupsNewLinked(t *testing.T) {
+	c := NewUserCluster("c1")
+	ug := NewLinkedUsersAndGroups(c).SetValues(
+		[]UserInfo{
+			{Name: "alice", Password: "l3tm31n"},
+			{Name: "bob", Password: "1122334455"},
+		},
+		[]GroupInfo{
+			{Name: "itstaff"},
+		},
+	)
+	assert.NoError(t, ug.Validate())
+	assert.Equal(t, ug.LinkedToCluster, "c1")
+	assert.Len(t, c.UserGroupSettings, 1)
+	assert.Equal(t, c.UserGroupSettings[0].Ref, ug.UsersGroupsID)
+}
+
+func TestUsersAndGroupsMarshalUnmarshal(t *testing.T) {
+	ug := NewUsersAndGroups("ug1").SetValues(
+		[]UserInfo{
+			{Name: "alice", Password: "l3tm31n"},
+			{Name: "bob", Password: "1122334455"},
+		},
+		[]GroupInfo{
+			{Name: "itstaff"},
+		},
+	)
+	j, err := json.Marshal(ug)
+	assert.NoError(t, err)
+	ug2 := &UsersAndGroups{}
+	err = json.Unmarshal(j, ug2)
+	assert.NoError(t, err)
+	assert.Equal(t, ug.UsersGroupsID, ug2.UsersGroupsID)
+	assert.EqualValues(t, ug.Values, ug2.Values)
+}
+
+func TestUsersAndGroupsSetAuth(t *testing.T) {
+	ug := &UsersAndGroups{IntentValue: Present, UsersGroupsID: "abc"}
+	ug.SetValues(
+		[]UserInfo{
+			{Name: "alice", Password: "l3tm31n"},
+			{Name: "bob", Password: "1122334455"},
+		},
+		[]GroupInfo{
+			{Name: "itstaff"},
+		},
+	)
+	assert.NotNil(t, ug.Values)
+	assert.Len(t, ug.Values.Users, 2)
+	assert.Len(t, ug.Values.Groups, 1)
+}

--- a/common/commands/interfaces.go
+++ b/common/commands/interfaces.go
@@ -6,10 +6,22 @@ type MgrCommander interface {
 	MgrCommand(buf [][]byte) ([]byte, string, error)
 }
 
+// MgrBufferCommander is an interface for the API needed to execute JSON
+// formatted commands with an input buffer on the Ceph mgr.
+type MgrBufferCommander interface {
+	MgrCommandWithInputBuffer([][]byte, []byte) ([]byte, string, error)
+}
+
 // MonCommander is an interface for the API needed to execute JSON formatted
 // commands on the ceph mon(s).
 type MonCommander interface {
 	MonCommand(buf []byte) ([]byte, string, error)
+}
+
+// MonBufferCommander is an interface for the API needed to execute JSON
+// formatted commands with an input buffer on the Ceph mon(s).
+type MonBufferCommander interface {
+	MonCommandWithInputBuffer([]byte, []byte) ([]byte, string, error)
 }
 
 // RadosCommander provides an interface for APIs needed to execute JSON
@@ -17,4 +29,12 @@ type MonCommander interface {
 type RadosCommander interface {
 	MgrCommander
 	MonCommander
+}
+
+// RadosBufferCommander provides an interface for APIs that need to execute
+// JSON formatted commands with an input buffer on the Ceph cluster.
+type RadosBufferCommander interface {
+	RadosCommander
+	MgrBufferCommander
+	MonBufferCommander
 }

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2410,5 +2410,375 @@
         "became_stable_version": "v0.31.0"
       }
     ]
+  },
+  "common/admin/smb": {
+    "preview_api": [
+      {
+        "name": "NewFromConn",
+        "comment": "NewFromConn creates an new management object from a preexisting\nrados connection. The existing connection can be rados.Conn or any\ntype implementing the RadosCommander interface.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "SimplePlacement",
+        "comment": "SimplePlacement returns a placement with common placement parameters - count\nand label - specified.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Cluster.Type",
+        "comment": "Type returns a ResourceType value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Cluster.Intent",
+        "comment": "Intent controls if a resource is to be created/updated or removed.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Cluster.Identity",
+        "comment": "Identity returns a ResourceRef identifying this cluster.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Cluster.MarshalJSON",
+        "comment": "MarshalJSON supports marshalling a cluster to JSON.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Cluster.Validate",
+        "comment": "Validate returns an error describing an issue with the resource or\nnil if the resource object is valid.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Cluster.SetPlacement",
+        "comment": "SetPlacement modifies a cluster's placment settings.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewUserCluster",
+        "comment": "NewUserCluster returns a new Cluster with default values set to\ncreate/update a cluster with local users-and-groups defined.\nIn addition to the cluster name, this function accepts zero or more\nID values naming ceph.smb.usersgroups resources.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewActiveDirectoryCluster",
+        "comment": "NewActiveDirectoryCluster returns a new Cluster with default values set to\ncreate/update a cluster with active directory authentication.\nIn addition to the cluster name, this function accepts the name of the\ndomain/realm and zero or more ID values naming ceph.smb.join.auth resources.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewClusterToRemove",
+        "comment": "NewClusterToRemove return a new Cluster with default values set to remove a\ncluster from management.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "JoinAuth.Type",
+        "comment": "Type returns a ResourceType value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "JoinAuth.Intent",
+        "comment": "Intent controls if a resource is to be created/updated or removed.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "JoinAuth.Identity",
+        "comment": "Identity returns a ResourceRef identifying this joinauth resource.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "JoinAuth.Validate",
+        "comment": "Validate returns an error describing an issue with the resource or nil if\nthe resource object is valid.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "JoinAuth.MarshalJSON",
+        "comment": "MarshalJSON supports marshalling a cluster to JSON.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "JoinAuth.SetAuth",
+        "comment": "SetAuth modifies a JoinAuth's authentication values.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewJoinAuth",
+        "comment": "NewJoinAuth returns a new JoinAuth with default values.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewLinkedJoinAuth",
+        "comment": "NewLinkedJoinAuth returns a new JoinAuth with default values that link the\nresource to a particular cluster. Linked resources can only be used by the\ncluster they link to and are automatically deleted when the linked cluster\nis deleted.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewJoinAuthToRemove",
+        "comment": "NewJoinAuthToRemove returns a new JoinAuth with default values set to remove\nthe join auth resource from management.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ResourceType.Type",
+        "comment": "Type returns a ResourceType value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ResourceType.String",
+        "comment": "String returns a string value referring to a resource.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ResourceID.Type",
+        "comment": "Type returns a ResourceType value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ResourceID.String",
+        "comment": "String returns a string value referring to a resource.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ChildResourceID.Type",
+        "comment": "Type returns a ResourceType value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ChildResourceID.String",
+        "comment": "String returns a string value referring to a resource.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.Show",
+        "comment": "Show smb module resource descriptions stored on the Ceph cluster.\nIf any values are provided in the refs slice, the function will query\nonly resources matching those references. These may be all matching\nresources of a type or more specific references with IDs. The opts value\ncan be nil for default behavior or supplied to customize the query results.\nCurrently, ShowOptions can be used to filter password values.\n\nSimilar To:\n\n\tceph smb show\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.Apply",
+        "comment": "Apply changes to the resource descriptions stored on the Ceph cluster.\nSupply one or more Resource objects in the slice and these resources will\nbe created, updated, or removed based on the Resource's parameters.\nAn Intent() of Present will create or update a resource.\nAn Intent() of Removed will remove a matching resource or be a no-op if nothing\nis matched.\nThe opts value can be nil for default behavior or supplied to customize the\nway the command processes inputs and outputs. Currently, the password values\nsupplied in the objects and returned in the result can be filtered depending\non the fields in the ApplyOptions structure.\n\nSimilar To:\n\n\tceph smb apply -i -\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ValidateResources",
+        "comment": "ValidateResources in the supplied slice, returning an error if any\nresource is invalid or nil if all resources are valid. The first invalid resource\nwill be identified and described in the resulting error.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.RemoveCluster",
+        "comment": "RemoveCluster will remove a Cluster resource with a matching ID value\nfrom the Ceph cluster. This is a convenience function that creates a\nCluster resource to remove and then applies it in one step.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.RemoveShare",
+        "comment": "RemoveShare will remove a Share resource with matching ID values from\nthe Ceph cluster. This is a convenience function that creates a Share\nresource to remove and then applies it in one step.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.RemoveJoinAuth",
+        "comment": "RemoveJoinAuth will remove a JoinAuth resource with a matching ID value\nfrom the Ceph cluster. This is a convenience function that creates a\nJoinAuth resource to remove and then applies it in one step.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.RemoveUsersAndGroups",
+        "comment": "RemoveUsersAndGroups will remove a UsersAndGroups resource with a matching\nID value from the Ceph cluster. This is a convenience function that creates\na UsersAndGroups resource to remove and then applies it in one step.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Result.UnmarshalJSON",
+        "comment": "UnmarshalJSON support unmarshalling JSON to a Result.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Result.Ok",
+        "comment": "Ok returns true if the resource modification was a success.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Result.Resource",
+        "comment": "Resource returns the resource changed.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Result.Message",
+        "comment": "Message returns an optional string describing the modification state.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Result.Error",
+        "comment": "Error supports treating a failed result as a Go error.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Result.State",
+        "comment": "State returns a short string describing the state of the resource.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Result.Dump",
+        "comment": "Dump additional fields returned with the result.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ResultGroup.Ok",
+        "comment": "Ok returns true if all the resource modifications were successful.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ResultGroup.ErrorResults",
+        "comment": "ErrorResults returns a slice of results containing items that were not\nsuccessful.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ResultGroup.Error",
+        "comment": "Error supports treating a failed ResultGroup as a Go error.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ShareAccess.Validate",
+        "comment": "Validate returns an error describing an issue with the share access object\nor nil if the object is valid.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Share.Type",
+        "comment": "Type returns a ResourceType value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Share.Intent",
+        "comment": "Intent controls if a resource is to be created/updated or removed.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Share.Identity",
+        "comment": "Identity returns a ResourceRef identifying this share resource.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Share.MarshalJSON",
+        "comment": "MarshalJSON supports marshalling a Share resource to JSON.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Share.Validate",
+        "comment": "Validate returns an error describing an issue with the resource or nil if\nthe resource object is valid.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Share.SetCephFS",
+        "comment": "SetCephFS modifies a Share resource's CephFS storage parameters.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewShare",
+        "comment": "NewShare returns a new Share resource object with default values.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewShareToRemove",
+        "comment": "NewShareToRemove returns a new Share resource object with default values set\nto remove the share from management.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "UsersAndGroups.Type",
+        "comment": "Type returns a ResourceType value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "UsersAndGroups.Intent",
+        "comment": "Intent controls if a resource is to be created/updated or removed.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "UsersAndGroups.Identity",
+        "comment": "Identity returns a ResourceRef identifying this users and groups resource.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "UsersAndGroups.Validate",
+        "comment": "Validate returns an error describing an issue with the resource or nil if\nthe resource object is valid.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "UsersAndGroups.MarshalJSON",
+        "comment": "MarshalJSON supports marshalling a UsersAndGroups resource to JSON.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "UsersAndGroups.SetValues",
+        "comment": "SetValues modifies a UsersAndGroups resource's users list and groups list.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewUsersAndGroups",
+        "comment": "NewUsersAndGroups returns a new UsersAndGroups resource object with default\nvalues.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewLinkedUsersAndGroups",
+        "comment": "NewLinkedUsersAndGroups returns a new UsersAndGroups resource object with\ndefault values that link the resource to a particular cluster. Linked\nresources can only be used by the cluster they link to and are automatically\ndeleted when the linked cluster is deleted.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewUsersAndGroupsToRemove",
+        "comment": "NewUsersAndGroupsToRemove returns a new UsersAndGroups resource object with\ndefault values set to remove the users and groups resource from management.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ]
   }
 }

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -69,3 +69,71 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 No Preview/Deprecated APIs found. All APIs are considered stable.
 
+## Package: common/admin/smb
+
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+NewFromConn | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+SimplePlacement | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Cluster.Type | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Cluster.Intent | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Cluster.Identity | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Cluster.MarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Cluster.Validate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Cluster.SetPlacement | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewUserCluster | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewActiveDirectoryCluster | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewClusterToRemove | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+JoinAuth.Type | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+JoinAuth.Intent | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+JoinAuth.Identity | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+JoinAuth.Validate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+JoinAuth.MarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+JoinAuth.SetAuth | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewJoinAuth | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewLinkedJoinAuth | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewJoinAuthToRemove | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ResourceType.Type | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ResourceType.String | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ResourceID.Type | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ResourceID.String | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ChildResourceID.Type | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ChildResourceID.String | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.Show | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.Apply | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ValidateResources | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.RemoveCluster | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.RemoveShare | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.RemoveJoinAuth | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.RemoveUsersAndGroups | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Result.UnmarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Result.Ok | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Result.Resource | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Result.Message | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Result.Error | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Result.State | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Result.Dump | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ResultGroup.Ok | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ResultGroup.ErrorResults | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ResultGroup.Error | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ShareAccess.Validate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Share.Type | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Share.Intent | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Share.Identity | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Share.MarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Share.Validate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Share.SetCephFS | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewShare | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewShareToRemove | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+UsersAndGroups.Type | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+UsersAndGroups.Intent | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+UsersAndGroups.Identity | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+UsersAndGroups.Validate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+UsersAndGroups.MarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+UsersAndGroups.SetValues | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewUsersAndGroups | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewLinkedUsersAndGroups | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewUsersAndGroupsToRemove | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+

--- a/internal/admintest/admintest.go
+++ b/internal/admintest/admintest.go
@@ -62,8 +62,8 @@ func NewConnFromConfig(t *testing.T, configFile string) *rados.Conn {
 
 // WrapConn wraps the given conn in as a "tracer" if so enabled in the
 // environment.
-func WrapConn(conn *rados.Conn) ccom.RadosCommander {
-	var c ccom.RadosCommander = conn
+func WrapConn(conn *rados.Conn) ccom.RadosBufferCommander {
+	var c ccom.RadosBufferCommander = conn
 	if DebugTraceEnabled() {
 		c = commands.NewTraceCommander(conn)
 	}
@@ -100,7 +100,7 @@ func (c *Connector) GetConn(t *testing.T) *rados.Conn {
 
 // Get returns a RadosCommander that may or may not be wrapped.
 // Typically this is the one you want.
-func (c *Connector) Get(t *testing.T) ccom.RadosCommander {
+func (c *Connector) Get(t *testing.T) ccom.RadosBufferCommander {
 	conn := WrapConn(c.realConn(t))
 	// We sleep briefly before returning in order to ensure we have a mgr map
 	// before we start executing the tests.

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -51,3 +51,41 @@ func MarshalMonCommand(m ccom.MonCommander, v interface{}) Response {
 	}
 	return RawMonCommand(m, b)
 }
+
+// MarshalMgrCommandWithBuffer takes a generic interface{} value, converts
+// it to JSON and sends the JSON, along with the buffer data, to the MGR as
+// a command.
+func MarshalMgrCommandWithBuffer(
+	m ccom.MgrBufferCommander, v interface{}, buf []byte) Response {
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return Response{err: err}
+	}
+	if err := validate(m); err != nil {
+		return Response{err: err}
+	}
+	return NewResponse(m.MgrCommandWithInputBuffer(
+		[][]byte{b},
+		buf,
+	))
+}
+
+// MarshalMonCommandWithBuffer takes a generic interface{} value, converts
+// it to JSON and sends the JSON, along with the buffer data, to the MON(s)
+// as a command.
+func MarshalMonCommandWithBuffer(
+	m ccom.MonBufferCommander, v interface{}, buf []byte) Response {
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return Response{err: err}
+	}
+	if err := validate(m); err != nil {
+		return Response{err: err}
+	}
+	return NewResponse(m.MonCommandWithInputBuffer(
+		b,
+		buf,
+	))
+}

--- a/internal/commands/trace.go
+++ b/internal/commands/trace.go
@@ -9,7 +9,7 @@ import (
 // NewTraceCommander is a RadosCommander that wraps a given RadosCommander
 // and when commands are executes prints debug level "traces" to the
 // standard output.
-func NewTraceCommander(c ccom.RadosCommander) ccom.RadosCommander {
+func NewTraceCommander(c ccom.RadosBufferCommander) ccom.RadosBufferCommander {
 	return &tracingCommander{c}
 }
 
@@ -19,7 +19,7 @@ func NewTraceCommander(c ccom.RadosCommander) ccom.RadosCommander {
 // interface in FSAdmin. You can layer any sort of debugging, error injection,
 // or whatnot between the FSAdmin layer and the RADOS layer.
 type tracingCommander struct {
-	conn ccom.RadosCommander
+	conn ccom.RadosBufferCommander
 }
 
 func (t *tracingCommander) MgrCommand(buf [][]byte) ([]byte, string, error) {
@@ -42,6 +42,42 @@ func (t *tracingCommander) MonCommand(buf []byte) ([]byte, string, error) {
 	fmt.Println("(MON Command)")
 	fmt.Println("IN:", string(buf))
 	r, s, err := t.conn.MonCommand(buf)
+	fmt.Println("OUT(result):", string(r))
+	if s != "" {
+		fmt.Println("OUT(status):", s)
+	}
+	if err != nil {
+		fmt.Println("OUT(error):", err.Error())
+	}
+	return r, s, err
+}
+
+func (t *tracingCommander) MgrCommandWithInputBuffer(
+	cbuf [][]byte, dbuf []byte) ([]byte, string, error) {
+
+	fmt.Println("(MGR Command w/buffer)")
+	for i := range cbuf {
+		fmt.Println("IN:", string(cbuf[i]))
+	}
+	fmt.Println("IN DATA:", string(dbuf))
+	r, s, err := t.conn.MgrCommandWithInputBuffer(cbuf, dbuf)
+	fmt.Println("OUT(result):", string(r))
+	if s != "" {
+		fmt.Println("OUT(status):", s)
+	}
+	if err != nil {
+		fmt.Println("OUT(error):", err.Error())
+	}
+	return r, s, err
+}
+
+func (t *tracingCommander) MonCommandWithInputBuffer(
+	cbuf []byte, dbuf []byte) ([]byte, string, error) {
+
+	fmt.Println("(MON Command w/buffer)")
+	fmt.Println("IN:", string(cbuf))
+	fmt.Println("IN DATA:", string(dbuf))
+	r, s, err := t.conn.MonCommandWithInputBuffer(cbuf, dbuf)
 	fmt.Println("OUT(result):", string(r))
 	if s != "" {
 		fmt.Println("OUT(status):", s)


### PR DESCRIPTION
Add a new smb admin api.
This should be compatible with the recently added [smb mgr module](https://docs.ceph.com/en/latest/mgr/smb/) in ceph.

Note that the smb module on the ceph side supports a declarative style api where resource specs are the full power interface to use. There are some imperative style apis but we don't need to implement those in this library.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
