### PR TITLE
cephfs: add support for cephfs snapdiff api

### DIFF
--- a/cephfs/errors.go
+++ b/cephfs/errors.go
@@ -40,6 +40,8 @@ var (
 	// ErrOpNotSupported is returned in general for operations that are not
 	// supported.
 	ErrOpNotSupported = getError(-C.EOPNOTSUPP)
+	// ErrNotImplemented indicates a function is not implemented in by libcephfs.
+	ErrNotImplemented = getError(-C.ENOSYS)
 
 	// Private errors:
 

--- a/cephfs/snap_diff.go
+++ b/cephfs/snap_diff.go
@@ -1,0 +1,268 @@
+//go:build ceph_preview
+
+package cephfs
+
+/*
+#cgo LDFLAGS: -lcephfs
+#cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
+#include <stdlib.h>
+#include <dirent.h>
+#include <cephfs/libcephfs.h>
+
+// Types and constants are copied from libcephfs.h with added "_" as prefix. This
+// prevents redefinition of the types on libcephfs versions that have them
+// already.
+
+typedef struct {
+  struct dirent dir_entry;
+  uint64_t snapid;
+} _ceph_snapdiff_entry_t;
+
+typedef struct {
+  struct ceph_mount_info* cmount;
+  struct ceph_dir_result* dir1;
+  struct ceph_dir_result* dir_aux;
+} _ceph_snapdiff_info;
+
+// open_snapdiff_fn matches the open_snapdiff function signature.
+typedef int(*open_snapdiff_fn)(struct ceph_mount_info* cmount,
+                                  const char* root_path,
+                                  const char* rel_path,
+                                  const char* snap1,
+                                  const char* snap2,
+                                  _ceph_snapdiff_info* out);
+
+// open_snapdiff_dlsym take *fn as open_snapdiff_fn and calls the dynamically loaded
+// open_snapdiff function passed as 1st argument.
+static inline int open_snapdiff_dlsym(void *fn,
+                                  struct ceph_mount_info* cmount,
+                                  const char* root_path,
+                                  const char* rel_path,
+                                  const char* snap1,
+                                  const char* snap2,
+                                  _ceph_snapdiff_info* out) {
+	// cast function pointer fn to open_snapdiff and call the function
+	return ((open_snapdiff_fn) fn)(cmount, root_path, rel_path, snap1, snap2, out);
+}
+
+// readdir_snapdiff_fn matches the readdir_snapdiff function signature.
+typedef int(*readdir_snapdiff_fn)(_ceph_snapdiff_info* snapdiff,
+                                  _ceph_snapdiff_entry_t* out);
+
+// readdir_snapdiff_dlsym take *fn as readdir_snapdiff_fn and calls the dynamically loaded
+// readdir_snapdiff function passed as 1st argument.
+static inline int readdir_snapdiff_dlsym(void *fn,
+                                  _ceph_snapdiff_info* snapdiff,
+                                  _ceph_snapdiff_entry_t* out) {
+	// cast function pointer fn to readdir_snapdiff and call the function
+	return ((readdir_snapdiff_fn) fn)(snapdiff, out);
+}
+
+// close_snapdiff_fn matches the close_snapdiff function signature.
+typedef int(*close_snapdiff_fn)(_ceph_snapdiff_info* snapdiff);
+
+// close_snapdiff_dlsym take *fn as close_snapdiff_fn and calls the dynamically loaded
+// close_snapdiff function passed as 1st argument.
+static inline int close_snapdiff_dlsym(void *fn,
+                                  _ceph_snapdiff_info* snapdiff) {
+	// cast function pointer fn to close_snapdiff and call the function
+	return ((close_snapdiff_fn) fn)(snapdiff);
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/dlsym"
+)
+
+var (
+	cephOpenSnapDiffOnce    sync.Once
+	cephReaddirSnapDiffOnce sync.Once
+	cephCloseSnapDiffOnce   sync.Once
+	cephOpenSnapDiff        unsafe.Pointer
+	cephReaddirSnapDiff     unsafe.Pointer
+	cephCloseSnapDiff       unsafe.Pointer
+	cephOpenSnapDiffErr     error
+	cephReaddirSnapDiffErr  error
+	cephCloseSnapDiffErr    error
+)
+
+// SnapDiffInfo is a handle to a snapshot diff API.
+type SnapDiffInfo struct {
+	cMount *MountInfo
+	dir1   *Directory
+	dirAux *Directory
+}
+
+// SnapDiffEntry is a single entry in the snapshot diff.
+// It contains a DirEntry and the ID of the snapshot to
+// which the directory belongs.
+type SnapDiffEntry struct {
+	DirEntry *DirEntry
+	SnapID   uint64
+}
+
+// SnapDiffConfig is used to define the parameters of a open_snapdiff call.
+// Snapshot Delta is generated between the passed snapshots snap1 and snap2.
+// All fields must be specified before passing to OpenSnapDiff().
+type SnapDiffConfig struct {
+	// CMount is the ceph mount handle that will be used for snap.diff retrieval.
+	CMount *MountInfo
+	// RootPath represents the root path for snapshots-in-question.
+	RootPath string
+	// RelPath is the subpath under the root to build delta for.
+	RelPath string
+	// Snap1 is the first snapshot name.
+	Snap1 string
+	// Snap2 is the second snapshot name.
+	Snap2 string
+}
+
+// OpenSnapDiff opens a snapshot diff stream to get snapshots delta
+// and returns a SnapDiffInfo struct containing the diff information.
+//
+// Implements:
+//
+//	int ceph_open_snapdiff(struct ceph_mount_info* cmount,
+//	                       const char* root_path,
+//	                       const char* rel_path,
+//	                       const char* snap1,
+//	                       const char* snap2,
+//	                       struct ceph_snapdiff_info* out);
+func OpenSnapDiff(config SnapDiffConfig) (*SnapDiffInfo, error) {
+	if config.CMount == nil || config.RootPath == "" || config.RelPath == "" ||
+		config.Snap1 == "" || config.Snap2 == "" {
+		return nil, errInvalid
+	}
+
+	cephOpenSnapDiffOnce.Do(func() {
+		cephOpenSnapDiff, cephOpenSnapDiffErr = dlsym.LookupSymbol("ceph_open_snapdiff")
+	})
+
+	if cephOpenSnapDiffErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrNotImplemented, cephOpenSnapDiffErr)
+	}
+
+	rawCephSnapDiffInfo := &C._ceph_snapdiff_info{}
+
+	ret := C.open_snapdiff_dlsym(
+		cephOpenSnapDiff,
+		config.CMount.mount,
+		C.CString(config.RootPath),
+		C.CString(config.RelPath),
+		C.CString(config.Snap1),
+		C.CString(config.Snap2),
+		rawCephSnapDiffInfo)
+
+	if ret != 0 {
+		return nil, getError(ret)
+	}
+
+	mountInfo := &MountInfo{
+		mount: rawCephSnapDiffInfo.cmount,
+	}
+	cephSnapDiffInfo := &SnapDiffInfo{
+		cMount: mountInfo,
+		dir1: &Directory{
+			mount: mountInfo,
+			dir:   rawCephSnapDiffInfo.dir1,
+		},
+		dirAux: &Directory{
+			mount: mountInfo,
+			dir:   rawCephSnapDiffInfo.dir_aux,
+		},
+	}
+
+	return cephSnapDiffInfo, nil
+}
+
+// validate checks that the SnapDiffInfo struct is valid.
+func (info *SnapDiffInfo) validate() error {
+	if info.cMount == nil || info.dir1 == nil || info.dirAux == nil {
+		return errInvalid
+	}
+
+	return nil
+}
+
+// Readdir returns the next entry in the snapshot diff stream.
+// If there are no more entries, it returns (nil, nil).
+//
+// Implements:
+//
+//	int ceph_readdir_snapdiff(struct ceph_snapdiff_info* snapdiff,
+//	                           struct ceph_snapdiff_entry_t* out);
+func (info *SnapDiffInfo) Readdir() (*SnapDiffEntry, error) {
+	if err := info.validate(); err != nil {
+		return nil, err
+	}
+
+	cephReaddirSnapDiffOnce.Do(func() {
+		cephReaddirSnapDiff, cephReaddirSnapDiffErr = dlsym.LookupSymbol("ceph_readdir_snapdiff")
+	})
+	if cephReaddirSnapDiffErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrNotImplemented, cephReaddirSnapDiffErr)
+	}
+
+	rawSnapDiffEntry := &C._ceph_snapdiff_entry_t{}
+	rawSnapDiffInfo := &C._ceph_snapdiff_info{
+		cmount:  info.cMount.mount,
+		dir1:    info.dir1.dir,
+		dir_aux: info.dirAux.dir,
+	}
+
+	ret := C.readdir_snapdiff_dlsym(
+		cephReaddirSnapDiff,
+		rawSnapDiffInfo,
+		rawSnapDiffEntry)
+	if ret < 0 {
+		return nil, getError(ret)
+	}
+	if ret == 0 {
+		// return 0 indicates there is not more entries to return.
+		return nil, nil
+	}
+
+	snapDiffEntry := &SnapDiffEntry{
+		DirEntry: toDirEntry(&rawSnapDiffEntry.dir_entry),
+		SnapID:   uint64(rawSnapDiffEntry.snapid),
+	}
+	return snapDiffEntry, nil
+}
+
+// Close closes the snapshot diff handle.
+//
+// Implements:
+//
+//	int ceph_close_snapdiff(struct ceph_snapdiff_info* snapdiff);
+func (info *SnapDiffInfo) Close() error {
+	if err := info.validate(); err != nil {
+		return err
+	}
+
+	cephCloseSnapDiffOnce.Do(func() {
+		cephCloseSnapDiff, cephCloseSnapDiffErr = dlsym.LookupSymbol("ceph_close_snapdiff")
+	})
+	if cephCloseSnapDiffErr != nil {
+		return fmt.Errorf("%w: %w", ErrNotImplemented, cephCloseSnapDiffErr)
+	}
+
+	rawCephSnapDiffInfo := &C._ceph_snapdiff_info{
+		cmount:  info.cMount.mount,
+		dir1:    info.dir1.dir,
+		dir_aux: info.dirAux.dir,
+	}
+	ret := C.close_snapdiff_dlsym(
+		cephCloseSnapDiff,
+		rawCephSnapDiffInfo)
+
+	if ret != 0 {
+		return getError(ret)
+	}
+
+	return nil
+}

--- a/cephfs/snap_diff_test.go
+++ b/cephfs/snap_diff_test.go
@@ -1,0 +1,143 @@
+//go:build ceph_preview
+
+package cephfs
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	fsadmin "github.com/ceph/go-ceph/cephfs/admin"
+	"github.com/ceph/go-ceph/internal/admintest"
+	"github.com/ceph/go-ceph/internal/dlsym"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	radosConnector = admintest.NewConnector()
+)
+
+// NoGroup should be used when an optional subvolume group name is not
+// specified.
+const NoGroup = ""
+
+func TestSnapDiff(t *testing.T) {
+	_, cephOpenSnapDiffErr := dlsym.LookupSymbol("ceph_open_snapdiff")
+	if cephOpenSnapDiffErr != nil {
+		t.Logf("skipping SnapDiff tests: ceph_open_snapdiff not found: %v", cephOpenSnapDiffErr)
+
+		return
+	}
+
+	fsa := fsadmin.NewFromConn(radosConnector.Get(t))
+	volume := "cephfs"
+
+	subname := "SubVol1"
+	err := fsa.CreateSubVolume(volume, NoGroup, subname, nil)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolume(volume, NoGroup, subname)
+		assert.NoError(t, err)
+	}()
+
+	subVolPath, err := fsa.SubVolumePath(volume, NoGroup, subname)
+	assert.NoError(t, err)
+	subVolRootPath := "/volumes/_nogroup/SubVol1"
+	relPath := strings.TrimPrefix(subVolPath, subVolRootPath)
+
+	mount := fsConnect(t)
+	defer fsDisconnect(t, mount)
+
+	f1name := "file-1.txt"
+	f1path := path.Join(subVolPath, f1name)
+	f1, err := mount.Open(f1path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	assert.NoError(t, err)
+	assert.NotNil(t, f1)
+	err = f1.Close()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, mount.Unlink(f1path))
+	}()
+
+	snap1 := "Snap1"
+	err = fsa.CreateSubVolumeSnapshot(volume, NoGroup, subname, snap1)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeSnapshot(volume, NoGroup, subname, snap1)
+		assert.NoError(t, err)
+	}()
+
+	snap2 := "Snap2"
+	err = fsa.CreateSubVolumeSnapshot(volume, NoGroup, subname, snap2)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeSnapshot(volume, NoGroup, subname, snap2)
+		assert.NoError(t, err)
+	}()
+
+	changedFiles := getChangedFiles(t, SnapDiffConfig{
+		CMount:   mount,
+		RootPath: subVolRootPath,
+		RelPath:  relPath,
+		Snap1:    snap1,
+		Snap2:    snap2,
+	})
+	// No changes between the two snapshots.
+	assert.Len(t, changedFiles, 0)
+
+	f2name := "file-2.txt"
+	f2path := path.Join(subVolPath, f2name)
+	f2, err := mount.Open(f2path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	assert.NoError(t, err)
+	assert.NotNil(t, f2)
+	err = f2.Close()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, mount.Unlink(f2path))
+	}()
+
+	snap3 := "Snap3"
+	err = fsa.CreateSubVolumeSnapshot(volume, NoGroup, subname, snap3)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeSnapshot(volume, NoGroup, subname, snap3)
+		assert.NoError(t, err)
+	}()
+
+	changedFiles = getChangedFiles(t, SnapDiffConfig{
+		CMount:   mount,
+		RootPath: subVolRootPath,
+		RelPath:  relPath,
+		Snap1:    snap2,
+		Snap2:    snap3,
+	})
+	// one changed file between the two snapshots.
+	assert.Len(t, changedFiles, 1)
+	assert.Equal(t, changedFiles[0], f2name)
+}
+
+func getChangedFiles(t *testing.T, snapDiffConfig SnapDiffConfig) []string {
+	diff, err := OpenSnapDiff(snapDiffConfig)
+	assert.NoError(t, err)
+	assert.NotNil(t, diff)
+	defer func() {
+		assert.NoError(t, diff.Close())
+	}()
+
+	changedFiles := []string{}
+	for {
+		diffEntry, err := diff.Readdir()
+		assert.NoError(t, err)
+
+		if diffEntry == nil {
+			break
+		}
+		if diffEntry.DirEntry.Name() == "." || diffEntry.DirEntry.Name() == ".." {
+			continue
+		}
+		changedFiles = append(changedFiles, diffEntry.DirEntry.Name())
+	}
+
+	return changedFiles
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -384,6 +384,24 @@
         "comment": "Futimes changes file/directory last access and modification times, here times param\nis an array of Timeval struct type having length 2, where times[0] represents the access time\nand times[1] represents the modification time.\n\nImplements:\n\n\tint ceph_futimes(struct ceph_mount_info *cmount, int fd, struct timeval times[2]);\n",
         "added_in_version": "v0.35.0",
         "expected_stable_version": "v0.37.0"
+      },
+      {
+        "name": "OpenSnapDiff",
+        "comment": "OpenSnapDiff opens a snapshot diff stream to get snapshots delta\nand returns a SnapDiffInfo struct containing the diff information.\n\nImplements:\n\n\tint ceph_open_snapdiff(struct ceph_mount_info* cmount,\n\t                       const char* root_path,\n\t                       const char* rel_path,\n\t                       const char* snap1,\n\t                       const char* snap2,\n\t                       struct ceph_snapdiff_info* out);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "SnapDiffInfo.Readdir",
+        "comment": "Readdir returns the next entry in the snapshot diff stream.\nIf there are no more entries, it returns (nil, nil).\n\nImplements:\n\n\tint ceph_readdir_snapdiff(struct ceph_snapdiff_info* snapdiff,\n\t                           struct ceph_snapdiff_entry_t* out);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "SnapDiffInfo.Close",
+        "comment": "Close closes the snapshot diff handle.\n\nImplements:\n\n\tint ceph_close_snapdiff(struct ceph_snapdiff_info* snapdiff);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -12,6 +12,9 @@ File.Fd | v0.35.0 | v0.37.0 |
 File.Futime | v0.35.0 | v0.37.0 | 
 File.Futimens | v0.35.0 | v0.37.0 | 
 File.Futimes | v0.35.0 | v0.37.0 | 
+OpenSnapDiff | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+SnapDiffInfo.Readdir | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+SnapDiffInfo.Close | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: cephfs/admin
 


### PR DESCRIPTION
This commit adds support for cephfs snap diff
APIs which gives a list of changed files between
two snapshots.

Refer:
- cephfs.h
  - https://github.com/ceph/ceph/blob/2de95964cd9797d77385f98d9efe6946259f7bcc/src/include/cephfs/libcephfs.h#L117-L120 
  - https://github.com/ceph/ceph/blob/2de95964cd9797d77385f98d9efe6946259f7bcc/src/include/cephfs/libcephfs.h#L643-L650 
- cephfs.cc
  - https://github.com/ceph/ceph/blob/2de95964cd9797d77385f98d9efe6946259f7bcc/src/include/cephfs/libcephfs.h#L729-L753 
 
fixes #1087 

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
