### PR TITLE
admin/smb: Add TLSCredentialType validation and generic Apply results

### DIFF
--- a/common/admin/smb/generic_ext.go
+++ b/common/admin/smb/generic_ext.go
@@ -1,0 +1,71 @@
+//go:build !(pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"encoding/json"
+
+	"github.com/ceph/go-ceph/internal/commands"
+)
+
+type genericResultCommon struct {
+	Resource GenericResource `json:"resource"`
+	Message  string          `json:"msg"`
+	Success  bool            `json:"success"`
+	State    string          `json:"state"`
+}
+
+type genericResult struct {
+	genericResultCommon
+	status map[string]any
+}
+
+func (gr *genericResult) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &gr.genericResultCommon); err != nil {
+		return err
+	}
+	gr.status = map[string]any{}
+	return json.Unmarshal(data, &gr.status)
+}
+
+type genericResultGroup struct {
+	Success bool            `json:"success"`
+	Results []genericResult `json:"results"`
+}
+
+func applyGenericUnmarshal(r commands.Response) (ResultGroup, error) {
+	rg := genericResultGroup{}
+	if err := r.NoStatus().Unmarshal(&rg).End(); err != nil {
+		return ResultGroup{}, err
+	}
+	out := ResultGroup{Success: rg.Success}
+	out.Results = make([]*Result, len(rg.Results))
+	for i := range rg.Results {
+		out.Results[i] = &Result{
+			resource: &rg.Results[i].Resource,
+			message:  rg.Results[i].Message,
+			success:  rg.Results[i].Success,
+			state:    rg.Results[i].State,
+			status:   rg.Results[i].status,
+		}
+	}
+	return out, nil
+}
+
+// SetGeneric enables or disables returning GenericResource objects within
+// the results of the Apply function. If true all Resource objects embedded
+// in Apply results will be GenericResource instances.
+func (opts *ApplyOptions) SetGeneric(b bool) *ApplyOptions {
+	if b {
+		opts.unmarshal = applyGenericUnmarshal
+	} else {
+		opts.unmarshal = nil
+	}
+	return opts
+}
+
+// Generic returns true if the apply options are set to return
+// GenericResource instances in Apply results.
+func (opts *ApplyOptions) Generic() bool {
+	return opts.unmarshal != nil
+}

--- a/common/admin/smb/generic_ext_test.go
+++ b/common/admin/smb/generic_ext_test.go
@@ -1,0 +1,81 @@
+//go:build !(pacific || quincy || reef || squid) && ceph_preview
+
+package smb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var genericResults = `
+{
+  "results": [
+    {
+      "resource": {
+        "resource_type": "ceph.smb.fish",
+        "external_id": "tuna",
+        "info": {
+          "count": "123456"
+        }
+      },
+      "state": "created",
+      "success": true
+    },
+    {
+      "resource": {
+        "resource_type": "ceph.smb.share",
+        "cluster_id": "c1",
+        "share_id": "s1",
+        "intent": "present",
+        "name": "s1",
+        "readonly": false,
+        "browseable": true,
+        "cephfs": {
+          "volume": "cephfs",
+          "path": "/"
+        }
+      },
+      "state": "created",
+      "success": true
+    }
+  ],
+  "success": true
+}
+`
+
+func TestApplyWithGenericResults(t *testing.T) {
+	sa := NewFromConn(&phoneyConn{
+		mgrCommandWithInputBuffer: func(_ [][]byte, _ []byte) ([]byte, string, error) {
+			return []byte(genericResults), "", nil
+		},
+	})
+	gr := &GenericResource{
+		Values: map[string]any{
+			"resource_type": "ceph.smb.fish",
+			"intent":        "present",
+			"external_id":   "tuna",
+			"info": map[string]any{
+				"count": "123456",
+			},
+		},
+	}
+	share := NewShare("c1", "s1").SetCephFS("cephfs", "", "", "/")
+	opts := &ApplyOptions{}
+	opts.SetGeneric(true)
+	rgroup, err := sa.Apply([]Resource{gr, share}, opts)
+	assert.NoError(t, err)
+
+	assert.True(t, rgroup.Ok())
+	assert.Len(t, rgroup.Results, 2)
+
+	gr1, ok := rgroup.Results[0].Resource().(*GenericResource)
+	assert.True(t, ok)
+	assert.Equal(t, gr1.Type(), ResourceType("ceph.smb.fish"))
+	assert.Equal(t, gr1.Values["external_id"].(string), "tuna")
+	assert.Equal(t, rgroup.Results[0].State(), "created")
+
+	gr2, ok := rgroup.Results[1].Resource().(*GenericResource)
+	assert.True(t, ok)
+	assert.Equal(t, gr2.Type(), ShareType)
+}

--- a/common/admin/smb/resources.go
+++ b/common/admin/smb/resources.go
@@ -164,6 +164,9 @@ type ApplyOptions struct {
 	// PasswordFilterOut can be used to filter/obfuscate password values
 	// returned from the Ceph cluster.
 	PasswordFilterOut PasswordFilter
+
+	// custom unmarshaler for apply results
+	unmarshal func(r commands.Response) (ResultGroup, error)
 }
 
 // Apply changes to the resource descriptions stored on the Ceph cluster.
@@ -202,6 +205,9 @@ func (a *Admin) Apply(resources []Resource, opts *ApplyOptions) (
 		m["password_filter_out"] = string(opts.PasswordFilterOut)
 	}
 	c := commands.MarshalMgrCommandWithBuffer(a.conn, m, buf)
+	if opts != nil && opts.unmarshal != nil {
+		return opts.unmarshal(c)
+	}
 	if err := c.NoStatus().Unmarshal(&rg).End(); err != nil {
 		return rg, err
 	}

--- a/common/admin/smb/resources.go
+++ b/common/admin/smb/resources.go
@@ -87,7 +87,7 @@ func (e *resourceEntry) UnmarshalJSON(data []byte) error {
 
 func validResourceType(v ResourceType) bool {
 	switch v {
-	case ClusterType, ShareType, JoinAuthType, UsersAndGroupsType:
+	case ClusterType, ShareType, JoinAuthType, UsersAndGroupsType, TLSCredentialType:
 		return true
 	}
 	return false

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2640,6 +2640,18 @@
         "comment": "Generic returns true if the show options are set to return\nGenericResource instances from the Show function.\n",
         "added_in_version": "v0.39.0",
         "expected_stable_version": "v0.41.0"
+      },
+      {
+        "name": "ApplyOptions.SetGeneric",
+        "comment": "SetGeneric enables or disables returning GenericResource objects within\nthe results of the Apply function. If true all Resource objects embedded\nin Apply results will be GenericResource instances.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "ApplyOptions.Generic",
+        "comment": "Generic returns true if the apply options are set to return\nGenericResource instances in Apply results.\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ],
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -101,6 +101,8 @@ GenericResource.Convert | v0.39.0 | v0.41.0 |
 ToGeneric | v0.39.0 | v0.41.0 | 
 ShowOptions.SetGeneric | v0.39.0 | v0.41.0 | 
 ShowOptions.Generic | v0.39.0 | v0.41.0 | 
+ApplyOptions.SetGeneric | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+ApplyOptions.Generic | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: common/admin/osd
 


### PR DESCRIPTION
- Add `TLSCredentialType` to _validResourceType()_ so resources with this type pass validation.
- Add _SetGeneric_/_Generic_ methods to _ApplyOptions_, allowing _Apply()_ results to return `GenericResource` instances that preserve all JSON fields, including those unknown to the library.