### PR TITLE
github: try to fix mergify error

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -65,3 +65,6 @@ pull_request_rules:
           This pull request now has conflicts with the target branch.
           Could you please resolve conflicts and force push the corrected
           changes? 🙏
+
+merge_queue:
+  max_parallel_checks: 1


### PR DESCRIPTION
Mergify won't merge our PRs automatically any more and displays the following, confusing error:
```
The branch protection setting Require branches to be up to date before
merging is not compatible with max_parallel_checks>1, queue_conditions
!= merge_conditions and must be unset.
```
This change tries to see if just forcing max_parallel_checks to be 1 resolves the problem.

