### PR TITLE
github: Remove unwanted target from pull request branch filter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches:
       - master
-      # run the CI also on PRs that are based on branches starting with pr/...
-      - 'pr/**'
   schedule:
     - cron: 1 1 * * *
   workflow_dispatch:


### PR DESCRIPTION
As per the [documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#running-your-pull_request-workflow-based-on-the-head-or-base-branch-of-a-pull-request), the list of branches for pull_request event are expected to be target branches for the pull request (and not source branches). Thus it doesn't make sense to have a custom target branch as changes from pull requests are always created against master unless we have to run CI on specific release branches which are non-existent.
