### PR TITLE
rgw/admin: support placement-tags for user creation/modification

### DIFF
--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -21,7 +21,7 @@ type User struct {
 	OpMask              string         `json:"op_mask" url:"op-mask"`
 	DefaultPlacement    string         `json:"default_placement" url:"default-placement"`
 	DefaultStorageClass string         `json:"default_storage_class" url:"default-storage-class"`
-	PlacementTags       []interface{}  `json:"placement_tags"`
+	PlacementTags       []string       `json:"placement_tags" url:"placement-tags"`
 	BucketQuota         QuotaSpec      `json:"bucket_quota"`
 	UserQuota           QuotaSpec      `json:"user_quota"`
 	TempURLKeys         []interface{}  `json:"temp_url_keys"`
@@ -161,8 +161,8 @@ func (api *API) CreateUser(ctx context.Context, user User) (User, error) {
 		return User{}, errMissingUserDisplayName
 	}
 
-	// valid parameters not supported by go-ceph: system, exclusive, placement-tags
-	body, err := api.call(ctx, http.MethodPut, "/user", valueToURLParams(user, []string{"uid", "display-name", "default-placement", "default-storage-class", "email", "key-type", "access-key", "secret-key", "user-caps", "tenant", "generate-key", "max-buckets", "suspended", "op-mask", "account-id", "account-root"}))
+	// valid parameters not supported by go-ceph: system, exclusive
+	body, err := api.call(ctx, http.MethodPut, "/user", valueToURLParams(user, []string{"uid", "display-name", "default-placement", "placement-tags", "default-storage-class", "email", "key-type", "access-key", "secret-key", "user-caps", "tenant", "generate-key", "max-buckets", "suspended", "op-mask", "account-id", "account-root"}))
 	if err != nil {
 		return User{}, err
 	}
@@ -197,8 +197,8 @@ func (api *API) ModifyUser(ctx context.Context, user User) (User, error) {
 		return User{}, errMissingUserID
 	}
 
-	// valid parameters not supported by go-ceph: system, placement-tags
-	body, err := api.call(ctx, http.MethodPost, "/user", valueToURLParams(user, []string{"uid", "display-name", "default-placement", "default-storage-class", "email", "generate-key", "access-key", "secret-key", "key-type", "max-buckets", "suspended", "op-mask", "account-id", "account-root"}))
+	// valid parameters not supported by go-ceph: system
+	body, err := api.call(ctx, http.MethodPost, "/user", valueToURLParams(user, []string{"uid", "display-name", "default-placement", "placement-tags", "default-storage-class", "email", "generate-key", "access-key", "secret-key", "key-type", "max-buckets", "suspended", "op-mask", "account-id", "account-root"}))
 	if err != nil {
 		return User{}, err
 	}

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -106,9 +106,10 @@ func (suite *RadosGWTestSuite) TestUser() {
 
 	suite.T().Run("user creation success", func(_ *testing.T) {
 		usercaps := "users=read"
-		user, err := co.CreateUser(context.Background(), User{ID: "leseb", DisplayName: "This is leseb", Email: "leseb@example.com", UserCaps: usercaps, OpMask: "delete", DefaultPlacement: "default-placement", DefaultStorageClass: "STANDARD"})
+		user, err := co.CreateUser(context.Background(), User{ID: "leseb", DisplayName: "This is leseb", Email: "leseb@example.com", UserCaps: usercaps, OpMask: "delete", DefaultPlacement: "default-placement", DefaultStorageClass: "STANDARD", PlacementTags: []string{"fast", "ssd"}})
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@example.com", user.Email)
+		assert.Equal(suite.T(), []string{"fast", "ssd"}, user.PlacementTags)
 	})
 
 	suite.T().Run("get user leseb by uid", func(_ *testing.T) {
@@ -119,6 +120,7 @@ func (suite *RadosGWTestSuite) TestUser() {
 		assert.Equal(suite.T(), "read", user.Caps[0].Perm)
 		assert.Equal(suite.T(), "delete", user.OpMask)
 		assert.Equal(suite.T(), "default-placement", user.DefaultPlacement)
+		assert.Equal(suite.T(), []string{"fast", "ssd"}, user.PlacementTags)
 		os.Setenv("LESEB_ACCESS_KEY", user.Keys[0].AccessKey)
 	})
 
@@ -141,6 +143,17 @@ func (suite *RadosGWTestSuite) TestUser() {
 		assert.NoError(suite.T(), err)
 		assert.Equal(suite.T(), "leseb@leseb.com", user.Email)
 		assert.Equal(suite.T(), -1, *user.MaxBuckets)
+	})
+
+	suite.T().Run("modify user placement tags", func(_ *testing.T) {
+		user, err := co.ModifyUser(context.Background(), User{ID: "leseb", PlacementTags: []string{"slow", "hdd"}})
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), []string{"slow", "hdd"}, user.PlacementTags)
+
+		// confirm the change is actually persisted, not just echoed back
+		fetched, err := co.GetUser(context.Background(), User{ID: "leseb"})
+		assert.NoError(suite.T(), err)
+		assert.Equal(suite.T(), []string{"slow", "hdd"}, fetched.PlacementTags)
 	})
 
 	suite.T().Run("user already exists", func(_ *testing.T) {

--- a/rgw/admin/utils.go
+++ b/rgw/admin/utils.go
@@ -76,6 +76,19 @@ func getReflect(i interface{}, acceptableFields []string, values *url.Values) {
 		}
 
 		if v2.Kind() == reflect.Slice {
+			if v2.Type().Elem().Kind() == reflect.String {
+				if v2.Len() > 0 && contains(acceptableFields, name) {
+					tags := make([]string, v2.Len())
+					for i := 0; i < v2.Len(); i++ {
+						tags[i] = v2.Index(i).String()
+					}
+					// the RGW admin ops API expects a single comma-separated
+					// value here, not repeated params (see RGWOp_User_Create::execute()
+					// in rgw_rest_user.cc from Ceph sources)
+					values.Add(name, strings.Join(tags, ","))
+				}
+				continue
+			}
 			for i := 0; i < v2.Len(); i++ {
 				item := v2.Index(i)
 				getReflect(item.Interface(), acceptableFields, values)

--- a/rgw/admin/utils_test.go
+++ b/rgw/admin/utils_test.go
@@ -25,18 +25,22 @@ func TestBuildQueryPath(t *testing.T) {
 
 func TestValueToURLParams(t *testing.T) {
 	type args struct {
-		i interface{}
+		i                interface{}
+		acceptableFields []string
 	}
 	tests := []struct {
 		name string
 		args args
 		want string
 	}{
-		{"default", args{User{ID: "leseb", Email: "leseb@example.com"}}, "format=json&uid=leseb"},
+		{"default", args{User{ID: "leseb", Email: "leseb@example.com"}, []string{"uid"}}, "format=json&uid=leseb"},
+		// RGW expects placement-tags as a single comma-separated value, not repeated params.
+		{"placement tags", args{User{ID: "leseb", PlacementTags: []string{"fast", "ssd"}}, []string{"uid", "placement-tags"}}, "format=json&placement-tags=fast%2Cssd&uid=leseb"},
+		{"empty placement tags", args{User{ID: "leseb"}, []string{"uid", "placement-tags"}}, "format=json&uid=leseb"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := valueToURLParams(tt.args.i, []string{"uid"})
+			got := valueToURLParams(tt.args.i, tt.args.acceptableFields)
 			if !reflect.DeepEqual(got.Encode(), tt.want) {
 				t.Errorf("valueToURLParams() = %v, want %v", got.Encode(), tt.want)
 			}


### PR DESCRIPTION

`User.PlacementTags` was declared as `[]interface{}` and excluded from
the accepted-fields list passed to `valueToURLParams` in both
`CreateUser` and `ModifyUser`, so it was effectively a dead field —
setting it never reached the RGW admin ops API.

This changes `PlacementTags` to `[]string` (tags are always strings in
the admin ops API), adds `placement-tags` to the accepted fields for
`CreateUser`/`ModifyUser`, and updates `getReflect` in utils.go to
encode a string-slice field as a single comma-separated URL param
(e.g. `placement-tags=fast,ssd`).

This single-value, comma-separated encoding is required by the server:
`RGWOp_User_Create::execute()` in `rgw_rest_user.cc` reads
`placement-tags` via `RESTArgs::get_string()` into one `std::string`
and splits it on `,`. `RGWHTTPArgs` stores query params in a
`std::map<std::string,std::string>`, so repeated `placement-tags=...`
params would silently overwrite each other and only the last tag would
ever reach the server — verified this against the Ceph source and with
a live RGW integration test before settling on this approach.

Tests added:
- `TestValueToURLParams` (utils_test.go): table cases covering
  placement-tags encoding (present and empty).
- `TestUser` (user_test.go, live-cluster integration suite): create
  with placement-tags, fetch and verify round-trip, and a dedicated
  modify-placement-tags case that re-fetches to confirm persistence.


## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
