### PR TITLE
rbd: implement `rbd_get_data_pool_id`

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2018,7 +2018,14 @@
         "became_stable_version": "v0.35.0"
       }
     ],
-    "preview_api": []
+    "preview_api": [
+      {
+        "name": "Image.GetDataPoolID",
+        "comment": "GetDataPoolID returns the ID of the data pool assigned to an image\n\nImplements:\n\n\tint64_t rbd_get_data_pool_id(rbd_image_t image)\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ]
   },
   "rbd/admin": {
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -27,6 +27,12 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: rbd
 
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+Image.GetDataPoolID | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+
 ### Deprecated APIs
 
 Name | Deprecated in Version | Expected Removal Version | 

--- a/rbd/data_pool_id.go
+++ b/rbd/data_pool_id.go
@@ -1,0 +1,20 @@
+//go:build ceph_preview
+
+package rbd
+
+// #cgo LDFLAGS: -lrbd
+// #include <rbd/librbd.h>
+import "C"
+
+// GetDataPoolID returns the ID of the data pool assigned to an image
+//
+// Implements:
+//
+//	int64_t rbd_get_data_pool_id(rbd_image_t image)
+func (image *Image) GetDataPoolID() (int64, error) {
+	if err := image.validate(imageIsOpen); err != nil {
+		return -1, err
+	}
+
+	return int64(C.rbd_get_data_pool_id(image.image)), nil
+}

--- a/rbd/data_pool_id_test.go
+++ b/rbd/data_pool_id_test.go
@@ -1,0 +1,75 @@
+//go:build ceph_preview
+
+package rbd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDataPoolID(t *testing.T) {
+	conn := radosConnect(t)
+
+	poolname := GetUUID()
+	err := conn.MakePool(poolname)
+	assert.NoError(t, err)
+
+	dataPoolname := GetUUID()
+	err = conn.MakePool(dataPoolname)
+	assert.NoError(t, err)
+
+	ioctx, err := conn.OpenIOContext(poolname)
+	require.NoError(t, err)
+
+	name := GetUUID()
+	options := NewRbdImageOptions()
+	assert.NoError(t, options.SetString(ImageOptionDataPool, dataPoolname))
+
+	err = CreateImage(ioctx, name, testImageSize, options)
+	assert.NoError(t, err)
+
+	workingImage, err := OpenImage(ioctx, name, NoSnapshot)
+	assert.NoError(t, err)
+
+	dataPoolId, err := conn.GetPoolByName(dataPoolname)
+	assert.NoError(t, err)
+
+	t.Run("GetDataPoolId", func(t *testing.T) {
+		id, err := workingImage.GetDataPoolID()
+		assert.NoError(t, err)
+		assert.Equal(t, dataPoolId, id)
+	})
+
+	singlePoolImageName := GetUUID()
+	singlePoolImageOptions := NewRbdImageOptions()
+	err = CreateImage(ioctx, singlePoolImageName, testImageSize, singlePoolImageOptions)
+	assert.NoError(t, err)
+
+	singlePoolImage, err := OpenImage(ioctx, singlePoolImageName, NoSnapshot)
+	assert.NoError(t, err)
+
+	t.Run("GetDataPoolIdNoDataPool", func(t *testing.T) {
+		expectedPoolId, err := conn.GetPoolByName(poolname)
+		assert.NoError(t, err)
+
+		id, err := singlePoolImage.GetDataPoolID()
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedPoolId, id)
+	})
+
+	assert.NoError(t, workingImage.Close())
+	err = workingImage.Remove()
+	assert.NoError(t, err)
+
+	assert.NoError(t, singlePoolImage.Close())
+	err = singlePoolImage.Remove()
+	assert.NoError(t, err)
+
+	ioctx.Destroy()
+	conn.DeletePool(poolname)
+	conn.DeletePool(dataPoolname)
+	conn.Shutdown()
+}


### PR DESCRIPTION
Add go-ceph binding for `rbd_get_data_pool_id` which is required to fetch the data pool for erasure coded volumes


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
