### PR TITLE
cephfs: Use wrappers to handle the ABI changes with chown APIs

### DIFF
--- a/cephfs/file.go
+++ b/cephfs/file.go
@@ -7,6 +7,10 @@ package cephfs
 #include <stdlib.h>
 #include <fcntl.h>
 #include <cephfs/libcephfs.h>
+
+int _go_ceph_fchown(struct ceph_mount_info *cmount, int fd, uid_t uid, gid_t gid) {
+	return ceph_fchown(cmount, fd, uid, gid);
+}
 */
 import "C"
 
@@ -278,13 +282,13 @@ func (f *File) Fchmod(mode uint32) error {
 //
 // Implements:
 //
-//	int ceph_fchown(struct ceph_mount_info *cmount, int fd, int uid, int gid);
+//	int ceph_fchown(struct ceph_mount_info *cmount, int fd, uid_t uid, gid_t gid);
 func (f *File) Fchown(user uint32, group uint32) error {
 	if err := f.validate(); err != nil {
 		return err
 	}
 
-	ret := C.ceph_fchown(f.mount.mount, f.fd, C.int(user), C.int(group))
+	ret := C._go_ceph_fchown(f.mount.mount, f.fd, C.uid_t(user), C.gid_t(group))
 	return getError(ret)
 }
 

--- a/cephfs/file_test.go
+++ b/cephfs/file_test.go
@@ -402,16 +402,16 @@ func TestFchown(t *testing.T) {
 
 	sx, err := mount.Statx(fname, StatxBasicStats, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(sx.Uid), root)
-	assert.Equal(t, uint32(sx.Gid), root)
+	assert.Equal(t, sx.Uid, root)
+	assert.Equal(t, sx.Gid, root)
 
 	err = f1.Fchown(bob, bob)
 	assert.NoError(t, err)
 
 	sx, err = mount.Statx(fname, StatxBasicStats, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(sx.Uid), bob)
-	assert.Equal(t, uint32(sx.Gid), bob)
+	assert.Equal(t, sx.Uid, bob)
+	assert.Equal(t, sx.Gid, bob)
 
 	// TODO use t.Run sub-tests where appropriate
 	f2 := &File{}

--- a/cephfs/permissions.go
+++ b/cephfs/permissions.go
@@ -5,6 +5,14 @@ package cephfs
 #cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
 #include <stdlib.h>
 #include <cephfs/libcephfs.h>
+
+int _go_ceph_chown(struct ceph_mount_info *cmount, const char *path, uid_t uid, gid_t gid) {
+	return ceph_chown(cmount, path, uid, gid);
+}
+
+int _go_ceph_lchown(struct ceph_mount_info *cmount, const char *path, uid_t uid, gid_t gid) {
+	return ceph_lchown(cmount, path, uid, gid);
+}
 */
 import "C"
 
@@ -26,7 +34,7 @@ func (mount *MountInfo) Chown(path string, user uint32, group uint32) error {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_chown(mount.mount, cPath, C.int(user), C.int(group))
+	ret := C._go_ceph_chown(mount.mount, cPath, C.uid_t(user), C.gid_t(group))
 	return getError(ret)
 }
 
@@ -35,6 +43,6 @@ func (mount *MountInfo) Lchown(path string, user uint32, group uint32) error {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
 
-	ret := C.ceph_lchown(mount.mount, cPath, C.int(user), C.int(group))
+	ret := C._go_ceph_lchown(mount.mount, cPath, C.uid_t(user), C.gid_t(group))
 	return getError(ret)
 }

--- a/cephfs/permissions_test.go
+++ b/cephfs/permissions_test.go
@@ -53,16 +53,16 @@ func TestChown(t *testing.T) {
 	sx, err := mount.Statx(dirname, StatxBasicStats, 0)
 	require.NoError(t, err)
 
-	assert.Equal(t, uint32(sx.Uid), root)
-	assert.Equal(t, uint32(sx.Gid), root)
+	assert.Equal(t, sx.Uid, root)
+	assert.Equal(t, sx.Gid, root)
 
 	err = mount.Chown(dirname, bob, bob)
 	assert.NoError(t, err)
 
 	sx, err = mount.Statx(dirname, StatxBasicStats, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(sx.Uid), bob)
-	assert.Equal(t, uint32(sx.Gid), bob)
+	assert.Equal(t, sx.Uid, bob)
+	assert.Equal(t, sx.Gid, bob)
 }
 
 func TestLchown(t *testing.T) {
@@ -87,9 +87,9 @@ func TestLchown(t *testing.T) {
 	err = mount.Lchown("symlnk", bob, bob)
 	sx, err := mount.Statx("symlnk", StatxBasicStats, AtSymlinkNofollow)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(sx.Uid), bob)
-	assert.Equal(t, uint32(sx.Gid), bob)
+	assert.Equal(t, sx.Uid, bob)
+	assert.Equal(t, sx.Gid, bob)
 	sx, err = mount.Statx(dirname, StatxBasicStats, AtSymlinkNofollow)
-	assert.Equal(t, uint32(sx.Uid), root)
-	assert.Equal(t, uint32(sx.Gid), root)
+	assert.Equal(t, sx.Uid, root)
+	assert.Equal(t, sx.Gid, root)
 }


### PR DESCRIPTION
Create backward compatible wrappers to cope with the change in ABI for chown family of APIs counting on the implicit type conversion from C.

fixes #1119 