### PR TITLE
rados: allow shutting down unconnected handles

### DIFF
--- a/rados/conn.go
+++ b/rados/conn.go
@@ -6,6 +6,7 @@ package rados
 import "C"
 
 import (
+	"runtime"
 	"unsafe"
 
 	"github.com/ceph/go-ceph/internal/cutil"
@@ -69,12 +70,21 @@ func (c *Conn) Connect() error {
 	return nil
 }
 
-// Shutdown disconnects from the cluster.
+// Shutdown disconnects from the cluster and releases the cluster handle.
+// It may be called before Connect. Subsequent calls have no effect.
 func (c *Conn) Shutdown() {
-	if err := c.ensureConnected(); err != nil {
-		return
+	runtime.SetFinalizer(c, nil)
+	c.releaseClusterHandle()
+}
+
+// releaseClusterHandle performs the native cleanup shared by explicit
+// shutdown and the garbage-collector fallback.
+func (c *Conn) releaseClusterHandle() {
+	if c.cluster != nil {
+		C.rados_shutdown(c.cluster)
+		c.cluster = nil
 	}
-	freeConn(c)
+	c.connected = false
 }
 
 // ReadConfigFile configures the connection using a Ceph configuration file.

--- a/rados/conn_test.go
+++ b/rados/conn_test.go
@@ -1,0 +1,31 @@
+package rados
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShutdownBeforeConnect(t *testing.T) {
+	conn, err := NewConn()
+	require.NoError(t, err)
+	require.NotNil(t, conn.cluster)
+	require.False(t, conn.connected)
+
+	conn.Shutdown()
+
+	assert.Nil(t, conn.cluster)
+	assert.False(t, conn.connected)
+}
+
+func TestShutdownIsIdempotent(t *testing.T) {
+	conn, err := NewConn()
+	require.NoError(t, err)
+
+	conn.Shutdown()
+	conn.Shutdown()
+
+	assert.Nil(t, conn.cluster)
+	assert.False(t, conn.connected)
+}

--- a/rados/rados.go
+++ b/rados/rados.go
@@ -113,20 +113,13 @@ func NewConnWithClusterAndUser(clusterName string, userName string) (*Conn, erro
 	return conn, nil
 }
 
-// freeConn releases resources that are allocated while configuring the
-// connection to the cluster. rados_shutdown() should only be needed after a
-// successful call to rados_connect(), however if the connection has been
-// configured with non-default parameters, some of the parameters may be
-// allocated before connecting. rados_shutdown() will free the allocated
-// resources, even if there has not been a connection yet.
-//
-// This function is setup as a destructor/finalizer when rados_create() is
-// called.
+// freeConn is a garbage-collector fallback for callers that did not call
+// Shutdown explicitly.
 func freeConn(conn *Conn) {
-	if conn.cluster != nil {
-		log.Warnf("unreachable Conn object has not been shut down. Cleaning up.")
-		C.rados_shutdown(conn.cluster)
-		// prevent calling rados_shutdown() more than once
-		conn.cluster = nil
+	if conn.cluster == nil {
+		return
 	}
+
+	log.Warnf("unreachable Conn object has not been shut down. Cleaning up.")
+	conn.releaseClusterHandle()
 }


### PR DESCRIPTION
## Summary

Make `rados.Conn.Shutdown()` deterministically release its native cluster
handle even when `Connect()` has not succeeded.

Previously, `Shutdown()` returned immediately when the connection was not
marked as connected. A handle allocated by `rados_create()` could therefore
only be released by the Go finalizer after configuration or connection
failure. Because finalizer execution depends on garbage collection, native
resources could remain allocated for an indeterminate amount of time during
repeated failed connection attempts.

The librados `rados_shutdown()` function releases a cluster handle even if it
has not connected successfully. This change allows callers to use `Shutdown()`
for deterministic cleanup in that situation.

## Changes

- Allow `Shutdown()` to release a cluster handle before a successful
  `Connect()`.
- Keep `freeConn()` as fallback cleanup for callers that omit `Shutdown()`.
- Separate garbage-collector fallback handling from native handle release.
- Disable the finalizer after explicit shutdown.
- Clear both the native cluster handle and connected state during release.
- Make subsequent `Shutdown()` calls have no effect.
- Document the updated `Shutdown()` behavior.
- Add tests for shutdown before connecting and repeated shutdown.

Related to #109 and #905.

## Testing

The following checks completed successfully:

```text
go test ./rados -run '^TestShutdown' -count=10
go vet ./rados
sudo make RESULTS_DIR="$PWD/_results" api-update
```

`make api-update` completed without producing tracked API changes.

## Checklist

- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? No; this changes the behavior of an existing API, so a `//go:build ceph_preview` file is not applicable
- [x] Ran `make api-update` to record new APIs