### PR TITLE
Dockerfile: Bump golang version to 1.24

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -29,7 +29,7 @@ RUN true \
     && yum clean all \
     && true
 
-ARG GO_VERSION=1.23.7
+ARG GO_VERSION=1.24.9
 ENV GO_VERSION=${GO_VERSION}
 ARG GOARCH
 ENV GOARCH=${GOARCH}


### PR DESCRIPTION
Bump the default Go version in test container to 1.24.9 which is the oldest supported as of now. This change does not affect the CI because it always queries for the latest version. But users who build directly from the Dockerfile can avoid an extra toolchain download when working with go‑ceph since the minimum Go version required by go.mod is 1.24.0.
