### PR TITLE
workflows: Use `gh` command line to create issues

### DIFF
--- a/.github/workflows/report-stable.yml
+++ b/.github/workflows/report-stable.yml
@@ -25,13 +25,8 @@ jobs:
           _results/
         retention-days: 30
       if: "!cancelled()"
-    #### Disabled action ####
-    # - name: File Issue
-    #  uses: JasonEtco/create-an-issue@v2
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #  with:
-    #    filename: _results/issue.md
-    #    update_existing: true
-    - name: Please file an issue
-      run: echo "Dear Human, Please file an issue with the following template"; cat _results/issue.md
+    - name: File a GitHub Issue
+      run: gh issue create --title "$(cat _results/title.txt)" --body-file _results/body.md
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}

--- a/Makefile
+++ b/Makefile
@@ -327,8 +327,7 @@ api-report-updates: api-check-updates
 api-report-issuetemplate: api-check-updates
 	./contrib/apiage.py --mode=updates-to-issuetemplate \
 		--current-tag="$$(git describe --tags --abbrev=0)" \
-		< $(RESULTS_DIR)/updates-found.json \
-		> $(RESULTS_DIR)/issue.md
+		< $(RESULTS_DIR)/updates-found.json
 
 ifeq ($(RESULTS_DIR),)
 IMPLEMENTS_DIR:=$(PWD)/_results

--- a/contrib/apiage.py
+++ b/contrib/apiage.py
@@ -287,13 +287,7 @@ def format_markdown(tracked, outfh):
             print("", file=outfh)
 
 
-def format_updates_markdown(updates, outfh, issuetemplate=False, next_ver=""):
-    if issuetemplate:
-        print("---", file=outfh)
-        print(
-            f"title: APIs pending stability updates in {next_ver}", file=outfh
-        )
-        print("---", file=outfh)
+def format_updates_markdown(updates, outfh, issuetemplate=False):
     print("## Preview APIs due to become stable", file=outfh)
     if not updates.get("preview"):
         print("n/a", file=outfh)
@@ -569,13 +563,14 @@ def main():
         updates_needed = json.load(sys.stdin)
         format_updates_markdown(updates_needed, sys.stdout)
     elif cli.mode == "updates-to-issuetemplate":
-        updates_needed = json.load(sys.stdin)
-        format_updates_markdown(
-            updates_needed,
-            sys.stdout,
-            issuetemplate=True,
-            next_ver=cli.added_in_version,
-        )
+        with open("./_results/title.txt", "w") as fh:
+            print(
+                f"APIs pending stability updates in {cli.added_in_version}",
+                file=fh,
+            )
+        with open("./_results/body.md", "w") as fh:
+            updates_needed = json.load(sys.stdin)
+            format_updates_markdown(updates_needed, fh, issuetemplate=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With the third party github actions disabled we directly make use of `gh` command line to create a bare minimum GitHub issue for any API updates to be performed in the next upcoming release.