### PR TITLE
Add a new check-commits CI job using gitlint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,25 @@ jobs:
     - name: Run checks
       run: make check
 
+  # Check commit messages (in particular enforce Signed-off-by)
+  check-commits:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+      with:
+        python-version: '3.13'
+    - name: Install gitlint
+      run: |
+        python3 -m venv venv.gitlint
+        ./venv.gitlint/bin/pip install gitlint==0.19.1
+    - name: Run gitlint
+      run: ./venv.gitlint/bin/gitlint -C .gitlint --commits origin/master.. lint
+
   # Run the test suite in a container per-ceph-codename
   test-suite:
     name: test-suite (${{ matrix.ceph_version }}${{ matrix.go_version != needs.go-versions.outputs.latest && format(', go{0}', matrix.go_version) || '' }})

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,24 @@
+[general]
+verbosity=3
+regex-style-search=true
+contrib=contrib-body-requires-signed-off-by
+
+[title-max-length]
+line-length=72
+
+[title-must-not-contain-word]
+# Comma-separated list of words that should not occur in the title. Matching is case
+# insensitive. It's fine if the keyword occurs as part of a larger word (so "WIPING"
+# will not cause a violation, but "WIP: my title" will).
+words=wip,WIP
+
+[title-match-regex]
+# python-style regex that the commit-msg title must match
+# Note that the regex can contradict with other rules if not used correctly
+# (e.g. title-must-not-contain-word).
+regex=^.{2,32}: .*
+
+[ignore-body-lines]
+# do not enforce the default body line length checks on lines that appear to be
+# HTTP(S) URLs.
+regex=https?://


### PR DESCRIPTION
Add a new check-commits CI job that uses gitlint to enforce some basic parameters of git commit messages in contributions to go-ceph. In particular we want to require the Signed-off-by on all commits. We were kinda-sorta requiring it but not always enforcing it. ceph/ceph has been requiring it for a long time.

I also think it's even more important now that people declare they have
the right to contribute change now that more and more tools are being
used to generate code.

I've used gitlint in other projects with success so I chose that rather than agonize other available tools.


