### PR TITLE
ci: fix meaningless package name check

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,5 +1,7 @@
+//revive:disable:var-naming Package name is intended
 package util
 
+//revive:enable:var-naming
 import "os"
 
 // CephVersion type


### PR DESCRIPTION
bypass var-naming check which now includes meaningless package name check for "util" package

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
