### PR TITLE
cephfs: add support for cephfs file block diff api

### DIFF
--- a/cephfs/block_diff.go
+++ b/cephfs/block_diff.go
@@ -1,0 +1,326 @@
+//go:build ceph_preview
+
+package cephfs
+
+/*
+#cgo LDFLAGS: -lcephfs
+#cgo CPPFLAGS: -D_FILE_OFFSET_BITS=64
+#include <stdlib.h>
+#include <dirent.h>
+#include <cephfs/libcephfs.h>
+
+// Types and constants are copied from libcephfs.h with added "_" as prefix. This
+// prevents redefinition of the types on libcephfs versions that have them
+// already.
+
+// struct ceph_file_blockdiff_result lacks a definition, so create an alias and
+// treat it as opaque.
+typedef struct _ceph_file_blockdiff_result _ceph_file_blockdiff_result;
+
+typedef struct
+{
+  struct ceph_mount_info* cmount;
+  struct _ceph_file_blockdiff_result* blockp;
+} _ceph_file_blockdiff_info;
+
+typedef struct
+{
+  uint64_t offset;
+  uint64_t len;
+} _cblock;
+
+typedef struct
+{
+  uint64_t num_blocks;
+  struct _cblock *b;
+} _ceph_file_blockdiff_changedblocks;
+
+// ceph_file_blockdiff_init_fn matches the ceph_file_blockdiff_init function signature.
+typedef int(*ceph_file_blockdiff_init_fn)(struct ceph_mount_info* cmount,
+                                  const char* root_path,
+                                  const char* rel_path,
+                                  const char* snap1,
+                                  const char* snap2,
+                                  _ceph_file_blockdiff_info* out_info);
+
+// ceph_file_blockdiff_init_dlsym take *fn as ceph_file_blockdiff_init and calls the dynamically loaded
+// ceph_file_blockdiff_init function passed as 1st argument.
+static inline int ceph_file_blockdiff_init_dlsym(void *fn,
+                                  struct ceph_mount_info* cmount,
+                                  const char* root_path,
+                                  const char* rel_path,
+                                  const char* snap1,
+                                  const char* snap2,
+                                  _ceph_file_blockdiff_info* out_info) {
+	// cast function pointer fn to ceph_file_blockdiff_init and call the function
+	return ((ceph_file_blockdiff_init_fn) fn)(cmount, root_path, rel_path, snap1, snap2, out_info);
+}
+
+// ceph_file_blockdiff_fn matches the ceph_file_blockdiff function signature.
+typedef int(*ceph_file_blockdiff_fn)(_ceph_file_blockdiff_info* info,
+                                  _ceph_file_blockdiff_changedblocks* blocks);
+
+// ceph_file_blockdiff_dlsym take *fn as ceph_file_blockdiff and calls the dynamically loaded
+// ceph_file_blockdiff function passed as 1st argument.
+static inline int ceph_file_blockdiff_dlsym(void *fn,
+                                  _ceph_file_blockdiff_info* info,
+                                  _ceph_file_blockdiff_changedblocks* blocks) {
+	// cast function pointer fn to ceph_file_blockdiff and call the function
+	return ((ceph_file_blockdiff_fn) fn)(info, blocks);
+}
+
+// ceph_free_file_blockdiff_buffer_fn matches the ceph_free_file_blockdiff_buffer function signature.
+typedef void(*ceph_free_file_blockdiff_buffer_fn)(_ceph_file_blockdiff_changedblocks* blocks);
+
+// ceph_free_file_blockdiff_buffer_dlsym take *fn as ceph_free_file_blockdiff_buffer and calls the dynamically loaded
+// ceph_free_file_blockdiff_buffer function passed as 1st argument.
+static inline void ceph_free_file_blockdiff_buffer_dlsym(void *fn,
+                                  _ceph_file_blockdiff_changedblocks* blocks) {
+	// cast function pointer fn to ceph_free_file_blockdiff_buffer and call the function
+	((ceph_free_file_blockdiff_buffer_fn) fn)(blocks);
+}
+
+// ceph_file_blockdiff_finish_fn matches the ceph_file_blockdiff_finish function signature.
+typedef int(*ceph_file_blockdiff_finish_fn)(_ceph_file_blockdiff_info* info);
+
+// ceph_file_blockdiff_finish_dlsym take *fn as ceph_file_blockdiff_finish and calls the dynamically loaded
+// ceph_file_blockdiff_finish function passed as 1st argument.
+static inline int ceph_file_blockdiff_finish_dlsym(void *fn,
+                                  _ceph_file_blockdiff_info* info) {
+	// cast function pointer fn to ceph_file_blockdiff_finish and call the function
+	return ((ceph_file_blockdiff_finish_fn) fn)(info);
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/dlsym"
+)
+
+var (
+	cephFileBlockDiffInitOnce       sync.Once
+	cephFileBlockDiffOnce           sync.Once
+	cephFreeFileBlockDiffBufferOnce sync.Once
+	cephFileBlockDiffFinishOnce     sync.Once
+
+	cephFileBlockDiffInitErr       error
+	cephFileBlockDiffErr           error
+	cephFreeFileBlockDiffBufferErr error
+	cephFileBlockDiffFinishErr     error
+
+	cephFileBlockDiffInit       unsafe.Pointer
+	cephFileBlockDiff           unsafe.Pointer
+	cephFreeFileBlockDiffBuffer unsafe.Pointer
+	cephFileBlockDiffFinish     unsafe.Pointer
+)
+
+// FileBlockDiffInfo is a struct that holds the block diff stream handle.
+type FileBlockDiffInfo struct {
+	cMount                  *MountInfo
+	cephFileBlockDiffResult *C._ceph_file_blockdiff_result
+	more                    bool
+}
+
+// ChangedBlock is a struct that holds the offset and length of a block.
+type ChangedBlock struct {
+	Offset uint64
+	Len    uint64
+}
+
+// FileBlockDiffChangedBlocks is a struct that holds the number of blocks
+// and list of Changed Blocks.
+type FileBlockDiffChangedBlocks struct {
+	NumBlocks     uint64
+	ChangedBlocks []ChangedBlock
+}
+
+// FileBlockDiffInit initializes the block diff stream to get file block deltas.
+// It takes the mount handle, root path, relative path, snapshot names and returns
+// a FileBlockDiffInfo struct that contains the block diff stream handle.
+//
+// Implements:
+//
+//	int ceph_file_blockdiff_init(struct ceph_mount_info* cmount,
+//				     const char* root_path,
+//				     const char* rel_path,
+//				     const char* snap1,
+//				     const char* snap2,
+//				     struct ceph_file_blockdiff_info* out_info);
+func FileBlockDiffInit(mount *MountInfo, rootPath, relPath, snap1, snap2 string) (*FileBlockDiffInfo, error) {
+	if mount == nil || rootPath == "" || relPath == "" ||
+		snap1 == "" || snap2 == "" {
+		return nil, errInvalid
+	}
+	cRootPath := C.CString(rootPath)
+	cRelPath := C.CString(relPath)
+	cSnap1 := C.CString(snap1)
+	cSnap2 := C.CString(snap2)
+	defer func() {
+		C.free(unsafe.Pointer(cRootPath))
+		C.free(unsafe.Pointer(cRelPath))
+		C.free(unsafe.Pointer(cSnap1))
+		C.free(unsafe.Pointer(cSnap2))
+	}()
+
+	// Load the ceph_file_blockdiff_init function from the shared library.
+	cephFileBlockDiffInitOnce.Do(func() {
+		cephFileBlockDiffInit, cephFileBlockDiffInitErr = dlsym.LookupSymbol("ceph_file_blockdiff_init")
+	})
+	if cephFileBlockDiffInitErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrNotImplemented, cephFileBlockDiffInitErr)
+	}
+
+	rawCephBlockDiffInfo := &C._ceph_file_blockdiff_info{}
+
+	// Call the ceph_file_blockdiff_init function with the provided arguments.
+	ret := C.ceph_file_blockdiff_init_dlsym(cephFileBlockDiffInit,
+		mount.mount,
+		cRootPath,
+		cRelPath,
+		cSnap1,
+		cSnap2,
+		rawCephBlockDiffInfo,
+	)
+	if ret != 0 {
+		return nil, getError(ret)
+	}
+
+	mountInfo := &MountInfo{
+		mount: rawCephBlockDiffInfo.cmount,
+	}
+
+	cephFileBlockDiffInfo := &FileBlockDiffInfo{
+		cMount:                  mountInfo,
+		cephFileBlockDiffResult: rawCephBlockDiffInfo.blockp,
+		more:                    true,
+	}
+
+	return cephFileBlockDiffInfo, nil
+}
+
+// validate checks if the FileBlockDiffInfo struct is valid.
+func (info *FileBlockDiffInfo) validate() error {
+	if info.cMount == nil || info.cephFileBlockDiffResult == nil {
+		return errInvalid
+	}
+
+	return nil
+}
+
+// Read retrieves the next set of changed blocks for a file.
+//
+// Implements:
+//
+//	int ceph_file_blockdiff(struct ceph_file_blockdiff_info* info,
+//				struct ceph_file_blockdiff_changedblocks* blocks);
+func (info *FileBlockDiffInfo) Read() (*FileBlockDiffChangedBlocks, error) {
+	err := info.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the ceph_file_blockdiff function from the shared library.
+	cephFileBlockDiffOnce.Do(func() {
+		cephFileBlockDiff, cephFileBlockDiffErr = dlsym.LookupSymbol("ceph_file_blockdiff")
+	})
+	if cephFileBlockDiffErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrNotImplemented, cephFileBlockDiffErr)
+	}
+	cephFreeFileBlockDiffBufferOnce.Do(func() {
+		cephFreeFileBlockDiffBuffer, cephFreeFileBlockDiffBufferErr = dlsym.LookupSymbol("ceph_free_file_blockdiff_buffer")
+	})
+	if cephFreeFileBlockDiffBufferErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrNotImplemented, cephFreeFileBlockDiffBufferErr)
+	}
+
+	rawCephBlockDiffChangedBlocks := &C._ceph_file_blockdiff_changedblocks{}
+	rawCephFileBlockDiffInfo := &C._ceph_file_blockdiff_info{
+		cmount: info.cMount.mount,
+		blockp: info.cephFileBlockDiffResult,
+	}
+
+	// Call the ceph_file_blockdiff function with the provided arguments.
+	ret := C.ceph_file_blockdiff_dlsym(cephFileBlockDiff,
+		rawCephFileBlockDiffInfo,
+		rawCephBlockDiffChangedBlocks,
+	)
+	if ret < 0 {
+		return nil, getError(ret)
+	}
+	// ret > 0 indicates that there are more entries after this call.
+	info.more = (ret > 0)
+
+	// Free the memory allocated for the blocks by ceph_file_blockdiff.
+	defer C.ceph_free_file_blockdiff_buffer_dlsym(cephFreeFileBlockDiffBuffer,
+		rawCephBlockDiffChangedBlocks)
+
+	cNumBlocks := uint64(rawCephBlockDiffChangedBlocks.num_blocks)
+
+	// Convert the C struct to Go struct.
+	cBlocks := make([]ChangedBlock, int(cNumBlocks))
+	if cNumBlocks == 0 {
+		return &FileBlockDiffChangedBlocks{
+			NumBlocks:     0,
+			ChangedBlocks: cBlocks,
+		}, nil
+	}
+
+	currentCBlock := (*C._cblock)(unsafe.Pointer(rawCephBlockDiffChangedBlocks.b))
+	for i := uint64(0); i < cNumBlocks; i++ {
+		cBlocks[i] = ChangedBlock{
+			Offset: uint64(currentCBlock.offset),
+			Len:    uint64(currentCBlock.len),
+		}
+		currentCBlock = (*C._cblock)(unsafe.Pointer(uintptr(unsafe.Pointer(currentCBlock)) + unsafe.Sizeof(C._cblock{})))
+	}
+
+	return &FileBlockDiffChangedBlocks{
+		NumBlocks:     cNumBlocks,
+		ChangedBlocks: cBlocks,
+	}, nil
+}
+
+// More returns true if there are more entries to read in the block diff stream.
+func (info *FileBlockDiffInfo) More() bool {
+	return info.more
+}
+
+// Close closes the block diff stream.
+//
+// Implements:
+//
+//	int ceph_file_blockdiff_finish(struct ceph_file_blockdiff_info* info);
+func (info *FileBlockDiffInfo) Close() error {
+	err := info.validate()
+	if err != nil {
+		return err
+	}
+
+	// Load the ceph_file_blockdiff_finish function from the shared library.
+	cephFileBlockDiffFinishOnce.Do(func() {
+		cephFileBlockDiffFinish, cephFileBlockDiffFinishErr = dlsym.LookupSymbol("ceph_file_blockdiff_finish")
+	})
+	if cephFileBlockDiffFinishErr != nil {
+		return fmt.Errorf("%w: %w", ErrNotImplemented, cephFileBlockDiffFinishErr)
+	}
+
+	rawCephFileBlockDiffInfo := &C._ceph_file_blockdiff_info{
+		cmount: info.cMount.mount,
+		blockp: info.cephFileBlockDiffResult,
+	}
+
+	// Call the ceph_file_blockdiff_finish function with the provided arguments.
+	ret := C.ceph_file_blockdiff_finish_dlsym(
+		cephFileBlockDiffFinish,
+		rawCephFileBlockDiffInfo,
+	)
+	if ret != 0 {
+		return getError(ret)
+	}
+
+	return nil
+}

--- a/cephfs/block_diff_test.go
+++ b/cephfs/block_diff_test.go
@@ -1,0 +1,164 @@
+//go:build ceph_preview
+
+package cephfs
+
+import (
+	"crypto/rand"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	fsadmin "github.com/ceph/go-ceph/cephfs/admin"
+	"github.com/ceph/go-ceph/internal/dlsym"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileBlockDiff(t *testing.T) {
+	_, cephFileBlockDiffInitErr = dlsym.LookupSymbol("ceph_file_blockdiff_init")
+	if cephFileBlockDiffInitErr != nil {
+		t.Logf("skipping FileBlockDiff tests: ceph_file_blockdiff_init not found: %v", cephFileBlockDiffInitErr)
+		return
+	}
+
+	fsa := fsadmin.NewFromConn(radosConnector.Get(t))
+	volume := "cephfs"
+
+	subname := "SubVol1"
+	err := fsa.CreateSubVolume(volume, NoGroup, subname, nil)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolume(volume, NoGroup, subname)
+		assert.NoError(t, err)
+	}()
+
+	subVolPath, err := fsa.SubVolumePath(volume, NoGroup, subname)
+	assert.NoError(t, err)
+	subVolRootPath := "/volumes/_nogroup/SubVol1"
+
+	mount := fsConnect(t)
+	defer fsDisconnect(t, mount)
+
+	f1name := "file-1.txt"
+	f1path := path.Join(subVolPath, f1name)
+	relPath := strings.TrimPrefix(f1path, subVolRootPath)
+
+	// 4MB buffer
+	randData := make([]byte, 4*1024*1024)
+	_, err = rand.Read(randData) // read 4MB of random data
+	assert.NoError(t, err)
+
+	// Create a file.
+	f1, err := mount.Open(f1path, os.O_RDWR|os.O_CREATE, 0644)
+	assert.NoError(t, err)
+	assert.NotNil(t, f1)
+
+	// Write 4MB random data to the file.
+	_, err = f1.Write(randData)
+	assert.NoError(t, err)
+	assert.NoError(t, f1.Sync())
+	assert.NoError(t, f1.Close())
+	defer func() {
+		assert.NoError(t, mount.Unlink(f1path))
+	}()
+
+	snap1 := "Snap1"
+	err = fsa.CreateSubVolumeSnapshot(volume, NoGroup, subname, snap1)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeSnapshot(volume, NoGroup, subname, snap1)
+		assert.NoError(t, err)
+	}()
+
+	snap2 := "Snap2"
+	err = fsa.CreateSubVolumeSnapshot(volume, NoGroup, subname, snap2)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeSnapshot(volume, NoGroup, subname, snap2)
+		assert.NoError(t, err)
+	}()
+
+	// Nothing has changed between snap1 and snap2.
+	changedBlocks := getChangedBlocks(t, mount, subVolRootPath, relPath, snap1, snap2)
+	assert.NotNil(t, changedBlocks)
+	assert.Equal(t, 0, len(*changedBlocks))
+
+	_, err = rand.Read(randData) // read 4MB of random data
+	assert.NoError(t, err)
+
+	// Write 4MB random data to the file.
+	f1, err = mount.Open(f1path, os.O_RDWR, 0644)
+	assert.NoError(t, err)
+	assert.NotNil(t, f1)
+	_, err = f1.WriteAt(randData, 0)
+	assert.NoError(t, err)
+	assert.NoError(t, f1.Sync())
+	assert.NoError(t, f1.Close())
+
+	snap3 := "Snap3"
+	err = fsa.CreateSubVolumeSnapshot(volume, NoGroup, subname, snap3)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeSnapshot(volume, NoGroup, subname, snap3)
+		assert.NoError(t, err)
+	}()
+
+	// 4MB at offset 0 has changed between snap2 and snap3.
+	changedBlocks = getChangedBlocks(t, mount, subVolRootPath, relPath, snap2, snap3)
+	assert.NotNil(t, changedBlocks)
+	assert.Equal(t, len(*changedBlocks), 1)
+	assert.Equal(t, (*changedBlocks)[0].Offset, uint64(0))
+	assert.Equal(t, (*changedBlocks)[0].Len, uint64(4*1024*1024))
+
+	// read 4MB of random data
+	_, err = rand.Read(randData)
+	assert.NoError(t, err)
+
+	// Write at multiple intervals to the file.
+	f1, err = mount.Open(f1path, os.O_RDWR, 0644)
+	assert.NoError(t, err)
+	assert.NotNil(t, f1)
+	// write 32 1 byte random data at offset 0 with gap of 20 bytes
+	for i := 0; i < 32; i++ {
+		_, err = f1.WriteAt(randData[i:i+1], int64(i*21))
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, f1.Sync())
+	assert.NoError(t, f1.Close())
+
+	snap4 := "Snap4"
+	err = fsa.CreateSubVolumeSnapshot(volume, NoGroup, subname, snap4)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeSnapshot(volume, NoGroup, subname, snap4)
+		assert.NoError(t, err)
+	}()
+
+	// test for multiple changed blocks between snap3 and snap4.
+	changedBlocks = getChangedBlocks(t, mount, subVolRootPath, relPath, snap3, snap4)
+	assert.NotNil(t, changedBlocks)
+	assert.Equal(t, len(*changedBlocks), 32)
+}
+
+func getChangedBlocks(t *testing.T,
+	mount *MountInfo, rootPath, relPath, snap1, snap2 string) *[]ChangedBlock {
+	fileBlockDiffInfo, err := FileBlockDiffInit(mount, rootPath, relPath, snap1, snap2)
+	assert.NoError(t, err)
+	changedBlocksList := make([]ChangedBlock, 0)
+	defer func() {
+		assert.NoError(t, fileBlockDiffInfo.Close())
+	}()
+	for {
+		fileChangedBlocksInfo, err := fileBlockDiffInfo.Read()
+		assert.NoError(t, err)
+		if fileChangedBlocksInfo == nil || fileChangedBlocksInfo.NumBlocks == 0 {
+			break
+		}
+		changedBlocksList = append(changedBlocksList, fileChangedBlocksInfo.ChangedBlocks...)
+		if !fileBlockDiffInfo.More() {
+			break
+		}
+	}
+
+	return &changedBlocksList
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -402,6 +402,30 @@
         "comment": "Close closes the snapshot diff handle.\n\nImplements:\n\n\tint ceph_close_snapdiff(struct ceph_snapdiff_info* snapdiff);\n",
         "added_in_version": "v0.37.0",
         "expected_stable_version": "v0.39.0"
+      },
+      {
+        "name": "FileBlockDiffInit",
+        "comment": "FileBlockDiffInit initializes the block diff stream to get file block deltas.\nIt takes the mount handle, root path, relative path, snapshot names and returns\na FileBlockDiffInfo struct that contains the block diff stream handle.\n\nImplements:\n\n\t    int ceph_file_blockdiff_init(\n\t\t    struct ceph_mount_info* cmount,\n\t\t\tconst char* root_path,\n\t\t\tconst char* rel_path,\n\t\t\tconst char* snap1,\n\t\t\tconst char* snap2,\n\t\t\tstruct ceph_file_blockdiff_info* out_info);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "FileBlockDiffInfo.Close",
+        "comment": "Close closes the block diff stream.\n\nImplements:\n\nint ceph_file_blockdiff_finish(struct ceph_file_blockdiff_info* info);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "FileBlockDiffInfo.More",
+        "comment": "More returns true if there are more entries to read in the block diff stream.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "FileBlockDiffInfo.Read",
+        "comment": "Read retrieves the next set of file block diffs.\nIt returns\n  - FileBlockDiffChangedBlocks struct that contains the number of blocks and list of ChangedBlocks and error if any.\n\nImplements:\n\n\tint ceph_file_blockdiff(struct ceph_file_blockdiff_info* info,\n\t\t\t\t\t   \t\tstruct ceph_file_blockdiff_changedblocks* blocks);\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -11,6 +11,10 @@ Name | Added in Version | Expected Stable Version |
 OpenSnapDiff | v0.37.0 | v0.39.0 | 
 SnapDiffInfo.Readdir | v0.37.0 | v0.39.0 | 
 SnapDiffInfo.Close | v0.37.0 | v0.39.0 | 
+FileBlockDiffInit | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+FileBlockDiffInfo.Close | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+FileBlockDiffInfo.More | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+FileBlockDiffInfo.Read | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: cephfs/admin
 


### PR DESCRIPTION
cephfs: add support for cephfs file block diff api 

This commit adds support for cephfs file block diff
APIs which gives a list of changed blocks with in a
file between two snapshots.

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
