### PR TITLE
admin/smb: Fix JSON serialization of required fields

### DIFF
--- a/common/admin/smb/cluster_core.go
+++ b/common/admin/smb/cluster_core.go
@@ -19,8 +19,8 @@ type DomainSettings struct {
 
 // PublicAddress used by a cluster with integrated Samba clustering enabled.
 type PublicAddress struct {
-	Address     string
-	Destination []string
+	Address     string   `json:"address"`
+	Destination []string `json:"destination,omitempty"`
 }
 
 // Type returns a ResourceType value.

--- a/common/admin/smb/users_groups.go
+++ b/common/admin/smb/users_groups.go
@@ -22,7 +22,7 @@ type GroupInfo struct {
 // an SMB server instance.
 type UsersAndGroupsValues struct {
 	Users  []UserInfo  `json:"users,omitempty"`
-	Groups []GroupInfo `json:"groups,omitempty"`
+	Groups []GroupInfo `json:"groups"`
 }
 
 // UsersAndGroups is a resource containing user and group definitions that


### PR DESCRIPTION
Fix JSON serialization issues in smb admin structures by ensuring required fields are always included in the JSON output. These changes prevent validation errors when the backend (ceph smb manager module) expects specific fields to be present.