### PR TITLE
rbd: retry lock owner listing with resized buffer

### DIFF
--- a/rbd/locks.go
+++ b/rbd/locks.go
@@ -11,6 +11,8 @@ import "C"
 
 import (
 	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/retry"
 )
 
 // LockMode represents a group of configurable lock modes.
@@ -75,21 +77,26 @@ func (image *Image) LockGetOwners() ([]*LockOwner, error) {
 	}
 
 	var (
-		maxLockOwners  = C.size_t(8)
-		cLockOwners    = make([]*C.char, 8)
+		err            error
+		ret            C.int
+		maxLockOwners  C.size_t
+		cLockOwners    []*C.char
 		lockMode       LockMode
 		lockOwnersList []*LockOwner
 	)
 
-	for {
-		ret := C.rbd_lock_get_owners(image.image, (*C.rbd_lock_mode_t)(&lockMode), &cLockOwners[0], &maxLockOwners)
-		if ret >= 0 {
-			break
-		} else if ret == -C.ENOENT {
+	retry.WithSizes(8, 4096, func(size int) retry.Hint {
+		maxLockOwners = C.size_t(size)
+		cLockOwners = make([]*C.char, maxLockOwners)
+		ret = C.rbd_lock_get_owners(image.image, (*C.rbd_lock_mode_t)(&lockMode), &cLockOwners[0], &maxLockOwners)
+		err = getErrorIfNegative(ret)
+		return retry.Size(int(maxLockOwners)).If(err == errRange)
+	})
+	if err != nil {
+		if ret == -C.ENOENT {
 			return nil, nil
-		} else if ret != -C.ERANGE {
-			return nil, getError(ret)
 		}
+		return nil, err
 	}
 
 	defer C.rbd_lock_get_owners_cleanup(&cLockOwners[0], maxLockOwners)


### PR DESCRIPTION
<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

Update lock owner listing retry behavior:

- use `retry.WithSizes` in `LockGetOwners`
- reallocate the lock owner buffer when `rbd_lock_get_owners` returns `ERANGE`
- preserve the existing `ENOENT` behavior


No new test was added because reproducing this path requires librbd to return `ERANGE` from `rbd_lock_get_owners`, 
which depends on having more lock owners than the initial buffer size.

This is not a new API, so `ceph_preview` and `make api-update` do not apply.

fixes #1269

## Checklist
- [ ] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
