### PR TITLE
rgw/admin: fix op-mask url parameter

### DIFF
--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -18,7 +18,7 @@ type User struct {
 	Keys                []UserKeySpec  `json:"keys"`
 	SwiftKeys           []SwiftKeySpec `json:"swift_keys" url:"-"`
 	Caps                []UserCapSpec  `json:"caps"`
-	OpMask              string         `json:"op_mask"`
+	OpMask              string         `json:"op_mask" url:"op-mask"`
 	DefaultPlacement    string         `json:"default_placement"`
 	DefaultStorageClass string         `json:"default_storage_class"`
 	PlacementTags       []interface{}  `json:"placement_tags"`

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -107,7 +107,7 @@ func (suite *RadosGWTestSuite) TestUser() {
 
 	suite.T().Run("user creation success", func(_ *testing.T) {
 		usercaps := "users=read"
-		user, err := co.CreateUser(context.Background(), User{ID: "leseb", DisplayName: "This is leseb", Email: "leseb@example.com", UserCaps: usercaps})
+		user, err := co.CreateUser(context.Background(), User{ID: "leseb", DisplayName: "This is leseb", Email: "leseb@example.com", UserCaps: usercaps, OpMask: "delete"})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@example.com", user.Email)
 	})
@@ -118,6 +118,7 @@ func (suite *RadosGWTestSuite) TestUser() {
 		assert.Equal(suite.T(), "leseb@example.com", user.Email)
 		assert.Equal(suite.T(), "users", user.Caps[0].Type)
 		assert.Equal(suite.T(), "read", user.Caps[0].Perm)
+		assert.Equal(suite.T(), "delete", user.OpMask)
 		os.Setenv("LESEB_ACCESS_KEY", user.Keys[0].AccessKey)
 	})
 


### PR DESCRIPTION
The op-mask was not correctly transmitted when creating a user.

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
