### PR TITLE
admin/smb updates

### DIFF
--- a/common/admin/smb/admin_bindaddrs_test.go
+++ b/common/admin/smb/admin_bindaddrs_test.go
@@ -1,0 +1,37 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *SMBAdminSuite) TestClusterWithBindAddrs() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	cluster := NewUserCluster("caddrs1")
+	ug := NewLinkedUsersAndGroups(cluster).SetValues(
+		[]UserInfo{{"foobar", "L3tM31n"}},
+		[]GroupInfo{{"clients"}},
+	)
+	cluster.BindAddrs = []BindAddress{
+		NewBindAddress("192.168.2.12"),
+		NewBindAddress("192.168.2.13"),
+		NewBindAddress("192.168.2.14"),
+		NewNetworkBindAddress("192.168.2.200/30"),
+	}
+	rgroup, err := sa.Apply([]Resource{cluster, ug}, nil)
+	assert.NoError(t, err)
+	assert.True(t, rgroup.Ok())
+
+	res, err := sa.Show([]ResourceRef{cluster.Identity()}, nil)
+	assert.NoError(t, err)
+	if assert.Len(t, res, 1) {
+		nc := res[0].(*Cluster)
+		assert.Len(t, nc.BindAddrs, 4)
+		assert.False(t, nc.BindAddrs[0].IsNetwork())
+		assert.EqualValues(t, nc.BindAddrs[0].Address(), "192.168.2.12")
+		assert.True(t, nc.BindAddrs[3].IsNetwork())
+		assert.EqualValues(t, nc.BindAddrs[3].Network(), "192.168.2.200/30")
+	}
+}

--- a/common/admin/smb/admin_customports_test.go
+++ b/common/admin/smb/admin_customports_test.go
@@ -1,0 +1,35 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *SMBAdminSuite) TestClusterWithCustomPorts() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	cluster := NewUserCluster("cports1")
+	ug := NewLinkedUsersAndGroups(cluster).SetValues(
+		[]UserInfo{{"foobar", "L3tM31n"}},
+		[]GroupInfo{{"clients"}},
+	)
+	cluster.CustomPorts = CustomPortsMap{
+		SMBService:        8675,
+		SMBMetricsService: 3090,
+		CTDBService:       2112,
+	}
+	rgroup, err := sa.Apply([]Resource{cluster, ug}, nil)
+	assert.NoError(t, err)
+	assert.True(t, rgroup.Ok())
+
+	res, err := sa.Show([]ResourceRef{cluster.Identity()}, nil)
+	assert.NoError(t, err)
+	if assert.Len(t, res, 1) {
+		nc := res[0].(*Cluster)
+		assert.Len(t, nc.CustomPorts, 3)
+		assert.EqualValues(t, nc.CustomPorts[SMBService], 8675)
+		assert.EqualValues(t, nc.CustomPorts[SMBMetricsService], 3090)
+		assert.EqualValues(t, nc.CustomPorts[CTDBService], 2112)
+	}
+}

--- a/common/admin/smb/admin_remotectl_test.go
+++ b/common/admin/smb/admin_remotectl_test.go
@@ -1,0 +1,40 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *SMBAdminSuite) TestClusterWithRemoteControl() {
+	t := suite.T()
+	sa := NewFromConn(suite.vconn.Get(t))
+	cluster := NewUserCluster("caddrs1")
+	ug := NewLinkedUsersAndGroups(cluster).SetValues(
+		[]UserInfo{{"foobar", "L3tM31n"}},
+		[]GroupInfo{{"clients"}},
+	)
+	tc1 := NewTLSCredential("tc1").Set(TLSCert, "INVALIDCERTDATA")
+	tc2 := NewTLSCredential("tc2").Set(TLSKey, "INVALIDCERTDATA")
+	tc3 := NewTLSCredential("tc3").Set(TLSCACert, "INVALIDCERTDATA")
+	cluster.RemoteControl = &RemoteControl{
+		Cert:   &TLSCredentialSource{ResourceSource, "tc1"},
+		Key:    &TLSCredentialSource{ResourceSource, "tc2"},
+		CACert: &TLSCredentialSource{ResourceSource, "tc3"},
+	}
+
+	rgroup, err := sa.Apply([]Resource{cluster, ug, tc1, tc2, tc3}, nil)
+	assert.NoError(t, err)
+	assert.True(t, rgroup.Ok())
+
+	res, err := sa.Show([]ResourceRef{cluster.Identity()}, nil)
+	assert.NoError(t, err)
+	if assert.Len(t, res, 1) {
+		nc := res[0].(*Cluster)
+		if assert.NotNil(t, nc.RemoteControl) {
+			assert.EqualValues(t, nc.RemoteControl.Cert.Ref, "tc1")
+			assert.EqualValues(t, nc.RemoteControl.Key.Ref, "tc2")
+			assert.EqualValues(t, nc.RemoteControl.CACert.Ref, "tc3")
+		}
+	}
+}

--- a/common/admin/smb/admin_test.go
+++ b/common/admin/smb/admin_test.go
@@ -137,7 +137,14 @@ func (suite *SMBAdminSuite) TearDownTest() {
 	sa := NewFromConn(suite.vconn.Get(suite.T()))
 	r, err := sa.Show(nil, nil)
 	suite.Assert().NoError(err)
+
 	for i := range r {
+		if sio, ok := r[i].(interface{ SetIntent(Intent) }); ok {
+			sio.SetIntent(Removed)
+			continue
+		}
+		// TODO: maybe go back and make a SetIntent receiver for the
+		// existing core resource types
 		switch res := r[i].(type) {
 		case *Cluster:
 			res.IntentValue = Removed

--- a/common/admin/smb/bind_addr.go
+++ b/common/admin/smb/bind_addr.go
@@ -1,0 +1,71 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+)
+
+// bindAddr is the low level type in the smb mgr module json/yaml and acts
+// a bit like a union where the key determines the type. To avoid callers
+// setting more than one field at once this is a private type mediated
+// thru BindAddress.
+type bindAddr struct {
+	Address string `json:"address,omitempty"`
+	Network string `json:"network,omitempty"`
+}
+
+// BindAddress indicates an IP Address or Network (IP address range) that
+// the cluster is permitted to listen to.
+type BindAddress struct {
+	a bindAddr
+}
+
+// NewBindAddress returns a BindAddress associated with a single IP address.
+func NewBindAddress(s string) BindAddress {
+	var b BindAddress
+	b.a.Address = s
+	return b
+}
+
+// NewNetworkBindAddress returns a BindAddress associated with a network
+// address. The network address is a range of addresses determined using
+// a prefix length.
+func NewNetworkBindAddress(s string) BindAddress {
+	var b BindAddress
+	b.a.Network = s
+	return b
+}
+
+// MarshalJSON supports marshalling a BindAddress to JSON.
+func (b BindAddress) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.a)
+}
+
+// UnmarshalJSON supports un-marshalling a JSON to a BindAddress.
+func (b *BindAddress) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &b.a)
+}
+
+// Address returns the IP address value.
+func (b BindAddress) Address() string {
+	return b.a.Address
+}
+
+// Network returns the IP network address value.
+func (b BindAddress) Network() string {
+	return b.a.Network
+}
+
+// IsNetwork returns true if this BindAddress contains a network value.
+func (b BindAddress) IsNetwork() bool {
+	return b.a.Network != ""
+}
+
+// String returns a string representing this BindAddress.
+func (b BindAddress) String() string {
+	if b.a.Network != "" {
+		return "network:" + b.a.Network
+	}
+	return "address:" + b.a.Address
+}

--- a/common/admin/smb/cluster.go
+++ b/common/admin/smb/cluster.go
@@ -17,23 +17,6 @@ type DomainSettings struct {
 	JoinSources []JoinAuthSource `json:"join_sources"`
 }
 
-// Placement is passed to cephadm to determine where cluster services
-// will be run.
-type Placement map[string]any
-
-// SimplePlacement returns a placement with common placement parameters - count
-// and label - specified.
-func SimplePlacement(count int, label string) Placement {
-	p := Placement{}
-	if count > 0 {
-		p["count"] = count
-	}
-	if label != "" {
-		p["label"] = label
-	}
-	return p
-}
-
 // PublicAddress used by a cluster with integrated Samba clustering enabled.
 type PublicAddress struct {
 	Address     string

--- a/common/admin/smb/cluster.go
+++ b/common/admin/smb/cluster.go
@@ -7,21 +7,6 @@ import (
 	"fmt"
 )
 
-// JoinAuthSource identifies a Join Auth resource that will be used
-// as a source of authentication parameters to join a cluster to
-// a domain.
-type JoinAuthSource struct {
-	SourceType SourceType `json:"source_type"`
-	Ref        string     `json:"ref"`
-}
-
-// UserGroupSource identifies a Users and Groups resource that will be
-// used as a source of user and group information on the SMB cluster.
-type UserGroupSource struct {
-	SourceType SourceType `json:"source_type"`
-	Ref        string     `json:"ref"`
-}
-
 // DomainSettings are used to configure domain related settings for a
 // cluster using active directory authentication.
 type DomainSettings struct {

--- a/common/admin/smb/cluster.go
+++ b/common/admin/smb/cluster.go
@@ -2,27 +2,6 @@
 
 package smb
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
-// DomainSettings are used to configure domain related settings for a
-// cluster using active directory authentication.
-type DomainSettings struct {
-	// Realm identifies the AD/Kerberos Realm to use.
-	Realm string `json:"realm"`
-	// JoinSources should contain one or more JoinAuthSource that
-	// the cluster may use to join a domain.
-	JoinSources []JoinAuthSource `json:"join_sources"`
-}
-
-// PublicAddress used by a cluster with integrated Samba clustering enabled.
-type PublicAddress struct {
-	Address     string
-	Destination []string
-}
-
 // Cluster configures an SMB Cluster resource that is managed within a
 // Ceph cluster.
 type Cluster struct {
@@ -37,126 +16,8 @@ type Cluster struct {
 	PublicAddrs       []PublicAddress   `json:"public_addrs,omitempty"`
 }
 
-// Type returns a ResourceType value.
-func (*Cluster) Type() ResourceType {
-	return ClusterType
-}
-
-// Intent controls if a resource is to be created/updated or removed.
-func (cluster *Cluster) Intent() Intent {
-	return cluster.IntentValue
-}
-
-// Identity returns a ResourceRef identifying this cluster.
-func (cluster *Cluster) Identity() ResourceRef {
-	return ResourceID{
-		ResourceType: cluster.Type(),
-		ID:           cluster.ClusterID,
-	}
-}
-
-// MarshalJSON supports marshalling a cluster to JSON.
-func (cluster *Cluster) MarshalJSON() ([]byte, error) {
-	type vCluster Cluster
-	type wCluster struct {
-		ResourceType ResourceType `json:"resource_type"`
-		vCluster
-	}
-	return json.Marshal(wCluster{
-		ResourceType: cluster.Type(),
-		vCluster:     vCluster(*cluster),
-	})
-}
-
 // Validate returns an error describing an issue with the resource or
 // nil if the resource object is valid.
 func (cluster *Cluster) Validate() error {
-	var minimal bool
-	switch cluster.IntentValue {
-	case Present:
-	case Removed:
-		minimal = true
-	default:
-		return fmt.Errorf("missing intent")
-	}
-	if cluster.ClusterID == "" {
-		return fmt.Errorf("missing ClusterID")
-	}
-	if minimal {
-		return nil // minimal checks have been done, return early
-	}
-
-	switch cluster.AuthMode {
-	case ActiveDirectoryAuth:
-		if cluster.DomainSettings == nil {
-			return fmt.Errorf(
-				"missing domain settings for %v cluster", ActiveDirectoryAuth)
-		}
-	case UserAuth:
-		if len(cluster.UserGroupSettings) == 0 {
-			return fmt.Errorf(
-				"missing user and group settings for %v cluster",
-				UserAuth)
-		}
-	default:
-		return fmt.Errorf("invalid AuthMode: %#v", cluster.AuthMode)
-	}
-	return nil
-}
-
-// SetPlacement modifies a cluster's placment settings.
-func (cluster *Cluster) SetPlacement(p Placement) *Cluster {
-	cluster.Placement = p
-	return cluster
-}
-
-// NewUserCluster returns a new Cluster with default values set to
-// create/update a cluster with local users-and-groups defined.
-// In addition to the cluster name, this function accepts zero or more
-// ID values naming ceph.smb.usersgroups resources.
-func NewUserCluster(clusterID string, ids ...string) *Cluster {
-	ugs := make([]UserGroupSource, len(ids))
-	for i := range ids {
-		ugs[i] = UserGroupSource{
-			SourceType: ResourceSource,
-			Ref:        ids[i],
-		}
-	}
-	return &Cluster{
-		IntentValue:       Present,
-		ClusterID:         clusterID,
-		AuthMode:          UserAuth,
-		UserGroupSettings: ugs,
-	}
-}
-
-// NewActiveDirectoryCluster returns a new Cluster with default values set to
-// create/update a cluster with active directory authentication.
-// In addition to the cluster name, this function accepts the name of the
-// domain/realm and zero or more ID values naming ceph.smb.join.auth resources.
-func NewActiveDirectoryCluster(
-	clusterID string, realm string, ids ...string) *Cluster {
-
-	jss := make([]JoinAuthSource, len(ids))
-	for i := range ids {
-		jss[i] = JoinAuthSource{
-			SourceType: ResourceSource,
-			Ref:        ids[i],
-		}
-	}
-	return &Cluster{
-		IntentValue: Present,
-		ClusterID:   clusterID,
-		AuthMode:    ActiveDirectoryAuth,
-		DomainSettings: &DomainSettings{
-			Realm:       realm,
-			JoinSources: jss,
-		},
-	}
-}
-
-// NewClusterToRemove return a new Cluster with default values set to remove a
-// cluster from management.
-func NewClusterToRemove(clusterID string) *Cluster {
-	return &Cluster{IntentValue: Removed, ClusterID: clusterID}
+	return cluster.coreValidate()
 }

--- a/common/admin/smb/cluster_core.go
+++ b/common/admin/smb/cluster_core.go
@@ -1,0 +1,148 @@
+//go:build !(octopus || pacific || quincy || reef || squid)
+
+package smb
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DomainSettings are used to configure domain related settings for a
+// cluster using active directory authentication.
+type DomainSettings struct {
+	// Realm identifies the AD/Kerberos Realm to use.
+	Realm string `json:"realm"`
+	// JoinSources should contain one or more JoinAuthSource that
+	// the cluster may use to join a domain.
+	JoinSources []JoinAuthSource `json:"join_sources"`
+}
+
+// PublicAddress used by a cluster with integrated Samba clustering enabled.
+type PublicAddress struct {
+	Address     string
+	Destination []string
+}
+
+// Type returns a ResourceType value.
+func (*Cluster) Type() ResourceType {
+	return ClusterType
+}
+
+// Intent controls if a resource is to be created/updated or removed.
+func (cluster *Cluster) Intent() Intent {
+	return cluster.IntentValue
+}
+
+// Identity returns a ResourceRef identifying this cluster.
+func (cluster *Cluster) Identity() ResourceRef {
+	return ResourceID{
+		ResourceType: cluster.Type(),
+		ID:           cluster.ClusterID,
+	}
+}
+
+// MarshalJSON supports marshalling a cluster to JSON.
+func (cluster *Cluster) MarshalJSON() ([]byte, error) {
+	type vCluster Cluster
+	type wCluster struct {
+		ResourceType ResourceType `json:"resource_type"`
+		vCluster
+	}
+	return json.Marshal(wCluster{
+		ResourceType: cluster.Type(),
+		vCluster:     vCluster(*cluster),
+	})
+}
+
+// coreValidate returns an error describing an issue with the resource or
+// nil if the resource object is valid.
+func (cluster *Cluster) coreValidate() error {
+	var minimal bool
+	switch cluster.IntentValue {
+	case Present:
+	case Removed:
+		minimal = true
+	default:
+		return fmt.Errorf("missing intent")
+	}
+	if cluster.ClusterID == "" {
+		return fmt.Errorf("missing ClusterID")
+	}
+	if minimal {
+		return nil // minimal checks have been done, return early
+	}
+
+	switch cluster.AuthMode {
+	case ActiveDirectoryAuth:
+		if cluster.DomainSettings == nil {
+			return fmt.Errorf(
+				"missing domain settings for %v cluster", ActiveDirectoryAuth)
+		}
+	case UserAuth:
+		if len(cluster.UserGroupSettings) == 0 {
+			return fmt.Errorf(
+				"missing user and group settings for %v cluster",
+				UserAuth)
+		}
+	default:
+		return fmt.Errorf("invalid AuthMode: %#v", cluster.AuthMode)
+	}
+	return nil
+}
+
+// SetPlacement modifies a cluster's placement  settings.
+func (cluster *Cluster) SetPlacement(p Placement) *Cluster {
+	cluster.Placement = p
+	return cluster
+}
+
+// NewUserCluster returns a new Cluster with default values set to
+// create/update a cluster with local users-and-groups defined.
+// In addition to the cluster name, this function accepts zero or more
+// ID values naming ceph.smb.usersgroups resources.
+func NewUserCluster(clusterID string, ids ...string) *Cluster {
+	ugs := make([]UserGroupSource, len(ids))
+	for i := range ids {
+		ugs[i] = UserGroupSource{
+			SourceType: ResourceSource,
+			Ref:        ids[i],
+		}
+	}
+	return &Cluster{
+		IntentValue:       Present,
+		ClusterID:         clusterID,
+		AuthMode:          UserAuth,
+		UserGroupSettings: ugs,
+	}
+}
+
+// NewActiveDirectoryCluster returns a new Cluster with default values set to
+// create/update a cluster with active directory authentication.
+// In addition to the cluster name, this function accepts the name of the
+// domain/realm and zero or more ID values naming ceph.smb.join.auth resources.
+func NewActiveDirectoryCluster(
+	clusterID string, realm string, ids ...string) *Cluster {
+
+	jss := make([]JoinAuthSource, len(ids))
+	for i := range ids {
+		jss[i] = JoinAuthSource{
+			SourceType: ResourceSource,
+			Ref:        ids[i],
+		}
+	}
+	return &Cluster{
+		IntentValue: Present,
+		ClusterID:   clusterID,
+		AuthMode:    ActiveDirectoryAuth,
+		DomainSettings: &DomainSettings{
+			Realm:       realm,
+			JoinSources: jss,
+		},
+	}
+}
+
+// NewClusterToRemove return a new Cluster with default values set to remove a
+// cluster from management.
+func NewClusterToRemove(clusterID string) *Cluster {
+	return &Cluster{IntentValue: Removed, ClusterID: clusterID}
+}

--- a/common/admin/smb/cluster_preview.go
+++ b/common/admin/smb/cluster_preview.go
@@ -1,6 +1,10 @@
-//go:build !(octopus || pacific || quincy || reef || squid || ceph_preview)
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
 
 package smb
+
+// CustomPortsMap is used to configure a cluster with custom ports for
+// a specified service type.
+type CustomPortsMap map[Service]int
 
 // Cluster configures an SMB Cluster resource that is managed within a
 // Ceph cluster.
@@ -14,6 +18,9 @@ type Cluster struct {
 	Placement         Placement         `json:"placement,omitempty"`
 	Clustering        Clustering        `json:"clustering,omitempty"`
 	PublicAddrs       []PublicAddress   `json:"public_addrs,omitempty"`
+	// CustomPorts allows the customization of network port binding
+	// by virtual service name [PREVIEW].
+	CustomPorts CustomPortsMap `json:"custom_ports,omitempty"`
 }
 
 // Validate returns an error describing an issue with the resource or
@@ -21,3 +28,7 @@ type Cluster struct {
 func (cluster *Cluster) Validate() error {
 	return cluster.coreValidate()
 }
+
+// PREVIEW Field Group tracking
+// Group 1:
+//   CustomPorts

--- a/common/admin/smb/cluster_preview.go
+++ b/common/admin/smb/cluster_preview.go
@@ -24,15 +24,30 @@ type Cluster struct {
 	// BindAddrs allows specifying the addresses/networks an SMB cluster
 	// running on a ceph node will bind to [PREVIEW].
 	BindAddrs []BindAddress `json:"bind_addrs,omitempty"`
+	// RemoteControl is used to specify settings for the remote control
+	// support service [PREVIEW].
+	RemoteControl *RemoteControl `json:"remote_control,omitempty"`
 }
 
 // Validate returns an error describing an issue with the resource or
 // nil if the resource object is valid.
 func (cluster *Cluster) Validate() error {
-	return cluster.coreValidate()
+	if err := cluster.coreValidate(); err != nil {
+		return err
+	}
+	if cluster.RemoteControl != nil {
+		if err := cluster.RemoteControl.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // PREVIEW Field Group tracking
+// Increment the group number when adding PREVIEW fields in a new go-ceph
+// release cycle (maybe integrate with api-fix-versions in the future?)
+//
 // Group 1:
 //   CustomPorts
 //   BindAddress
+//   RemoteControl

--- a/common/admin/smb/cluster_preview.go
+++ b/common/admin/smb/cluster_preview.go
@@ -21,6 +21,9 @@ type Cluster struct {
 	// CustomPorts allows the customization of network port binding
 	// by virtual service name [PREVIEW].
 	CustomPorts CustomPortsMap `json:"custom_ports,omitempty"`
+	// BindAddrs allows specifying the addresses/networks an SMB cluster
+	// running on a ceph node will bind to [PREVIEW].
+	BindAddrs []BindAddress `json:"bind_addrs,omitempty"`
 }
 
 // Validate returns an error describing an issue with the resource or
@@ -32,3 +35,4 @@ func (cluster *Cluster) Validate() error {
 // PREVIEW Field Group tracking
 // Group 1:
 //   CustomPorts
+//   BindAddress

--- a/common/admin/smb/cluster_remotectl_test.go
+++ b/common/admin/smb/cluster_remotectl_test.go
@@ -1,0 +1,51 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshalUnmarshalClusterWithRemoteControl(t *testing.T) {
+	c1 := NewUserCluster("rcc")
+	ug := NewLinkedUsersAndGroups(c1).SetValues(
+		[]UserInfo{
+			{"bob", "M4r13y"},
+			{"billy", "p14n0m4N"},
+		},
+		[]GroupInfo{{"clients"}},
+	)
+	tc1 := NewLinkedTLSCredential(c1).Set(TLSCert, "INVALIDCERTDATA")
+	tc2 := NewLinkedTLSCredential(c1).Set(TLSKey, "INVALIDCERTDATA")
+	tc3 := NewLinkedTLSCredential(c1).Set(TLSCACert, "INVALIDCERTDATA")
+	c1.RemoteControl = &RemoteControl{
+		Cert:   &TLSCredentialSource{ResourceSource, tc1.TLSCredentialID},
+		Key:    &TLSCredentialSource{ResourceSource, tc2.TLSCredentialID},
+		CACert: &TLSCredentialSource{ResourceSource, tc3.TLSCredentialID},
+	}
+
+	rg := resourceGroup{Resources: []Resource{c1, ug, tc1, tc2, tc3}}
+	assert.NoError(t, ValidateResources(rg.Resources))
+	j, err := json.Marshal(rg)
+	assert.NoError(t, err)
+
+	rg = resourceGroup{}
+	err = json.Unmarshal(j, &rg)
+	assert.NoError(t, err)
+	assert.Len(t, rg.Resources, 5)
+	assert.Equal(t, rg.Resources[0].Type(), ClusterType)
+	assert.Equal(t, rg.Resources[1].Type(), UsersAndGroupsType)
+	assert.Equal(t, rg.Resources[2].Type(), TLSCredentialType)
+	assert.Equal(t, rg.Resources[3].Type(), TLSCredentialType)
+	assert.Equal(t, rg.Resources[4].Type(), TLSCredentialType)
+
+	c2 := rg.Resources[0].(*Cluster)
+	if assert.NotNil(t, c2.RemoteControl) {
+		assert.EqualValues(t, c2.RemoteControl.Cert.Ref, tc1.TLSCredentialID)
+		assert.EqualValues(t, c2.RemoteControl.Key.Ref, tc2.TLSCredentialID)
+		assert.EqualValues(t, c2.RemoteControl.CACert.Ref, tc3.TLSCredentialID)
+	}
+}

--- a/common/admin/smb/enums.go
+++ b/common/admin/smb/enums.go
@@ -24,6 +24,9 @@ const (
 	JoinAuthType = ResourceType("ceph.smb.join.auth")
 	// UsersAndGroupsType resources contain data used to define users and groups.
 	UsersAndGroupsType = ResourceType("ceph.smb.usersgroups")
+	// TLSCredentialType resources contain data used to establish TLS
+	// secured network connections.
+	TLSCredentialType = ResourceType("ceph.smb.tls.credential")
 )
 
 // SourceType indicates how a Cluster resource refers to another resource it

--- a/common/admin/smb/enums.go
+++ b/common/admin/smb/enums.go
@@ -115,3 +115,18 @@ const (
 	// placeholder values.
 	PasswordFilterHidden = PasswordFilter("hidden")
 )
+
+// Service names particular network services provided by an ceph smb cluster.
+type Service string
+
+const (
+	// SMBService represents the core smb network file system service.
+	SMBService = Service("smb")
+	// SMBMetricsService represents the prometheus style metrics service.
+	SMBMetricsService = Service("smbmetrics")
+	// CTDBService represents the ctdb service used to coordinate clusters.
+	CTDBService = Service("ctdb")
+	// RemoteControlService represents a cloud compatible remote control
+	// service (based on gRPC).
+	RemoteControlService = Service("remote-control")
+)

--- a/common/admin/smb/placement.go
+++ b/common/admin/smb/placement.go
@@ -1,0 +1,20 @@
+//go:build !(octopus || pacific || quincy || reef || squid)
+
+package smb
+
+// Placement is passed to cephadm to determine where cluster services
+// will be run.
+type Placement map[string]any
+
+// SimplePlacement returns a placement with common placement parameters - count
+// and label - specified.
+func SimplePlacement(count int, label string) Placement {
+	p := Placement{}
+	if count > 0 {
+		p["count"] = count
+	}
+	if label != "" {
+		p["label"] = label
+	}
+	return p
+}

--- a/common/admin/smb/remotectl.go
+++ b/common/admin/smb/remotectl.go
@@ -1,0 +1,36 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import "fmt"
+
+// RemoteControl configures the optional smb cluster remote control subsystem.
+type RemoteControl struct {
+	// Enabled is used to explicitly enable or disable the remote control
+	// subsystem. If Enabled is true the remote control subsystem will be
+	// enabled, if false always disabled. If unset (nil) the state of the
+	// subsystem is determined by the TLS sources being set or not.
+	Enabled *bool `json:"enabled,omitempty"`
+	// Cert is used to provide a TLS certificate to the remote control service.
+	Cert *TLSCredentialSource `json:"cert,omitempty"`
+	// Key is used to provide a TLS key to the remote control service.
+	Key *TLSCredentialSource `json:"key,omitempty"`
+	// CACert is used to provide a TLS CA certificate to the remote control
+	// service.
+	CACert *TLSCredentialSource `json:"ca_cert,omitempty"`
+}
+
+// Validate returns an error describing an issue with the remote control
+// configuration or nil if the resource object is valid.
+func (rc *RemoteControl) Validate() error {
+	hasCert := rc.Cert != nil
+	hasKey := rc.Key != nil
+	hasCACert := rc.CACert != nil
+	if hasCert != hasKey {
+		return fmt.Errorf("cert and key must be specified together")
+	}
+	if hasCACert != hasCert {
+		return fmt.Errorf("a CA cert must be specified with a cert and key")
+	}
+	return nil
+}

--- a/common/admin/smb/source.go
+++ b/common/admin/smb/source.go
@@ -1,0 +1,18 @@
+//go:build !(octopus || pacific || quincy || reef || squid)
+
+package smb
+
+// JoinAuthSource identifies a Join Auth resource that will be used
+// as a source of authentication parameters to join a cluster to
+// a domain.
+type JoinAuthSource struct {
+	SourceType SourceType `json:"source_type"`
+	Ref        string     `json:"ref"`
+}
+
+// UserGroupSource identifies a Users and Groups resource that will be
+// used as a source of user and group information on the SMB cluster.
+type UserGroupSource struct {
+	SourceType SourceType `json:"source_type"`
+	Ref        string     `json:"ref"`
+}

--- a/common/admin/smb/tls_cred.go
+++ b/common/admin/smb/tls_cred.go
@@ -1,0 +1,141 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TLSContent indicates the type of TLS file/data a resource contains.
+type TLSContent string
+
+const (
+	// TLSCert indicates the resource contains a TLS certificate.
+	TLSCert = TLSContent("cert")
+	// TLSKey indicates the resource contains a TLS key.
+	TLSKey = TLSContent("key")
+	// TLSCACert indicates the resource contains a TLS CA certificate.
+	TLSCACert = TLSContent("ca-cert")
+)
+
+// TLSCredential is a resource containing a TLS resource such as a
+// certificate, key, or ca certificate.
+// server to a domain.
+type TLSCredential struct {
+	IntentValue     Intent     `json:"intent"`
+	TLSCredentialID string     `json:"tls_credential_id"`
+	CredentialType  TLSContent `json:"credential_type"`
+	Value           string     `json:"value,omitempty"`
+	LinkedToCluster string     `json:"linked_to_cluster,omitempty"`
+}
+
+// Type returns a ResourceType value.
+func (*TLSCredential) Type() ResourceType {
+	return TLSCredentialType
+}
+
+// Intent controls if a resource is to be created/updated or removed.
+func (tc *TLSCredential) Intent() Intent {
+	return tc.IntentValue
+}
+
+// SetIntent updates the resource's intent value.
+func (tc *TLSCredential) SetIntent(i Intent) {
+	tc.IntentValue = i
+}
+
+// Identity returns a ResourceRef identifying this tls credential resource.
+func (tc *TLSCredential) Identity() ResourceRef {
+	return ResourceID{
+		ResourceType: tc.Type(),
+		ID:           tc.TLSCredentialID,
+	}
+}
+
+// Validate returns an error describing an issue with the resource or nil if
+// the resource object is valid.
+func (tc *TLSCredential) Validate() error {
+	var minimal bool
+	switch tc.IntentValue {
+	case Present:
+	case Removed:
+		minimal = true
+	default:
+		return fmt.Errorf("missing intent")
+	}
+	if tc.TLSCredentialID == "" {
+		return fmt.Errorf("missing TLSCredentialID")
+	}
+	if minimal {
+		return nil // minimal checks have been done, return early
+	}
+
+	switch tc.CredentialType {
+	case TLSCert, TLSKey, TLSCACert:
+	case TLSContent(""):
+		return fmt.Errorf("missing CredentialType")
+	default:
+		return fmt.Errorf("invalid CredentialType")
+	}
+	if tc.Value == "" {
+		return fmt.Errorf("missing Value")
+	}
+	return nil
+}
+
+// MarshalJSON supports marshalling a TLSCredential to JSON.
+func (tc *TLSCredential) MarshalJSON() ([]byte, error) {
+	type vTLSCredential TLSCredential
+	type wTLSCredential struct {
+		ResourceType ResourceType `json:"resource_type"`
+		vTLSCredential
+	}
+	return json.Marshal(wTLSCredential{
+		ResourceType:   tc.Type(),
+		vTLSCredential: vTLSCredential(*tc),
+	})
+}
+
+// Set modifies a TLSCredential's credential type and credential value.
+func (tc *TLSCredential) Set(ctype TLSContent, value string) *TLSCredential {
+	tc.CredentialType = ctype
+	tc.Value = value
+	return tc
+}
+
+// NewTLSCredential returns a new empty TLSCredential.
+func NewTLSCredential(id string) *TLSCredential {
+	return &TLSCredential{
+		IntentValue:     Present,
+		TLSCredentialID: id,
+	}
+}
+
+// NewLinkedTLSCredential returns a new TLSCredentialID with default values
+// that link the resource to a particular cluster. Linked resources can only
+// be used by the cluster they link to and are automatically deleted when the
+// linked cluster is deleted.
+func NewLinkedTLSCredential(cluster *Cluster) *TLSCredential {
+	tc := NewTLSCredential(randName(cluster.ClusterID))
+	tc.LinkedToCluster = cluster.ClusterID
+	return tc
+}
+
+// NewTLSCredentialToRemove returns a new TLSCredential with default values
+// set to remove the credential resource from management.
+func NewTLSCredentialToRemove(id string) *TLSCredential {
+	return &TLSCredential{
+		IntentValue:     Removed,
+		TLSCredentialID: id,
+	}
+}
+
+func init() {
+	if resourceTypes == nil {
+		resourceTypes = map[ResourceType]func() Resource{}
+	}
+	resourceTypes[TLSCredentialType] = func() Resource {
+		return new(TLSCredential)
+	}
+}

--- a/common/admin/smb/tls_cred_test.go
+++ b/common/admin/smb/tls_cred_test.go
@@ -1,0 +1,108 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTLSCredentialIdentity(t *testing.T) {
+	tc := NewTLSCredential("cert1")
+	assert.Equal(t, tc.Type(), TLSCredentialType)
+	tcid := tc.Identity()
+	assert.Equal(t, tcid.Type(), TLSCredentialType)
+	assert.Equal(t, tcid.String(), "ceph.smb.tls.credential.cert1")
+	assert.Equal(t, tc.Intent(), Present)
+}
+
+func TestTLSCredentialValidate(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		tc := &TLSCredential{}
+		assert.ErrorContains(t, tc.Validate(), "intent")
+	})
+	t.Run("missingID", func(t *testing.T) {
+		tc := &TLSCredential{IntentValue: Present}
+		assert.ErrorContains(t, tc.Validate(), "TLSCredentialID")
+	})
+	t.Run("intentRemoved", func(t *testing.T) {
+		tc := &TLSCredential{IntentValue: Removed, TLSCredentialID: "tc1"}
+		assert.NoError(t, tc.Validate())
+	})
+
+	// from this point on we're going to progressively add to
+	// tc1 until it is valid
+	tc1 := &TLSCredential{
+		IntentValue:     Present,
+		TLSCredentialID: "tc1",
+	}
+	t.Run("missingCredType", func(t *testing.T) {
+		assert.ErrorContains(t, tc1.Validate(), "missing CredentialType")
+	})
+	tc1.CredentialType = TLSContent("yyyy")
+	t.Run("invalidCredType", func(t *testing.T) {
+		assert.ErrorContains(t, tc1.Validate(), "invalid CredentialType")
+	})
+	tc1.CredentialType = TLSCert
+	t.Run("missingValue", func(t *testing.T) {
+		assert.ErrorContains(t, tc1.Validate(), "missing Value")
+	})
+	// not a valid cert, but we only check for some string in this lib.
+	// let the smb mgr module validate the string contents as needed.
+	tc1.Value = "asdfasdfasdfasdfasfasf"
+	t.Run("ok", func(t *testing.T) {
+		assert.NoError(t, tc1.Validate())
+	})
+}
+
+func TestMarshalTLSCredential(t *testing.T) {
+	tc := NewTLSCredential("tc1")
+	_, err := json.Marshal(tc)
+	assert.NoError(t, err)
+}
+
+func TestMarshalUnmarshalTLSCredential(t *testing.T) {
+	tc1 := NewTLSCredential("tc1").Set(TLSCert, "INVALIDCERTDATA")
+	assert.NoError(t, tc1.Validate())
+	j, err := json.Marshal(tc1)
+	assert.NoError(t, err)
+	tc2 := &TLSCredential{}
+	err = json.Unmarshal(j, tc2)
+	assert.NoError(t, err)
+	assert.NoError(t, tc2.Validate())
+	assert.EqualValues(t, tc1.TLSCredentialID, tc2.TLSCredentialID)
+	assert.EqualValues(t, tc1.IntentValue, tc2.IntentValue)
+	assert.EqualValues(t, tc1.CredentialType, tc2.CredentialType)
+	assert.EqualValues(t, tc1.Value, tc2.Value)
+}
+
+func TestMarshalUnmarshalLinkedTLSCredential(t *testing.T) {
+	c1 := NewUserCluster("c1")
+	ug := NewLinkedUsersAndGroups(c1).SetValues(
+		[]UserInfo{
+			{"bob", "M4r13y"},
+			{"billy", "p14n0m4N"},
+		},
+		[]GroupInfo{{"clients"}},
+	)
+	tc1 := NewLinkedTLSCredential(c1).Set(TLSCert, "INVALIDCERTDATA")
+	tc2 := NewLinkedTLSCredential(c1).Set(TLSKey, "INVALIDCERTDATA")
+	tc3 := NewLinkedTLSCredential(c1).Set(TLSCACert, "INVALIDCERTDATA")
+
+	rg1 := resourceGroup{Resources: []Resource{c1, ug, tc1, tc2, tc3}}
+	assert.NoError(t, ValidateResources(rg1.Resources))
+	j, err := json.Marshal(rg1)
+	assert.NoError(t, err)
+
+	rg2 := resourceGroup{}
+	err = json.Unmarshal(j, &rg2)
+	assert.NoError(t, err)
+	assert.Len(t, rg2.Resources, 5)
+	assert.Equal(t, rg2.Resources[0].Type(), ClusterType)
+	assert.Equal(t, rg2.Resources[1].Type(), UsersAndGroupsType)
+	assert.Equal(t, rg2.Resources[2].Type(), TLSCredentialType)
+	assert.Equal(t, rg2.Resources[3].Type(), TLSCredentialType)
+	assert.Equal(t, rg2.Resources[4].Type(), TLSCredentialType)
+}

--- a/common/admin/smb/tls_source.go
+++ b/common/admin/smb/tls_source.go
@@ -1,0 +1,11 @@
+//go:build !(octopus || pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+// TLSCredentialSource identifies a TLS Credential resource that will be
+// used as a source for TLS-based connection security for a service
+// used for-or-by the smb cluster.
+type TLSCredentialSource struct {
+	SourceType SourceType `json:"source_type"`
+	Ref        string     `json:"ref"`
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2459,7 +2459,128 @@
     ]
   },
   "common/admin/smb": {
-    "preview_api": [],
+    "preview_api": [
+      {
+        "name": "NewBindAddress",
+        "comment": "NewBindAddress returns a BindAddress associated with a single IP address.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewNetworkBindAddress",
+        "comment": "NewNetworkBindAddress returns a BindAddress associated with a network\naddress. The network address is a range of addresses determined using\na prefix length.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "BindAddress.MarshalJSON",
+        "comment": "MarshalJSON supports marshalling a BindAddress to JSON.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "BindAddress.UnmarshalJSON",
+        "comment": "UnmarshalJSON supports un-marshalling a JSON to a BindAddress.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "BindAddress.Address",
+        "comment": "Address returns the IP address value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "BindAddress.Network",
+        "comment": "Network returns the IP network address value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "BindAddress.IsNetwork",
+        "comment": "IsNetwork returns true if this BindAddress contains a network value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "BindAddress.String",
+        "comment": "String returns a string representing this BindAddress.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "Cluster.Validate",
+        "comment": "Validate returns an error describing an issue with the resource or\nnil if the resource object is valid.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "RemoteControl.Validate",
+        "comment": "Validate returns an error describing an issue with the remote control\nconfiguration or nil if the resource object is valid.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "TLSCredential.Type",
+        "comment": "Type returns a ResourceType value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "TLSCredential.Intent",
+        "comment": "Intent controls if a resource is to be created/updated or removed.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "TLSCredential.SetIntent",
+        "comment": "SetIntent updates the resource's intent value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "TLSCredential.Identity",
+        "comment": "Identity returns a ResourceRef identifying this tls credential resource.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "TLSCredential.Validate",
+        "comment": "Validate returns an error describing an issue with the resource or nil if\nthe resource object is valid.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "TLSCredential.MarshalJSON",
+        "comment": "MarshalJSON supports marshalling a TLSCredential to JSON.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "TLSCredential.Set",
+        "comment": "Set modifies a TLSCredential's credential type and credential value.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewTLSCredential",
+        "comment": "NewTLSCredential returns a new empty TLSCredential.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewLinkedTLSCredential",
+        "comment": "NewLinkedTLSCredential returns a new TLSCredentialID with default values\nthat link the resource to a particular cluster. Linked resources can only\nbe used by the cluster they link to and are automatically deleted when the\nlinked cluster is deleted.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "NewTLSCredentialToRemove",
+        "comment": "NewTLSCredentialToRemove returns a new TLSCredential with default values\nset to remove the credential resource from management.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ],
     "stable_api": [
       {
         "name": "NewFromConn",

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -70,7 +70,30 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: common/admin/smb
 
-No Preview/Deprecated APIs found. All APIs are considered stable.
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+NewBindAddress | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewNetworkBindAddress | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+BindAddress.MarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+BindAddress.UnmarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+BindAddress.Address | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+BindAddress.Network | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+BindAddress.IsNetwork | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+BindAddress.String | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+Cluster.Validate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+RemoteControl.Validate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+TLSCredential.Type | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+TLSCredential.Intent | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+TLSCredential.SetIntent | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+TLSCredential.Identity | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+TLSCredential.Validate | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+TLSCredential.MarshalJSON | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+TLSCredential.Set | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewTLSCredential | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewLinkedTLSCredential | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+NewTLSCredentialToRemove | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: common/admin/osd
 


### PR DESCRIPTION
Extend the structures in the (already preview) common/admin/smb package with recent additions to the ceph smb mgr module resources "api".

This addds:
* custom ports
* custom ip address binds
* tls credential resource
* remote control configuration


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
