### PR TITLE
Revert "rgw/admin: Fix version check for return code"

### DIFF
--- a/rgw/admin/bucket_test.go
+++ b/rgw/admin/bucket_test.go
@@ -137,10 +137,10 @@ func (suite *RadosGWTestSuite) TestBucket() {
 	suite.T().Run("remove non-existing bucket", func(_ *testing.T) {
 		err := co.RemoveBucket(context.Background(), Bucket{Bucket: "foo"})
 		assert.Error(suite.T(), err)
-		if util.CurrentCephVersion() >= util.CephPacific && util.CurrentCephVersion() <= util.CephSquid {
-			assert.True(suite.T(), errors.Is(err, ErrNoSuchBucket))
-		} else {
+		if util.CurrentCephVersion() <= util.CephOctopus {
 			assert.True(suite.T(), errors.Is(err, ErrNoSuchKey))
+		} else {
+			assert.True(suite.T(), errors.Is(err, ErrNoSuchBucket))
 		}
 	})
 }


### PR DESCRIPTION
This reverts commit 39e5ac04dc433bae6c2557e0a8421e8eb6b50072.

The regression itself is getting [fixed](https://tracker.ceph.com/issues/71159) from Ceph side. Therefore the earlier version adjustments won't be required anymore.