### PR TITLE
README.md: point to ceph slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,5 +158,6 @@ different channels:
   [user's mailing list](https://lists.ceph.io/hyperkitty/list/ceph-users@ceph.io/)
   and [dev list](https://lists.ceph.io/hyperkitty/list/dev@ceph.io/)
   and we also announce our releases on those lists
-* You can sometimes find us in the
-  [#ceph-devel IRC channel](https://ceph.io/irc/) - hours may vary
+* You can sometimes chat with us in realtime in the
+  [#go-ceph Slack channel](https://ceph.io/en/community/connect/) or
+  [#ceph-devel Slack channel](https://ceph.io/en/community/connect/)


### PR DESCRIPTION
For better or for worse much of the ceph community communication is being done on Slack now. Personally, I haven't used IRC in a couple of years at least.

The Ceph community manager recently created a dedicated `#go-ceph` channel at the request of a community member.

Let's update the readme to point at slack and the new channel

