### PR TITLE
rgw/admin: use shared AWS SigV4 signer in API client

### DIFF
--- a/rgw/admin/radosgw.go
+++ b/rgw/admin/radosgw.go
@@ -38,6 +38,7 @@ type API struct {
 	SecretKey  string
 	Endpoint   string
 	HTTPClient HTTPClient
+	signer     *v4.Signer
 }
 
 // New returns client for Ceph RGW
@@ -62,11 +63,17 @@ func New(endpoint, accessKey, secretKey string, httpClient HTTPClient) (*API, er
 		httpClient = &http.Client{Timeout: connectionTimeout}
 	}
 
+	signer := v4.NewSigner()
+	// This was present in https://github.com/IrekFasikhov/go-rgwadmin/ but it seems that the lib works without it
+	// Let's keep it here just in case something shows up
+	// signer.DisableRequestBodyOverwrite = true
+
 	return &API{
 		Endpoint:   endpoint,
 		AccessKey:  accessKey,
 		SecretKey:  secretKey,
 		HTTPClient: httpClient,
+		signer:     signer,
 	}, nil
 }
 
@@ -85,14 +92,9 @@ func (api *API) call(ctx context.Context, httpMethod, path string, args url.Valu
 		return nil, err
 	}
 
-	signer := v4.NewSigner()
-	// This was present in https://github.com/IrekFasikhov/go-rgwadmin/ but it seems that the lib works without it
-	// Let's keep it here just in case something shows up
-	// signer.DisableRequestBodyOverwrite = true
-
 	// Sign in S3
 	const emptyPayloadHash = "UNSIGNED-PAYLOAD"
-	err = signer.SignHTTP(ctx, creds, request, emptyPayloadHash, service, authRegion, time.Now())
+	err = api.signer.SignHTTP(ctx, creds, request, emptyPayloadHash, service, authRegion, time.Now())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Instantiating a single-use signer per request is wasteful, resulting in an additional 35 allocs per request, in addition to a small speed overhead.

```
$ benchstat old new
goos: linux
goarch: amd64
pkg: github.com/ceph/go-ceph/rgw/admin
cpu: Intel(R) Core(TM) Ultra 7 165U
                 │     old     │                new                 │
                 │   sec/op    │   sec/op     vs base               │
GetBucketInfo-14   106.8µ ± 1%   103.1µ ± 1%  -3.48% (p=0.000 n=10)

                 │     old      │                 new                  │
                 │     B/op     │     B/op      vs base                │
GetBucketInfo-14   23.14Ki ± 0%   20.21Ki ± 0%  -12.66% (p=0.000 n=10)

                 │    old     │                new                 │
                 │ allocs/op  │ allocs/op   vs base                │
GetBucketInfo-14   325.0 ± 0%   290.0 ± 0%  -10.77% (p=0.000 n=10)
```

<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs