### PR TITLE
Dockerfile: Avoid LegacyKeyValueFormat warning

### DIFF
--- a/testing/containers/ceph/Dockerfile
+++ b/testing/containers/ceph/Dockerfile
@@ -46,7 +46,7 @@ RUN true && \
 ENV PATH="${PATH}:/opt/go/bin"
 ENV GOROOT=/opt/go
 ENV GO111MODULE=on
-ENV GOPATH /go
+ENV GOPATH=/go
 ENV GOCACHE=/go/cache
 WORKDIR /go/src/github.com/ceph/go-ceph
 VOLUME /go/src/github.com/ceph/go-ceph


### PR DESCRIPTION
```
1 warning found (use docker --debug to expand):
  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 49)
```