### PR TITLE
rbd/admin: Remove unused function

### DIFF
--- a/rbd/admin/msschedule_complex_test.go
+++ b/rbd/admin/msschedule_complex_test.go
@@ -4,7 +4,6 @@
 package admin
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -13,13 +12,6 @@ import (
 
 	"github.com/ceph/go-ceph/rbd"
 )
-
-func skipIfQuincy(t *testing.T) {
-	vname := os.Getenv("CEPH_VERSION")
-	if vname == "quincy" {
-		t.Skipf("disabled on ceph %s", vname)
-	}
-}
 
 func TestMirrorSnapshotScheduleStatus(t *testing.T) {
 	// note: the status function doesn't return anything "useful" unless


### PR DESCRIPTION
The only invocation of _skipIfQuincy()_ got removed with 0722af53753bd5b0f83d9c227b8c16d5968de559.