### PR TITLE
rbd/admin: Fix snapshot schedule start-time format

### DIFF
--- a/rbd/admin/msschedule_test.go
+++ b/rbd/admin/msschedule_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -211,7 +212,7 @@ func TestMirrorSnapshotScheduleAddRemove(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("startTime", func(t *testing.T) {
-		stime := StartTime("12:00:00")
+		stime := StartTime(time.Now().Format("2006-01-02T15:04:00"))
 		err := scheduler.Add(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), stime)
 		assert.NoError(t, err)
 		err = scheduler.Remove(NewLevelSpec(defaultPoolName, "", ""), Interval("1d"), stime)


### PR DESCRIPTION
The start‑time argument always accepted an ISO 8601 timestamp, but it wasn’t enforced until it was [fixed](https://github.com/ceph/ceph/pull/66735) recently. Therefore, it now conforms to the requirement in the corresponding tests.

fixes #1233 