### PR TITLE
rbd: increase initial array size for GetTrashList to 4k

### DIFF
--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -1028,7 +1028,7 @@ func GetTrashList(ioctx *rados.IOContext) ([]TrashInfo, error) {
 		count   C.size_t
 		entries []C.rbd_trash_image_info_t
 	)
-	retry.WithTries(32, 16, func(size int) retry.Hint {
+	retry.WithTries(4096, 16, func(size int) retry.Hint {
 		count = C.size_t(size)
 		entries = make([]C.rbd_trash_image_info_t, count)
 		ret := C.rbd_trash_list(cephIoctx(ioctx), &entries[0], &count)


### PR DESCRIPTION
As per https://github.com/ceph/go-ceph/pull/1320#discussion_r3814554729 we increase the size of the initial array passed to rbd_trash_list to 4k items. This means many calls will only hit the rbd api once without being too massive right out of the gate.



## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs

New or infrequent contributors may want to review the go-ceph [Developer's Guide](https://github.com/ceph/go-ceph/blob/master/docs/development.md) including the section on how we track [API Status](https://github.com/ceph/go-ceph/blob/master/docs/development.md#api-status) and the [API Stability Plan](https://github.com/ceph/go-ceph/blob/master/docs/api-stability.md).

The go-ceph project uses mergify. View the [mergify command guide](https://docs.mergify.com/commands/#commands) for information on how to interact with mergify. Add a comment with `@Mergifyio` `rebase` to rebase your PR when github indicates that the PR is out of date with the base branch.
