### PR TITLE
ci: have Dependabot update the contrib/implements dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,15 @@ updates:
       - "no-API"
     commit-message:
       prefix: "go-ceph"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/implements"
+    schedule:
+      interval: "monthly"
+    rebase-strategy: "disabled"
+    labels:
+      - "no-API"
+    commit-message:
+      prefix: "contrib"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Security checkers complain that the dependencies of the implements tool are outdated and contain vulnerabilities. The tool is only used to generate metadata, and not part of any application that vendors go-ceph. Updating the dependencies is not urgent, but definitely nice to do.