### PR TITLE
github: update mergify rules to support no-API PRs with a second review

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -42,12 +42,19 @@ pull_request_rules:
       - or:
           - and:
               - label=no-API
+              - label!=require-second-review
               - "#approved-reviews-by>=1"
+          - and:
+              - label=no-API
+              - label=require-second-review
+              - "#approved-reviews-by>=2"
           - and:
               - label=API
               - "#approved-reviews-by>=2"
           - and:
-              - label=API
+              - or:
+                - label=API
+                - label=no-API
               - "#approved-reviews-by>=1"
               - "updated-at<5 days ago"
     actions:


### PR DESCRIPTION
Update the mergify rules to support labeling PRs such that we can classify them as no-API (no API changes were made) but that the automatic merge rules would prefer a second (approving) review.

I named the label `with-second-review`. This is based off some names we were bouncing around in slack but I chose to start the name with `with` in order to strongly indicate that this is a modifier, as in: "this follows the rules of a no-API PR with a second review"

Like the `API` label and associated merge rules the 2nd review will be skipped after 5 days.


