### PR TITLE
github: update mergify rule to merge api changes after 5 days

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -49,7 +49,7 @@ pull_request_rules:
           - and:
               - label=API
               - "#approved-reviews-by>=1"
-              - "updated-at<10 days ago"
+              - "updated-at<5 days ago"
     actions:
       queue: {}
       dismiss_reviews: {}


### PR DESCRIPTION
Since we have new APIs in the preview phase and sometimes a maintainer's own PR struggles to get two reviews, decrease the wait time for automatically merging a PR with one approval to 5 days. Still plenty of time for feedback but a smaller waiting period.



## Checklist
n/a

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
