### PR TITLE
ci: test matrix updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,6 @@ jobs:
         - "reef"
         - "squid"
         - "tentacle"
-        - "pre-reef"
         - "pre-squid"
         - "pre-tentacle"
         - "main"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,9 +77,9 @@ jobs:
         go_version:
         - ${{ needs.go-versions.outputs.latest }}
         include:
-        - ceph_version: "squid"
+        - ceph_version: "tentacle"
           go_version: ${{ needs.go-versions.outputs.prev }}
-        - ceph_version: "squid"
+        - ceph_version: "tentacle"
           go_version: ${{ needs.go-versions.outputs.unstable }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
Refresh parts of the CI matrix:
* remove pre-reef
* update to tentacle for jobs using alternate Go versions

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
