### PR TITLE
github: Remove `octopus` and require `tentacle` for CI and mergify configurations

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,7 +8,6 @@ queue_rules:
     queue_conditions:
       - check-success=check
       - check-success=dpulls
-      - check-success=test-suite (octopus)
       - check-success=test-suite (pacific)
       - check-success=test-suite (quincy)
       - check-success=test-suite (reef)
@@ -36,7 +35,6 @@ pull_request_rules:
       - status-success=check
       - status-success=dpulls
       # See above
-      - status-success=test-suite (octopus)
       - status-success=test-suite (pacific)
       - status-success=test-suite (quincy)
       - status-success=test-suite (reef)

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,6 +13,7 @@ queue_rules:
       - check-success=test-suite (quincy)
       - check-success=test-suite (reef)
       - check-success=test-suite (squid)
+      - check-success=test-suite (tentacle)
     merge_method: rebase
     update_method: rebase
 
@@ -40,6 +41,7 @@ pull_request_rules:
       - status-success=test-suite (quincy)
       - status-success=test-suite (reef)
       - status-success=test-suite (squid)
+      - status-success=test-suite (tentacle)
       - or:
         - and:
           - label=no-API

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,6 @@ jobs:
       fail-fast: false
       matrix:
         ceph_version:
-        - "octopus"
         - "pacific"
         - "quincy"
         - "reef"


### PR DESCRIPTION
- Remove `octopus` job from test matrix and accordingly update the mergify configuration.
- Require `tentacle` job for mergify.