### PR TITLE
rgw/admin: fold User.Tenant into the uid on get/modify/remove

### DIFF
--- a/rgw/admin/errors.go
+++ b/rgw/admin/errors.go
@@ -93,6 +93,8 @@ const (
 
 var (
 	errMissingUserID          = errors.New("missing user ID")
+	errTenantMismatch         = errors.New("tenant conflicts with the tenant in the user ID")
+	errTenantWithoutUserID    = errors.New("tenant requires a user ID")
 	errMissingSubuserID       = errors.New("missing subuser ID")
 	errMissingUserAccessKey   = errors.New("missing user access key")
 	errMissingUserDisplayName = errors.New("missing user display name")

--- a/rgw/admin/user.go
+++ b/rgw/admin/user.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // User is GO representation of the json output of a user creation
@@ -28,14 +29,19 @@ type User struct {
 	Type                string         `json:"type"`
 	MfaIds              []interface{}  `json:"mfa_ids"` //revive:disable-line:var-naming old-yet-exported public api
 	KeyType             string         `url:"key-type"`
-	Tenant              string         `url:"tenant"`
-	GenerateKey         *bool          `url:"generate-key"`
-	PurgeData           *int           `url:"purge-data"`
-	GenerateStat        *bool          `url:"stats"`
-	Stat                UserStat       `json:"stats"`
-	UserCaps            string         `url:"user-caps"`
-	AccountID           string         `json:"account_id" url:"account-id"`
-	AccountRoot         *bool          `url:"account-root"`
+	// Tenant is sent as its own "tenant" parameter by CreateUser only.
+	// GetUser, ModifyUser and RemoveUser fold a populated Tenant into the
+	// uid as "tenant$uid"; combining it with an ID that already names a
+	// different tenant is an error. Responses never populate this field:
+	// the combined form is returned in ID.
+	Tenant       string   `url:"tenant"`
+	GenerateKey  *bool    `url:"generate-key"`
+	PurgeData    *int     `url:"purge-data"`
+	GenerateStat *bool    `url:"stats"`
+	Stat         UserStat `json:"stats"`
+	UserCaps     string   `url:"user-caps"`
+	AccountID    string   `json:"account_id" url:"account-id"`
+	AccountRoot  *bool    `url:"account-root"`
 }
 
 // SubuserSpec represents a subusers of a ceph-rgw user
@@ -109,6 +115,27 @@ type UserStat struct {
 	NumObjects  *uint64 `json:"num_objects"`
 }
 
+// withTenantUID returns a copy of u with a populated Tenant folded into
+// ID as "tenant$uid", the combined form RGW resolves tenancy through on
+// every operation. An ID that already names a different tenant is an
+// error, as is a Tenant without any ID (lookup by access key).
+func (u User) withTenantUID() (User, error) {
+	if u.Tenant == "" {
+		return u, nil
+	}
+	if u.ID == "" {
+		return User{}, errTenantWithoutUserID
+	}
+	if i := strings.IndexByte(u.ID, '$'); i >= 0 {
+		if u.ID[:i] != u.Tenant {
+			return User{}, fmt.Errorf("%w: tenant %q, user ID %q", errTenantMismatch, u.Tenant, u.ID)
+		}
+		return u, nil
+	}
+	u.ID = u.Tenant + "$" + u.ID
+	return u, nil
+}
+
 // GetUser retrieves a given object store user
 func (api *API) GetUser(ctx context.Context, user User) (User, error) {
 	if user.ID == "" && len(user.Keys) == 0 {
@@ -120,6 +147,10 @@ func (api *API) GetUser(ctx context.Context, user User) (User, error) {
 				return User{}, errMissingUserAccessKey
 			}
 		}
+	}
+	user, err := user.withTenantUID()
+	if err != nil {
+		return User{}, err
 	}
 
 	//  valid parameters not supported by go-ceph: sync
@@ -182,8 +213,12 @@ func (api *API) RemoveUser(ctx context.Context, user User) error {
 	if user.ID == "" {
 		return errMissingUserID
 	}
+	user, err := user.withTenantUID()
+	if err != nil {
+		return err
+	}
 
-	_, err := api.call(ctx, http.MethodDelete, "/user", valueToURLParams(user, []string{"uid", "purge-data"}))
+	_, err = api.call(ctx, http.MethodDelete, "/user", valueToURLParams(user, []string{"uid", "purge-data"}))
 	if err != nil {
 		return err
 	}
@@ -195,6 +230,10 @@ func (api *API) RemoveUser(ctx context.Context, user User) error {
 func (api *API) ModifyUser(ctx context.Context, user User) (User, error) {
 	if user.ID == "" {
 		return User{}, errMissingUserID
+	}
+	user, err := user.withTenantUID()
+	if err != nil {
+		return User{}, err
 	}
 
 	// valid parameters not supported by go-ceph: system

--- a/rgw/admin/user_test.go
+++ b/rgw/admin/user_test.go
@@ -309,3 +309,132 @@ func returnMockClient() *mockClient {
 		},
 	}
 }
+
+func returnMockClientCaptureQuery(rawQuery *string, response []byte) *mockClient {
+	return &mockClient{
+		mockDo: func(req *http.Request) (*http.Response, error) {
+			*rawQuery = req.URL.RawQuery
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(response)),
+			}, nil
+		},
+	}
+}
+
+func TestUserWithTenantUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      User
+		wantID  string
+		wantErr error
+	}{
+		{"no tenant", User{ID: "user1"}, "user1", nil},
+		{"no tenant with combined ID", User{ID: "tenantA$user1"}, "tenantA$user1", nil},
+		{"tenant folded into bare ID", User{ID: "user1", Tenant: "tenantA"}, "tenantA$user1", nil},
+		{"tenant matching combined ID", User{ID: "tenantA$user1", Tenant: "tenantA"}, "tenantA$user1", nil},
+		{"tenant conflicting with combined ID", User{ID: "tenantB$user1", Tenant: "tenantA"}, "", errTenantMismatch},
+		{"tenant conflicting with explicitly empty tenant", User{ID: "$user1", Tenant: "tenantA"}, "", errTenantMismatch},
+		{"tenant without user ID", User{Tenant: "tenantA"}, "", errTenantWithoutUserID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.in.withTenantUID()
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantID, got.ID)
+		})
+	}
+}
+
+func TestGetUserTenantMockAPI(t *testing.T) {
+	t.Run("tenant folded into uid", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, fakeUserResponse))
+		assert.NoError(t, err)
+		_, err = api.GetUser(context.TODO(), User{ID: "user1", Tenant: "tenantA"})
+		assert.NoError(t, err)
+		assert.Equal(t, "format=json&uid=tenantA%24user1", query)
+	})
+	t.Run("combined uid with matching tenant unchanged", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, fakeUserResponse))
+		assert.NoError(t, err)
+		_, err = api.GetUser(context.TODO(), User{ID: "tenantA$user1", Tenant: "tenantA"})
+		assert.NoError(t, err)
+		assert.Equal(t, "format=json&uid=tenantA%24user1", query)
+	})
+	t.Run("combined uid with conflicting tenant", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, fakeUserResponse))
+		assert.NoError(t, err)
+		_, err = api.GetUser(context.TODO(), User{ID: "tenantB$user1", Tenant: "tenantA"})
+		assert.ErrorIs(t, err, errTenantMismatch)
+		assert.Empty(t, query)
+	})
+	t.Run("tenant with lookup by access key", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, fakeUserResponse))
+		assert.NoError(t, err)
+		_, err = api.GetUser(context.TODO(), User{Tenant: "tenantA", Keys: []UserKeySpec{{AccessKey: "AKIAIOSFODNN7EXAMPLE"}}})
+		assert.ErrorIs(t, err, errTenantWithoutUserID)
+		assert.Empty(t, query)
+	})
+}
+
+func TestModifyUserTenantMockAPI(t *testing.T) {
+	t.Run("tenant folded into uid", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, fakeUserResponse))
+		assert.NoError(t, err)
+		_, err = api.ModifyUser(context.TODO(), User{ID: "user1", Tenant: "tenantA"})
+		assert.NoError(t, err)
+		assert.Equal(t, "format=json&uid=tenantA%24user1", query)
+	})
+	t.Run("combined uid with matching tenant unchanged", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, fakeUserResponse))
+		assert.NoError(t, err)
+		_, err = api.ModifyUser(context.TODO(), User{ID: "tenantA$user1", Tenant: "tenantA"})
+		assert.NoError(t, err)
+		assert.Equal(t, "format=json&uid=tenantA%24user1", query)
+	})
+	t.Run("combined uid with conflicting tenant", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, fakeUserResponse))
+		assert.NoError(t, err)
+		_, err = api.ModifyUser(context.TODO(), User{ID: "tenantB$user1", Tenant: "tenantA"})
+		assert.ErrorIs(t, err, errTenantMismatch)
+		assert.Empty(t, query)
+	})
+}
+
+func TestRemoveUserTenantMockAPI(t *testing.T) {
+	t.Run("tenant folded into uid", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, []byte("")))
+		assert.NoError(t, err)
+		err = api.RemoveUser(context.TODO(), User{ID: "user1", Tenant: "tenantA"})
+		assert.NoError(t, err)
+		assert.Equal(t, "format=json&uid=tenantA%24user1", query)
+	})
+	t.Run("combined uid with matching tenant unchanged", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, []byte("")))
+		assert.NoError(t, err)
+		err = api.RemoveUser(context.TODO(), User{ID: "tenantA$user1", Tenant: "tenantA"})
+		assert.NoError(t, err)
+		assert.Equal(t, "format=json&uid=tenantA%24user1", query)
+	})
+	t.Run("combined uid with conflicting tenant", func(t *testing.T) {
+		var query string
+		api, err := New("127.0.0.1", "accessKey", "secretKey", returnMockClientCaptureQuery(&query, []byte("")))
+		assert.NoError(t, err)
+		err = api.RemoveUser(context.TODO(), User{ID: "tenantB$user1", Tenant: "tenantA"})
+		assert.ErrorIs(t, err, errTenantMismatch)
+		assert.Empty(t, query)
+	})
+}


### PR DESCRIPTION
## Problem

`admin.User.Tenant` appears only in `CreateUser`'s URL-parameter whitelist. On `GetUser`, `ModifyUser` and `RemoveUser` a populated `Tenant` is silently dropped and the call addresses the bare `uid` — the same-named user in the empty tenant. RGW resolves tenancy through the combined uid on every operation, and the Admin Ops documentation declares the two spellings equivalent where the parameter exists: "A `tenant` may either be specified as a part of uid or as an additional request param" (doc/radosgw/adminops.rst, Create User).

Fixes #1323
Related: #1307 (empty values are never transmitted — a different gap in the same encoder; not addressed here)

## Change

`GetUser`/`ModifyUser`/`RemoveUser` now fold a populated `Tenant` into the uid before encoding:

- `ID` without `$` → sends `uid = Tenant + "$" + ID`
- `ID` already `tenant$uid` with the same tenant → unchanged
- `ID` already tenanted with a *different* tenant → error
- `Tenant` set with empty `ID` (GetUser lookup by access key) → error

`CreateUser` is untouched. No signatures change and no new exported symbols are added; the only affected calls are ones that today silently operate on the wrong user — behavior no correct program can rely on.

## Testing

Local, no cluster (librados headers are not installed here; `-tags nautilus` excludes the one rgw/admin test file that imports `rados`):

- `go build ./rgw/...` — ok
- `go vet -tags nautilus ./rgw/admin/` — ok
- `go test -tags nautilus ./rgw/admin/ -skip TestRadosGWTestSuite -v` — PASS (all mock/unit tests, including the new `TestUserWithTenantUID`, `TestGetUserTenantMockAPI`, `TestModifyUserTenantMockAPI`, `TestRemoveUserTenantMockAPI`)
- `revive -config .revive.toml ./rgw/admin/...` (v1.7.0) — clean
- `gofmt -l rgw/` — clean

The `RadosGWTestSuite` integration tests need a live cluster and were not run locally.

Server-side counterpart: https://tracker.ceph.com/issues/79816 proposes RGW itself accept the `tenant` parameter on user info/modify/remove (implementation in ceph/ceph#71301). That change and this one are independent — the combined-uid fold here works against all existing RGW releases.

AI assistance: this change was drafted by an AI agent under my direction and review.

