### PR TITLE
ci: update AWS SDK dependencies in a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       - "no-API"
     commit-message:
       prefix: "go-ceph"
+    groups:
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-*"
   - package-ecosystem: "gomod"
     directory: "/contrib/implements"
     schedule:


### PR DESCRIPTION
Use grouping with Dependabot to combine all github.com/aws/aws-sdk dependencies in one PR.
