### PR TITLE
rados: Implement Unwrap for OperationError

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1012,6 +1012,9 @@
         "name": "OperationError.Error"
       },
       {
+        "name": "OperationError.Unwrap"
+      },
+      {
         "name": "Version",
         "comment": "Version returns the major, minor, and patch components of the version of\nthe RADOS library linked against.\n"
       },

--- a/rados/operation.go
+++ b/rados/operation.go
@@ -56,6 +56,17 @@ func (e OperationError) Error() string {
 		strings.Join(subErrors, ", "))
 }
 
+func (e OperationError) Unwrap() []error {
+	subErrors := make([]error, 0, len(e.StepErrors)+1)
+	if e.OpError != nil {
+		subErrors = append(subErrors, e.OpError)
+	}
+	for _, es := range e.StepErrors {
+		subErrors = append(subErrors, es)
+	}
+	return subErrors
+}
+
 // opStep provides an interface for types that are tied to the management of
 // data being input or output from write ops and read ops. The steps are
 // meant to simplify the internals of the ops themselves and be exportable when


### PR DESCRIPTION
Exposing the operation and step errors wrapped by the OperationError makes it possible to use for example errors.Is to check the underlying error, and handle it properly.

## Checklist
- [x] Added tests for features and functional changes
- [ ] Public functions and types are documented → _I didn't document `Unwrap` because `Error` isn't documented either. These are quite well-known methods for Go errors._
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview` → _`OperationError.Unwrap` is technically a new API, but I don't believe it should be tagged as preview. Implementing this API for the `OperationError` type is more like a bug fix than a new feature._
- [x] Ran `make api-update` to record new APIs

