### PR TITLE
nfs: add ApplyExportInfo function

### DIFF
--- a/common/admin/nfs/admin.go
+++ b/common/admin/nfs/admin.go
@@ -7,14 +7,19 @@ import (
 	ccom "github.com/ceph/go-ceph/common/commands"
 )
 
+// Commander interface supports sending commands to Ceph.
+type Commander interface {
+	ccom.RadosBufferCommander
+}
+
 // Admin is used to administer ceph nfs features.
 type Admin struct {
-	conn ccom.RadosCommander
+	conn Commander
 }
 
 // NewFromConn creates an new management object from a preexisting
 // rados connection. The existing connection can be rados.Conn or any
 // type implementing the RadosCommander interface.
-func NewFromConn(conn ccom.RadosCommander) *Admin {
+func NewFromConn(conn Commander) *Admin {
 	return &Admin{conn}
 }

--- a/common/admin/nfs/export.go
+++ b/common/admin/nfs/export.go
@@ -208,10 +208,6 @@ func (nfsa *Admin) ExportInfo(clusterID, pseudoPath string) (ExportInfo, error) 
 /*
 TODO?
 
-'nfs export apply': cluster_id: str, inbuf: str
-"""Create or update an export by `-i <json_or_ganesha_export_file>`"""
-
-
 'nfs export create rgw':
 	   bucket: str,
 	   cluster_id: str,

--- a/common/admin/nfs/export_apply.go
+++ b/common/admin/nfs/export_apply.go
@@ -1,0 +1,56 @@
+//go:build !(nautilus || octopus || pacific || quincy) && ceph_preview
+
+package nfs
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+var errUnknownApplyState = errors.New("apply returned unknown state")
+
+// applyRes is used to parse the result from "nfs export apply" which can
+// modify multiple exports with a single call. Each export that was (attempted
+// to be) modified has JSON response with "pseudo" and "state" in it.
+// ApplyExportInfo() modifies only a single export, but the returned response
+// is still formatted in a JSON list.
+type applyRes []*struct {
+	Pseudo string `json:"pseudo"`
+	State  string `json:"state"`
+}
+
+func parseApplyResults(res commands.Response) error {
+	results := applyRes{}
+	if err := res.NoStatus().Unmarshal(&results).End(); err != nil {
+		return err
+	}
+	for _, ar := range results {
+		if ar.State == "added" || ar.State == "updated" {
+			// succes, nothing to do for this ar
+			continue
+		}
+		return fmt.Errorf("%w %s for pseudo %s", errUnknownApplyState, ar.State, ar.Pseudo)
+	}
+	return nil
+}
+
+// ApplyExportInfo will create or update an existing NFS export.
+//
+// Similar To:
+//
+//	ceph nfs export apply
+func (nfsa *Admin) ApplyExportInfo(clusterID string, info ExportInfo) error {
+	buf, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+	m := map[string]string{
+		"prefix":     "nfs export apply",
+		"format":     "json",
+		"cluster_id": clusterID,
+	}
+	return parseApplyResults(commands.MarshalMgrCommandWithBuffer(nfsa.conn, m, buf))
+}

--- a/common/admin/nfs/export_apply_test.go
+++ b/common/admin/nfs/export_apply_test.go
@@ -1,0 +1,57 @@
+//go:build !(nautilus || octopus || pacific || quincy) && ceph_preview
+
+package nfs
+
+func (suite *NFSAdminSuite) TestApplyExportInfo() {
+	require := suite.Require()
+	ra := radosConnector.Get(suite.T())
+	nfsa := NewFromConn(ra)
+
+	// Create initial export with ClientAddr
+	res, err := nfsa.CreateCephFSExport(CephFSExportSpec{
+		FileSystemName: suite.fileSystemName,
+		ClusterID:      suite.clusterID,
+		PseudoPath:     "/applytest",
+		Path:           "/january",
+		ClientAddr:     []string{"192.168.1.0/24"},
+	})
+	require.NoError(err)
+	require.Equal("/applytest", res.Bind)
+
+	defer func() {
+		err = nfsa.RemoveExport(suite.clusterID, "/applytest")
+		require.NoError(err)
+	}()
+
+	// Get initial export info
+	info, err := nfsa.ExportInfo(suite.clusterID, "/applytest")
+	require.NoError(err)
+	require.Equal("/applytest", info.PseudoPath)
+	require.Equal("/january", info.Path)
+	require.Len(info.Clients, 1)
+	require.Contains(info.Clients[0].Addresses, "192.168.1.0/24")
+
+	// Modify the export info and apply it
+	// Several attributes cause an NFS-server restart, this doesn't work in
+	// the CI as there is no orchestrator handling it.
+	// This test should not modify user_id, fs_name, path or pseudo.
+	info.Clients = []ClientInfo{
+		{
+			Addresses:  []string{"10.0.0.0/8", "172.16.0.0/12"},
+			AccessType: "RW",
+			Squash:     "none",
+		},
+	}
+	err = nfsa.ApplyExportInfo(suite.clusterID, info)
+	require.NoError(err)
+
+	// Verify the update by getting export info
+	updatedInfo, err := nfsa.ExportInfo(suite.clusterID, "/applytest")
+	require.NoError(err)
+	require.Equal("/applytest", updatedInfo.PseudoPath)
+	require.Equal("/january", updatedInfo.Path)
+	require.Len(updatedInfo.Clients, 1)
+	require.Len(updatedInfo.Clients[0].Addresses, 2)
+	require.Contains(updatedInfo.Clients[0].Addresses, "10.0.0.0/8")
+	require.Contains(updatedInfo.Clients[0].Addresses, "172.16.0.0/12")
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2392,7 +2392,14 @@
     ]
   },
   "common/admin/nfs": {
-    "preview_api": [],
+    "preview_api": [
+      {
+        "name": "Admin.ApplyExportInfo",
+        "comment": "ApplyExportInfo will create or update an existing NFS export.\n\nSimilar To:\n\n\tceph nfs export apply\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      }
+    ],
     "stable_api": [
       {
         "name": "NewFromConn",

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -62,7 +62,11 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 
 ## Package: common/admin/nfs
 
-No Preview/Deprecated APIs found. All APIs are considered stable.
+### Preview APIs
+
+Name | Added in Version | Expected Stable Version | 
+---- | ---------------- | ----------------------- | 
+Admin.ApplyExportInfo | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: rados/striper
 


### PR DESCRIPTION
Add ApplyExportInfo function to update existing NFS exports using the
'nfs export update' command prefix.

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs