### PR TITLE
cephfs: fix volumeInfo mon address check for ceph main version

### DIFF
--- a/cephfs/admin/volume_info_test.go
+++ b/cephfs/admin/volume_info_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ceph/go-ceph/internal/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +20,11 @@ func TestFetchVolumeInfo(t *testing.T) {
 		vinfo, err := fsa.FetchVolumeInfo(volume)
 		assert.NoError(t, err)
 		assert.NotNil(t, vinfo)
-		assert.Contains(t, vinfo.MonAddrs[0], "6789")
+		if util.CurrentCephVersion() > util.CephTentacle {
+			assert.Contains(t, vinfo.MonAddrs[0], "3300")
+		} else {
+			assert.Contains(t, vinfo.MonAddrs[0], "6789")
+		}
 		assert.Equal(t, "cephfs_data", vinfo.Pools.DataPool[0].Name)
 	})
 


### PR DESCRIPTION
Ceph has now defaulted to v2 protocol for mons, and as a result the port 3300 is the primary port for mon address in volume info.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs