### PR TITLE
rgw/admin: add SetAccountQuota for account and bucket quotas

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -2181,6 +2181,12 @@
         "comment": "GetIndividualBucketRateLimit returns rate-limits of a specific bucket.\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#get-bucket-rate-limit\n",
         "added_in_version": "v0.40.0",
         "expected_stable_version": "v0.42.0"
+      },
+      {
+        "name": "API.SetAccountQuota",
+        "comment": "SetAccountQuota sets the account-level or default-bucket quota for an RGW\naccount. The resulting quota can be read back with GetAccount, which populates\nAccount.Quota and Account.BucketQuota.\nThe underlying admin op requires Ceph v20.2.2 or later, or main; it is not\navailable in Squid, nor in Tentacle before v20.2.2.\nhttps://docs.ceph.com/en/latest/radosgw/adminops/#set-account-quota\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ],
     "stable_api": [

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -50,6 +50,7 @@ Name | Added in Version | Expected Stable Version |
 ---- | ---------------- | ----------------------- | 
 API.SetIndividualBucketRateLimit | v0.40.0 | v0.42.0 | 
 API.GetIndividualBucketRateLimit | v0.40.0 | v0.42.0 | 
+API.SetAccountQuota | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: common/admin/manager
 

--- a/rgw/admin/account.go
+++ b/rgw/admin/account.go
@@ -20,9 +20,9 @@ type Account struct {
 	MaxGroups     *int64 `json:"max_groups" url:"max-groups"`
 	MaxAccessKeys *int64 `json:"max_access_keys" url:"max-access-keys"`
 	MaxBuckets    *int64 `json:"max_buckets" url:"max-buckets"`
-	// Quota apis for account is only available mainline,
-	// but fields are available for preview builds for future compatibility
-	// Once backports merged will add account quota apis
+	// Quota and BucketQuota are populated by GetAccount. They can be set with
+	// SetAccountQuota; the underlying admin op requires Ceph v20.2.2 or later, or main.
+	// It is not present in Squid, nor in Tentacle before v20.2.2.
 	Quota       QuotaSpec `json:"quota"`
 	BucketQuota QuotaSpec `json:"bucket_quota"`
 }

--- a/rgw/admin/account_quota.go
+++ b/rgw/admin/account_quota.go
@@ -1,0 +1,51 @@
+//go:build !(pacific || quincy || reef) && ceph_preview
+
+package admin
+
+import (
+	"context"
+	"net/http"
+)
+
+// Account quota types accepted by SetAccountQuota.
+const (
+	// AccountQuotaTypeAccount applies the quota to the account as a whole.
+	AccountQuotaTypeAccount = "account"
+	// AccountQuotaTypeBucket applies the quota as the default per-bucket quota
+	// for buckets owned by the account.
+	AccountQuotaTypeBucket = "bucket"
+)
+
+// AccountQuotaSpec describes a quota to set on an RGW account. QuotaType selects
+// whether the limits apply to the account as a whole (AccountQuotaTypeAccount)
+// or as the default quota for each bucket the account owns
+// (AccountQuotaTypeBucket). Unset (nil) fields are left unchanged.
+type AccountQuotaSpec struct {
+	ID         string `url:"id"`
+	QuotaType  string `url:"quota-type"`
+	Enabled    *bool  `url:"enabled"`
+	MaxSize    *int64 `url:"max-size"`
+	MaxObjects *int64 `url:"max-objects"`
+}
+
+// SetAccountQuota sets the account-level or default-bucket quota for an RGW
+// account. The resulting quota can be read back with GetAccount, which populates
+// Account.Quota and Account.BucketQuota.
+// The underlying admin op requires Ceph v20.2.2 or later, or main; it is not
+// available in Squid, nor in Tentacle before v20.2.2.
+// https://docs.ceph.com/en/latest/radosgw/adminops/#set-account-quota
+func (api *API) SetAccountQuota(ctx context.Context, quota AccountQuotaSpec) error {
+	if quota.ID == "" {
+		return ErrInvalidArgument
+	}
+	if quota.QuotaType != AccountQuotaTypeAccount && quota.QuotaType != AccountQuotaTypeBucket {
+		return ErrInvalidArgument
+	}
+
+	_, err := api.call(ctx, http.MethodPut, "/account?quota", valueToURLParams(quota, []string{"id", "quota-type", "enabled", "max-size", "max-objects"}))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/rgw/admin/account_quota_test.go
+++ b/rgw/admin/account_quota_test.go
@@ -1,0 +1,73 @@
+//go:build !(pacific || quincy || reef) && ceph_preview
+
+package admin
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/ceph/go-ceph/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosGWTestSuite) TestAccountQuota() {
+	suite.SetupConnection()
+	co, err := New(suite.endpoint, suite.accessKey, suite.secretKey, newDebugHTTPClient(http.DefaultClient))
+	assert.NoError(suite.T(), err)
+
+	suite.T().Run("fail to set quota since no ID provided", func(t *testing.T) {
+		err := co.SetAccountQuota(context.Background(), AccountQuotaSpec{QuotaType: AccountQuotaTypeAccount})
+		assert.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	suite.T().Run("fail to set quota since quota-type is invalid", func(t *testing.T) {
+		err := co.SetAccountQuota(context.Background(), AccountQuotaSpec{ID: "RGW98765432109876543", QuotaType: "invalid"})
+		assert.ErrorIs(t, err, ErrInvalidArgument)
+	})
+
+	suite.T().Run("successfully set and read account quotas", func(t *testing.T) {
+		if util.CurrentCephVersion() < util.CephTentacle {
+			t.Skipf("account quota admin ops are not yet supported on %s", util.CurrentCephVersionString())
+		}
+
+		account, err := co.CreateAccount(context.Background(), Account{Name: "quota-test-account"})
+		assert.NoError(t, err)
+		id := account.ID
+		defer func() {
+			assert.NoError(t, co.DeleteAccount(context.Background(), id))
+		}()
+
+		enabled := true
+		var maxSize int64 = 1073741824
+		var maxObjects int64 = 1000
+		err = co.SetAccountQuota(context.Background(), AccountQuotaSpec{
+			ID:         id,
+			QuotaType:  AccountQuotaTypeAccount,
+			Enabled:    &enabled,
+			MaxSize:    &maxSize,
+			MaxObjects: &maxObjects,
+		})
+		assert.NoError(t, err)
+
+		var bucketMaxSize int64 = 524288000
+		var bucketMaxObjects int64 = 500
+		err = co.SetAccountQuota(context.Background(), AccountQuotaSpec{
+			ID:         id,
+			QuotaType:  AccountQuotaTypeBucket,
+			Enabled:    &enabled,
+			MaxSize:    &bucketMaxSize,
+			MaxObjects: &bucketMaxObjects,
+		})
+		assert.NoError(t, err)
+
+		got, err := co.GetAccount(context.Background(), id)
+		assert.NoError(t, err)
+		assert.Equal(t, &enabled, got.Quota.Enabled)
+		assert.Equal(t, &maxSize, got.Quota.MaxSize)
+		assert.Equal(t, &maxObjects, got.Quota.MaxObjects)
+		assert.Equal(t, &enabled, got.BucketQuota.Enabled)
+		assert.Equal(t, &bucketMaxSize, got.BucketQuota.MaxSize)
+		assert.Equal(t, &bucketMaxObjects, got.BucketQuota.MaxObjects)
+	})
+}


### PR DESCRIPTION
Add `SetAccountQuota` (ceph_preview) to set account-level and default-bucket quotas via PUT `/admin/account?quota`, alongside the `AccountQuotaSpec` type. The admin op is available in Ceph v20.2.2+ and main (ceph/ceph 67f655ca, tracker 72527).

https://github.com/ceph/ceph/commit/67f655ca1c704b6830fa5aa9d76f84c37471facf


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
