### PR TITLE
[cephfs] add subvolumegroup info

### DIFF
--- a/cephfs/admin/subvolumegroup_info.go
+++ b/cephfs/admin/subvolumegroup_info.go
@@ -1,0 +1,50 @@
+//go:build ceph_preview
+
+package admin
+
+// SubVolumeGroupInfo reports various informational values about a subvolume group.
+type SubVolumeGroupInfo struct {
+	Uid          int       `json:"uid"`
+	Gid          int       `json:"gid"`
+	Mode         int       `json:"mode"`
+	BytesPercent string    `json:"bytes_pcent"`
+	BytesUsed    ByteCount `json:"bytes_used"`
+	BytesQuota   QuotaSize `json:"-"`
+	DataPool     string    `json:"data_pool"`
+	Atime        TimeStamp `json:"atime"`
+	Mtime        TimeStamp `json:"mtime"`
+	Ctime        TimeStamp `json:"ctime"`
+	CreatedAt    TimeStamp `json:"created_at"`
+	MonAddrs     []string  `json:"mon_addrs"`
+}
+
+type subVolumeGroupInfoWrapper struct {
+	SubVolumeGroupInfo
+	VBytesQuota *quotaSizePlaceholder `json:"bytes_quota"`
+}
+
+func parseSubVolumeGroupInfo(res response) (*SubVolumeGroupInfo, error) {
+	var info subVolumeGroupInfoWrapper
+	if err := res.NoStatus().Unmarshal(&info).End(); err != nil {
+		return nil, err
+	}
+	if info.VBytesQuota != nil {
+		info.BytesQuota = info.VBytesQuota.Value
+	}
+	return &info.SubVolumeGroupInfo, nil
+}
+
+// SubVolumeGroupInfo returns information about the specified subvolume group.
+//
+// Similar To:
+//
+//	ceph fs subvolumegroup info <volume> <group_name>
+func (fsa *FSAdmin) SubVolumeGroupInfo(volume, name string) (*SubVolumeGroupInfo, error) {
+	res := fsa.marshalMgrCommand(map[string]string{
+		"prefix":     "fs subvolumegroup info",
+		"vol_name":   volume,
+		"group_name": name,
+		"format":     "json",
+	})
+	return parseSubVolumeGroupInfo(res)
+}

--- a/cephfs/admin/subvolumegroup_info_test.go
+++ b/cephfs/admin/subvolumegroup_info_test.go
@@ -1,0 +1,126 @@
+package admin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var sampleSubVolumeGroupInfo1 = []byte(`
+{
+    "atime": "2021-04-19 18:02:11",
+    "bytes_pcent": "undefined",
+    "bytes_quota": "infinite",
+    "bytes_used": 0,
+    "created_at": "2021-04-19 18:02:11",
+    "ctime": "2021-04-19 18:02:11",
+    "data_pool": "cephfs_data",
+    "gid": 0,
+    "mode": 16877,
+    "mon_addrs": [
+        "127.0.0.1:6789"
+    ],
+    "mtime": "2021-04-19 18:02:11",
+    "uid": 0
+}
+`)
+
+var sampleSubVolumeGroupInfo2 = []byte(`
+{
+    "atime": "2021-04-20 10:00:00",
+    "bytes_pcent": "0.00",
+    "bytes_quota": 10737418240,
+    "bytes_used": 1024,
+    "created_at": "2021-04-20 10:00:00",
+    "ctime": "2021-04-20 10:00:00",
+    "data_pool": "cephfs_data",
+    "gid": 100,
+    "mode": 16877,
+    "mon_addrs": [
+        "127.0.0.1:6789"
+    ],
+    "mtime": "2021-04-20 10:00:00",
+    "uid": 100
+}
+`)
+
+var badSampleSubVolumeGroupInfo1 = []byte(`
+{
+    "bytes_quota": "fishy",
+    "uid": 0
+}
+`)
+
+func TestParseSubVolumeGroupInfo(t *testing.T) {
+	R := newResponse
+	t.Run("error", func(t *testing.T) {
+		_, err := parseSubVolumeGroupInfo(R(nil, "", errors.New("gleep glop")))
+		assert.Error(t, err)
+		assert.Equal(t, "gleep glop", err.Error())
+	})
+	t.Run("statusSet", func(t *testing.T) {
+		_, err := parseSubVolumeGroupInfo(R(nil, "unexpected!", nil))
+		assert.Error(t, err)
+	})
+	t.Run("ok", func(t *testing.T) {
+		info, err := parseSubVolumeGroupInfo(R(sampleSubVolumeGroupInfo1, "", nil))
+		assert.NoError(t, err)
+		if assert.NotNil(t, info) {
+			assert.Equal(t, 0, info.Uid)
+			assert.Equal(t, 0, info.Gid)
+			assert.Equal(t, "cephfs_data", info.DataPool)
+			assert.Equal(t, Infinite, info.BytesQuota)
+			assert.Equal(t, ByteCount(0), info.BytesUsed)
+			assert.Equal(t, 1, len(info.MonAddrs))
+			assert.Equal(t, "127.0.0.1:6789", info.MonAddrs[0])
+			assert.Equal(t, 2021, info.CreatedAt.Year())
+		}
+	})
+	t.Run("ok2", func(t *testing.T) {
+		info, err := parseSubVolumeGroupInfo(R(sampleSubVolumeGroupInfo2, "", nil))
+		assert.NoError(t, err)
+		if assert.NotNil(t, info) {
+			assert.Equal(t, 100, info.Uid)
+			assert.Equal(t, 100, info.Gid)
+			assert.Equal(t, ByteCount(10737418240), info.BytesQuota)
+			assert.Equal(t, ByteCount(1024), info.BytesUsed)
+		}
+	})
+	t.Run("invalidBytesQuotaValue", func(t *testing.T) {
+		info, err := parseSubVolumeGroupInfo(R(badSampleSubVolumeGroupInfo1, "", nil))
+		assert.Error(t, err)
+		assert.Nil(t, info)
+	})
+}
+
+func TestSubVolumeGroupInfo(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+	group := "infogrp"
+
+	err := fsa.CreateSubVolumeGroup(volume, group, &SubVolumeGroupOptions{
+		Uid:  200,
+		Gid:  200,
+		Mode: 0755,
+	})
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeGroup(volume, group)
+		assert.NoError(t, err)
+	}()
+
+	info, err := fsa.SubVolumeGroupInfo(volume, group)
+	assert.NoError(t, err)
+	if assert.NotNil(t, info) {
+		assert.Equal(t, 200, info.Uid)
+		assert.Equal(t, 200, info.Gid)
+		assert.NotEmpty(t, info.DataPool)
+		assert.NotEmpty(t, info.MonAddrs)
+	}
+
+	// invalid group name
+	info, err = fsa.SubVolumeGroupInfo(volume, "oops")
+	assert.Error(t, err)
+	assert.Nil(t, info)
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -704,7 +704,14 @@
       }
     ],
     "deprecated_api": [],
-    "preview_api": []
+    "preview_api": [
+      {
+        "name": "FSAdmin.SubVolumeGroupInfo",
+        "comment": "SubVolumeGroupInfo returns information about the specified subvolume group.\n\nSimilar To:\n\n\tceph fs subvolumegroup info <volume> <group_name>\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ]
   },
   "rados": {
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -15,7 +15,11 @@ FileBlockDiffInfo.Read | v0.38.0 | v0.40.0 |
 
 ## Package: cephfs/admin
 
-No Preview/Deprecated APIs found. All APIs are considered stable.
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+FSAdmin.SubVolumeGroupInfo | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: rados
 


### PR DESCRIPTION
Add SubVolumeGroupInfo into the cephfs/admin api.

This is mainly usefull for subvolumegroup size and quota informations.
