### PR TITLE
cephfs: free C.CString allocations in OpenSnapDiff

### DIFF
--- a/cephfs/snap_diff.go
+++ b/cephfs/snap_diff.go
@@ -147,13 +147,22 @@ func OpenSnapDiff(config SnapDiffConfig) (*SnapDiffInfo, error) {
 
 	rawCephSnapDiffInfo := &C._ceph_snapdiff_info{}
 
+	cRootPath := C.CString(config.RootPath)
+	defer C.free(unsafe.Pointer(cRootPath))
+	cRelPath := C.CString(config.RelPath)
+	defer C.free(unsafe.Pointer(cRelPath))
+	cSnap1 := C.CString(config.Snap1)
+	defer C.free(unsafe.Pointer(cSnap1))
+	cSnap2 := C.CString(config.Snap2)
+	defer C.free(unsafe.Pointer(cSnap2))
+
 	ret := C.open_snapdiff_dlsym(
 		cephOpenSnapDiff,
 		config.CMount.mount,
-		C.CString(config.RootPath),
-		C.CString(config.RelPath),
-		C.CString(config.Snap1),
-		C.CString(config.Snap2),
+		cRootPath,
+		cRelPath,
+		cSnap1,
+		cSnap2,
 		rawCephSnapDiffInfo)
 
 	if ret != 0 {


### PR DESCRIPTION
## Summary
`C.CString()` allocates C heap memory that must be freed with `C.free()`. The 4 string allocations passed to `open_snapdiff_dlsym()` are never freed, causing a memory leak on every call. If the function returns early due to an error, all 4 strings leak.

Extracted each `C.CString()` into a named variable with a corresponding `defer C.free()`.

## Test plan
- [ ] Existing snap_diff tests still pass
- [ ] Verify with valgrind/ASAN that the leak is resolved