### PR TITLE
rbd: Add LockModeExclusiveTransient constant

### DIFF
--- a/rbd/locks_squid.go
+++ b/rbd/locks_squid.go
@@ -1,0 +1,12 @@
+//go:build !(nautilus || octopus || pacific || quincy || reef)
+
+package rbd
+
+// #include <rbd/librbd.h>
+import "C"
+
+const (
+	// LockModeExclusiveTransient is the representation of
+	// RBD_LOCK_MODE_EXCLUSIVE_TRANSIENT from librbd.
+	LockModeExclusiveTransient = LockMode(C.RBD_LOCK_MODE_EXCLUSIVE_TRANSIENT)
+)


### PR DESCRIPTION
Expose RBD_LOCK_MODE_EXCLUSIVE_TRANSIENT from librbd, available from Ceph Squid (v19.2.4) onwards.
 
fixes #1229 