### PR TITLE
contrib/apicompare: Fix bits interface macro definition for CephFS

### DIFF
--- a/contrib/apicompare.py
+++ b/contrib/apicompare.py
@@ -43,7 +43,7 @@ GNDN int foo(int x) {
 """
 
 CEPHFS_C = """
-#define FILE_OFFSET_BITS 64
+#define _FILE_OFFSET_BITS 64
 #include <stdlib.h>
 #define __USE_FILE_OFFSET64
 #include <cephfs/libcephfs.h>

--- a/contrib/apicompare.py
+++ b/contrib/apicompare.py
@@ -45,7 +45,6 @@ GNDN int foo(int x) {
 CEPHFS_C = """
 #define _FILE_OFFSET_BITS 64
 #include <stdlib.h>
-#define __USE_FILE_OFFSET64
 #include <cephfs/libcephfs.h>
 
 #define GNDN


### PR DESCRIPTION
Fix typo and avoid duplicate definition to achieve 64 bits file system interface.