### PR TITLE
admin/smb: fix test that was stil using errorMerge

### DIFF
--- a/common/admin/smb/resources_test.go
+++ b/common/admin/smb/resources_test.go
@@ -185,15 +185,15 @@ func TestErrorMerge(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(t, errorMerge(results, e))
+	assert.NoError(t, errorPick(results, e))
 
 	results.Results[0].success = false
 	results.Results[0].message = "bad mood"
 	results.Success = false
-	assert.ErrorContains(t, errorMerge(results, e), "bad mood")
+	assert.ErrorContains(t, errorPick(results, e), "bad mood")
 
 	e = fmt.Errorf("bigbad")
-	assert.ErrorContains(t, errorMerge(results, e), "bigbad")
+	assert.ErrorContains(t, errorPick(results, e), "bigbad")
 }
 
 type phoneyConn struct {


### PR DESCRIPTION
We renamed errorMerge to errorPick  but other test failures on main caused me to miss this problem in a prior PR.


## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
