### PR TITLE
workflows: enable tentacle job now that RCs are available

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
         - "quincy"
         - "reef"
         - "squid"
-      # - "tentacle"
+        - "tentacle"
         - "pre-reef"
         - "pre-squid"
         - "pre-tentacle"


### PR DESCRIPTION
Enabled the previously commented out tentacle job as tentacle RCs are now available.