### PR TITLE
cephfs/admin: Add PinSubVolumeInGroup API

### DIFF
--- a/cephfs/admin/pin.go
+++ b/cephfs/admin/pin.go
@@ -24,7 +24,7 @@ func (fsa *FSAdmin) PinSubVolume(volume, subvolume, pintype, pinsetting string) 
 	return parsePathResponse(fsa.marshalMgrCommand(m))
 }
 
-// PinSubVolumeGroup pins subvolume to ranks according to policies. A valid pin
+// PinSubVolumeGroup pins subvolume group to ranks according to policies. A valid pin
 // setting value depends on the type of pin as described in the docs from
 // https://docs.ceph.com/en/latest/cephfs/multimds/#cephfs-pinning and
 // https://docs.ceph.com/en/latest/cephfs/multimds/#setting-subtree-partitioning-policies

--- a/cephfs/admin/pin_subvolume_in_group.go
+++ b/cephfs/admin/pin_subvolume_in_group.go
@@ -1,0 +1,28 @@
+//go:build !nautilus && ceph_preview
+
+package admin
+
+// PinSubVolumeInGroup pins a subvolume in a volume and optional subvolume group
+// to ranks according to policies. A valid pin setting value depends on the type
+// of pin as described in the docs from
+// https://docs.ceph.com/en/latest/cephfs/multimds/#cephfs-pinning and
+// https://docs.ceph.com/en/latest/cephfs/multimds/#setting-subtree-partitioning-policies
+//
+// Similar To:
+//
+//	ceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting> [--group_name=<group>]
+func (fsa *FSAdmin) PinSubVolumeInGroup(volume, group, subvolume, pintype, pinsetting string) (string, error) {
+	m := map[string]string{
+		"prefix":      "fs subvolume pin",
+		"format":      "json",
+		"vol_name":    volume,
+		"sub_name":    subvolume,
+		"pin_type":    pintype,
+		"pin_setting": pinsetting,
+	}
+	if group != NoGroup {
+		m["group_name"] = group
+	}
+
+	return parsePathResponse(fsa.marshalMgrCommand(m))
+}

--- a/cephfs/admin/pin_subvolume_in_group_test.go
+++ b/cephfs/admin/pin_subvolume_in_group_test.go
@@ -1,0 +1,51 @@
+//go:build !nautilus && ceph_preview
+
+package admin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPinSubVolumeInGroup(t *testing.T) {
+	fsa := getFSAdmin(t)
+	volume := "cephfs"
+
+	subvolumegroup := "cephfs_subvol_group"
+	err := fsa.CreateSubVolumeGroup(volume, subvolumegroup, nil)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolumeGroup(volume, subvolumegroup)
+		assert.NoError(t, err)
+	}()
+
+	subvolname := "cephfs_subvol"
+	err = fsa.CreateSubVolume(volume, subvolumegroup, subvolname, nil)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolume(volume, subvolumegroup, subvolname)
+		assert.NoError(t, err)
+	}()
+
+	var ec errorCode
+	_, err = fsa.PinSubVolumeInGroup(volume, subvolumegroup, subvolname, "distributed", "2")
+	assert.True(t, errors.As(err, &ec))
+	assert.Equal(t, -22, ec.ErrorCode())
+
+	_, err = fsa.PinSubVolumeInGroup(volume, subvolumegroup, subvolname, "distributed", "1")
+	assert.NoError(t, err)
+
+	// Also test with NoGroup to verify it behaves like PinSubVolume.
+	subvolname2 := "cephfs_subvol_nogroup"
+	err = fsa.CreateSubVolume(volume, NoGroup, subvolname2, nil)
+	assert.NoError(t, err)
+	defer func() {
+		err := fsa.RemoveSubVolume(volume, NoGroup, subvolname2)
+		assert.NoError(t, err)
+	}()
+
+	_, err = fsa.PinSubVolumeInGroup(volume, NoGroup, subvolname2, "distributed", "1")
+	assert.NoError(t, err)
+}

--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -709,6 +709,12 @@
         "comment": "SubVolumeGroupInfo returns information about the specified subvolume group.\n\nSimilar To:\n\n\tceph fs subvolumegroup info <volume> <group_name>\n",
         "added_in_version": "v0.40.0",
         "expected_stable_version": "v0.42.0"
+      },
+      {
+        "name": "FSAdmin.PinSubVolumeInGroup",
+        "comment": "PinSubVolumeInGroup pins a subvolume in a volume and optional subvolume group\nto ranks according to policies. A valid pin setting value depends on the type\nof pin as described in the docs from\nhttps://docs.ceph.com/en/latest/cephfs/multimds/#cephfs-pinning and\nhttps://docs.ceph.com/en/latest/cephfs/multimds/#setting-subtree-partitioning-policies\n\nSimilar To:\n\n\tceph fs subvolume pin <vol_name> <sub_name> <pin_type> <pin_setting> [--group_name=<group>]\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -13,6 +13,7 @@ No Preview/Deprecated APIs found. All APIs are considered stable.
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 FSAdmin.SubVolumeGroupInfo | v0.40.0 | v0.42.0 | 
+FSAdmin.PinSubVolumeInGroup | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: rados
 


### PR DESCRIPTION
Add `PinSubVolumeInGroup` API with tests to pin CephFS subvolumes within a group, and update _api-status_ docs. Also fixes a comment in `PinSubVolumeGroup`.

fixes #1293 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs