### PR TITLE
rgw/admin: Fix version check for return code

### DIFF
--- a/rgw/admin/bucket_test.go
+++ b/rgw/admin/bucket_test.go
@@ -137,10 +137,10 @@ func (suite *RadosGWTestSuite) TestBucket() {
 	suite.T().Run("remove non-existing bucket", func(_ *testing.T) {
 		err := co.RemoveBucket(context.Background(), Bucket{Bucket: "foo"})
 		assert.Error(suite.T(), err)
-		if util.CurrentCephVersion() <= util.CephOctopus {
-			assert.True(suite.T(), errors.Is(err, ErrNoSuchKey))
-		} else {
+		if util.CurrentCephVersion() >= util.CephPacific && util.CurrentCephVersion() <= util.CephSquid {
 			assert.True(suite.T(), errors.Is(err, ErrNoSuchBucket))
+		} else {
+			assert.True(suite.T(), errors.Is(err, ErrNoSuchKey))
 		}
 	})
 }


### PR DESCRIPTION
The error code returned while trying to remove a non existing bucket changed from `NoSuchBucket` to `NoSuchKey` with tentacle.

fixes #1107 