### PR TITLE
rbd: update ListChildren APIs to use WithTries instead of WithSizes

### DIFF
--- a/rbd/snapshot_nautilus.go
+++ b/rbd/snapshot_nautilus.go
@@ -144,7 +144,7 @@ func (image *Image) ListChildren() (pools []string, images []string, err error) 
 		csize    C.size_t
 		children []C.rbd_linked_image_spec_t
 	)
-	retry.WithSizes(16, 4096, func(size int) retry.Hint {
+	retry.WithTries(1024, 16, func(size int) retry.Hint {
 		csize = C.size_t(size)
 		children = make([]C.rbd_linked_image_spec_t, csize)
 		ret := C.rbd_list_children3(
@@ -183,7 +183,7 @@ func (image *Image) ListChildrenAttributes() (imgSpec []ImageSpec, err error) {
 		csize    C.size_t
 		children []C.rbd_linked_image_spec_t
 	)
-	retry.WithSizes(16, 4096, func(size int) retry.Hint {
+	retry.WithTries(1024, 16, func(size int) retry.Hint {
 		csize = C.size_t(size)
 		children = make([]C.rbd_linked_image_spec_t, csize)
 		ret := C.rbd_list_children3(


### PR DESCRIPTION
`ListChildren()` and `ListChildrenAttributes()` listed children via `retry.WithSizes(16, 4096)`, so they could not return more than 4096 images. There is no librbd limit on the number of children an image can have.

Follow the GetTrashList pattern from #1318: use `retry.WithTries(16, 16)` so the size of the array is not capped. The second attempt uses the size hint from `rbd_list_children3`.

Fixes: #1319


<!--
Thank you for opening a pull request. Please provide:

- A clear summary of your changes

- Descriptive and succinct commit messages with the format:
  """
  [topic]: [short description]

  [Longer description]

  Signed-off-by: [Your Name] <[your email]>
  """

  Topic will generally be the go ceph package dir you are working in.

- Ensure checklist items listed below are accounted for
-->

## Checklist
- [ ] Added tests for features and functional changes
- [ ] Public functions and types are documented
- [ ] Standard formatting is applied to Go code
- [ ] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [ ] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
