### PR TITLE
admin/osd: Create a new OSD admin package to add blocklisting APIs

### DIFF
--- a/common/admin/osd/admin.go
+++ b/common/admin/osd/admin.go
@@ -1,0 +1,24 @@
+//go:build ceph_preview
+
+package osd
+
+import (
+	ccom "github.com/ceph/go-ceph/common/commands"
+)
+
+// Commander interface supports sending commands to Ceph.
+type Commander interface {
+	ccom.RadosCommander
+}
+
+// Admin is used to administer Ceph OSDs.
+type Admin struct {
+	conn Commander
+}
+
+// NewFromConn creates an new management object from a preexisting
+// rados connection. The existing connection can be rados.Conn or any
+// type implementing the RadosCommander interface.
+func NewFromConn(conn Commander) *Admin {
+	return &Admin{conn}
+}

--- a/common/admin/osd/admin.go
+++ b/common/admin/osd/admin.go
@@ -4,6 +4,7 @@ package osd
 
 import (
 	ccom "github.com/ceph/go-ceph/common/commands"
+	"github.com/ceph/go-ceph/internal/commands"
 )
 
 // Commander interface supports sending commands to Ceph.
@@ -22,3 +23,5 @@ type Admin struct {
 func NewFromConn(conn Commander) *Admin {
 	return &Admin{conn}
 }
+
+type response = commands.Response

--- a/common/admin/osd/admin_test.go
+++ b/common/admin/osd/admin_test.go
@@ -1,0 +1,40 @@
+//go:build ceph_preview
+
+package osd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	tsuite "github.com/stretchr/testify/suite"
+
+	"github.com/ceph/go-ceph/internal/admintest"
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+func TestOSDAdmin(t *testing.T) {
+	tsuite.Run(t, new(OSDAdminSuite))
+}
+
+// OSDAdminSuite is a suite of tests for the osd admin package.
+type OSDAdminSuite struct {
+	tsuite.Suite
+
+	vconn *admintest.Connector
+}
+
+func (suite *OSDAdminSuite) SetupSuite() {
+	suite.vconn = admintest.NewConnector()
+}
+
+func (suite *OSDAdminSuite) TestOSDList() {
+	cmd := map[string]string{"prefix": "osd ls", "format": "json"}
+
+	buf := commands.MarshalMonCommand(suite.vconn.Get(suite.T()), cmd)
+	assert.NoError(suite.T(), buf.End())
+
+	resp := make([]int, 0)
+	assert.NoError(suite.T(), buf.Unmarshal(&resp).End())
+	assert.Equal(suite.T(), 1, len(resp))
+	assert.EqualValues(suite.T(), 0, resp[0])
+}

--- a/common/admin/osd/doc.go
+++ b/common/admin/osd/doc.go
@@ -1,0 +1,5 @@
+/*
+Package osd from common/admin contains set of APIs to manage OSD configuration
+and administration.
+*/
+package osd

--- a/common/admin/osd/errors.go
+++ b/common/admin/osd/errors.go
@@ -1,0 +1,35 @@
+//go:build ceph_preview
+
+package osd
+
+/*
+#include <errno.h>
+*/
+import "C"
+
+import (
+	"errors"
+
+	"github.com/ceph/go-ceph/internal/errutil"
+)
+
+var (
+	// ErrEmptyArgument may be returned if argument is empty.
+	ErrEmptyArgument = errors.New("Argument must contain at least one item")
+	// ErrInvalidArgument may be returned if argument is invalid.
+	ErrInvalidArgument = getError(-C.EINVAL)
+)
+
+func getError(errno C.int) error {
+	return errutil.GetError("osd", int(errno))
+}
+
+// getErrorIfNegative converts a ceph return code to error if negative.
+// This is useful for functions that return a usable positive value on
+// success but a negative error number on error.
+func getErrorIfNegative(ret C.int) error {
+	if ret >= 0 {
+		return nil
+	}
+	return getError(ret)
+}

--- a/common/admin/osd/osd_blocklist.go
+++ b/common/admin/osd/osd_blocklist.go
@@ -1,0 +1,187 @@
+//go:build !octopus && ceph_preview
+
+package osd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+type ipList struct {
+	IPAddr string `json:"addr"`
+	Until  string `json:"until"`
+}
+
+type networkList struct {
+	Network string `json:"range"`
+	Until   string `json:"until"`
+}
+
+// Blocklist contains the address and expire value for a blocklist entry.
+type Blocklist struct {
+	Addr  string
+	Until string
+}
+
+func parseBlocklist(res response) (*[]Blocklist, error) {
+	var bl []Blocklist
+
+	dec := json.NewDecoder(bytes.NewReader(res.Body()))
+
+	for idx := 0; dec.More(); idx++ {
+		switch idx {
+		case 0:
+			var ip []ipList
+			err := dec.Decode(&ip)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, i := range ip {
+				bl = append(bl, Blocklist{
+					Addr:  i.IPAddr,
+					Until: i.Until,
+				})
+			}
+		case 1:
+			var nw []networkList
+			err := dec.Decode(&nw)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, n := range nw {
+				bl = append(bl, Blocklist{
+					Addr:  n.Network,
+					Until: n.Until,
+				})
+			}
+		default:
+			return nil, ErrInvalidArgument
+		}
+	}
+
+	return &bl, nil
+}
+
+// OSDBlocklist returns the list of blocklisted clients.
+//
+// Similar To:
+//
+//	ceph osd blocklist ls
+func (osda *Admin) OSDBlocklist() (*[]Blocklist, error) {
+	cmd := map[string]string{
+		"prefix": "osd blocklist ls",
+		"format": "json",
+	}
+
+	res := commands.MarshalMonCommand(osda.conn, cmd)
+	if !res.Ok() {
+		return nil, res.End()
+	}
+
+	return parseBlocklist(res)
+}
+
+// AddressEntry contains the ip or network address string along with the
+// optional expire value in seconds.
+type AddressEntry struct {
+	Addr   string
+	Expire float64
+}
+
+func isValidIP(addr string) bool {
+	if ip := net.ParseIP(addr); ip != nil {
+		return true
+	}
+
+	return false
+}
+
+func isValidCIDR(addr string) bool {
+	if _, _, err := net.ParseCIDR(addr); err == nil {
+		return true
+	}
+
+	return false
+}
+
+func blocklistOpCmd(addr string, op string) (map[string]any, error) {
+	m := map[string]any{"prefix": "osd blocklist",
+		"blocklistop": op,
+		"addr":        addr,
+	}
+
+	if !isValidIP(addr) {
+		if !isValidCIDR(addr) {
+			return nil, ErrInvalidArgument
+		}
+		m["range"] = "range"
+	}
+
+	return m, nil
+}
+
+// float is a custom type that implements the MarshalJSON interface. This is
+// used to format float64 values to one decimal place. By default these get
+// converted to integers in the JSON output and fail the command.
+type float float64
+
+// MarshalJSON is a custom implementation for the JSON marshaling of float.
+func (f float) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%.1f", float64(f))), nil
+}
+
+// OSDBlocklistAdd adds an ip address or network address in CIDR format to the
+// blocklist.
+//
+// Similar To:
+//
+//	ceph osd blocklist [range] add <ip_addr|cidr_network> [expire]
+func (osda *Admin) OSDBlocklistAdd(entry AddressEntry) error {
+	if entry.Addr == "" {
+		return ErrEmptyArgument
+	}
+
+	cmd, err := blocklistOpCmd(entry.Addr, "add")
+	if err != nil {
+		return err
+	}
+
+	if entry.Expire < 0 {
+		return ErrInvalidArgument
+	}
+
+	if entry.Expire != 0 {
+		cmd["expire"] = float(entry.Expire)
+	}
+
+	res := commands.MarshalMonCommand(osda.conn, cmd)
+
+	return res.End()
+}
+
+// OSDBlocklistRemove removes an ip address or network address from the
+// blocklist.
+//
+// Similar To:
+//
+//	ceph osd blocklist [range] rm <ip_addr|cidr_network>
+func (osda *Admin) OSDBlocklistRemove(entry AddressEntry) error {
+	if entry.Addr == "" {
+		return ErrEmptyArgument
+	}
+
+	cmd, err := blocklistOpCmd(entry.Addr, "rm")
+	if err != nil {
+		return err
+	}
+
+	res := commands.MarshalMonCommand(osda.conn, cmd)
+
+	return res.End()
+}

--- a/common/admin/osd/osd_blocklist_test.go
+++ b/common/admin/osd/osd_blocklist_test.go
@@ -1,0 +1,106 @@
+//go:build !octopus && ceph_preview
+
+package osd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *OSDAdminSuite) TestOSDBlocklist() {
+	osda := NewFromConn(suite.vconn.Get(suite.T()))
+
+	res, err := osda.OSDBlocklist()
+	assert.NoError(suite.T(), err)
+	prev := len(*res)
+
+	suite.T().Run("osd blocklist add address", func(t *testing.T) {
+		// empty address
+		err := osda.OSDBlocklistAdd(AddressEntry{})
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrEmptyArgument))
+
+		// add invalid ip address
+		err = osda.OSDBlocklistAdd(AddressEntry{
+			Addr: "192.168.122.257",
+		})
+		assert.Error(t, err)
+		assert.True(t,
+			errors.Unwrap(err) == errors.Unwrap(ErrInvalidArgument))
+
+		err = osda.OSDBlocklistAdd(AddressEntry{
+			Addr: "192.168.122.2",
+		})
+		assert.NoError(t, err)
+
+		// add ip address with invalid expire value
+		err = osda.OSDBlocklistAdd(AddressEntry{
+			Addr:   "192.168.122.3",
+			Expire: -1,
+		})
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrInvalidArgument)
+
+		err = osda.OSDBlocklistAdd(AddressEntry{
+			Addr:   "192.168.122.3",
+			Expire: 22.3,
+		})
+		assert.NoError(t, err)
+
+		// add invalid network
+		err = osda.OSDBlocklistAdd(AddressEntry{
+			Addr: "192.168.122.0/40",
+		})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "osd: ret=-22, Invalid argument")
+
+		err = osda.OSDBlocklistAdd(AddressEntry{
+			Addr: "192.168.122.0/24",
+		})
+		assert.NoError(t, err)
+	})
+
+	suite.T().Run("osd blocklist remove address", func(t *testing.T) {
+		// empty address
+		err := osda.OSDBlocklistRemove(AddressEntry{})
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrEmptyArgument))
+
+		err = osda.OSDBlocklistRemove(AddressEntry{
+			Addr: "192.168.122.2",
+		})
+		assert.NoError(t, err)
+
+		err = osda.OSDBlocklistRemove(AddressEntry{
+			Addr: "192.168.122.3",
+		})
+		assert.NoError(t, err)
+
+		// remove non existent ip address
+		err = osda.OSDBlocklistRemove(AddressEntry{
+			Addr: "192.168.122.4",
+		})
+		assert.NoError(t, err)
+
+		res, err := osda.OSDBlocklist()
+		assert.NoError(t, err)
+		assert.Equal(t, prev+1, len(*res))
+
+		err = osda.OSDBlocklistRemove(AddressEntry{
+			Addr: "192.168.122.0/24",
+		})
+		assert.NoError(t, err)
+
+		// remove non existent network
+		err = osda.OSDBlocklistRemove(AddressEntry{
+			Addr: "192.168.122.0/32",
+		})
+		assert.NoError(t, err)
+
+		res, err = osda.OSDBlocklist()
+		assert.NoError(t, err)
+		assert.Equal(t, prev, len(*res))
+	})
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2818,6 +2818,30 @@
         "comment": "NewFromConn creates an new management object from a preexisting\nrados connection. The existing connection can be rados.Conn or any\ntype implementing the RadosCommander interface.\n",
         "added_in_version": "$NEXT_RELEASE",
         "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.OSDBlocklist",
+        "comment": "OSDBlocklist returns the list of blocklisted clients.\n\nSimilar To:\n\n\tceph osd blocklist ls\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.OSDBlocklistAdd",
+        "comment": "OSDBlocklistAdd adds an ip address or network address in CIDR format to the\nblocklist.\n\nSimilar To:\n\n\tceph osd blocklist [range] add <ip_addr|cidr_network> [expire]\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Admin.OSDBlocklistRemove",
+        "comment": "OSDBlocklistRemove removes an ip address or network address from the\nblocklist.\n\nSimilar To:\n\n\tceph osd blocklist [range] rm <ip_addr|cidr_network>\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Float.MarshalJSON",
+        "comment": "MarshalJSON is a custom implementation for the JSON marshaling of Float.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   }

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2810,5 +2810,15 @@
         "expected_stable_version": "v0.36.0"
       }
     ]
+  },
+  "common/admin/osd": {
+    "preview_api": [
+      {
+        "name": "NewFromConn",
+        "comment": "NewFromConn creates an new management object from a preexisting\nrados connection. The existing connection can be rados.Conn or any\ntype implementing the RadosCommander interface.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ]
   }
 }

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -137,3 +137,11 @@ NewUsersAndGroups | v0.34.0 | v0.36.0 |
 NewLinkedUsersAndGroups | v0.34.0 | v0.36.0 | 
 NewUsersAndGroupsToRemove | v0.34.0 | v0.36.0 | 
 
+## Package: common/admin/osd
+
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+NewFromConn | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -144,4 +144,8 @@ NewUsersAndGroupsToRemove | v0.34.0 | v0.36.0 |
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 NewFromConn | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.OSDBlocklist | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.OSDBlocklistAdd | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Admin.OSDBlocklistRemove | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Float.MarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 


### PR DESCRIPTION
- Creates a new OSD admin package under _common/admin_.
- C API, _rados_blocklist_add()_, basically sends mon command behind the scenes and I couldn't find an equivalent API for removal. Therefore the go-ceph APIs introduced here rely on the actual mon commands. 

fixes #598 