### PR TITLE
rados: Add ordered omap value getters

### DIFF
--- a/docs/api-status.json
+++ b/docs/api-status.json
@@ -1277,6 +1277,18 @@
         "comment": "Checksum calculates the checksum of the given object data, using one of the supported checksum algorithms.\n\nImplements:\n\n\tint rados_checksum(rados_ioctx_t io,\n\t                   const char *oid,\n\t                   rados_checksum_type_t type,\n\t                   const char *init_value,\n\t                   size_t init_value_len,\n\t                   size_t len,\n\t                   uint64_t off,\n\t                   size_t chunk_size,\n\t                   char *pchecksum,\n\t                   size_t checksum_len);\n",
         "added_in_version": "v0.40.0",
         "expected_stable_version": "v0.42.0"
+      },
+      {
+        "name": "IOContext.GetOmapValuesOrdered",
+        "comment": "GetOmapValuesOrdered fetches a set of keys and their values from an omap and\nreturns them as an ordered slice of OmapKeyValue. Unlike GetOmapValues, which\nreturns an unordered map, the returned slice preserves the key ordering\nprovided by RADOS. This makes it suitable for pagination: the Key of the last\nelement can be passed as `startAfter` in a subsequent call.\n\n`startAfter`: retrieve only the keys after this specified one\n`filterPrefix`: retrieve only the keys beginning with this prefix\n`maxReturn`: retrieve no more than `maxReturn` key/value pairs\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
+      },
+      {
+        "name": "IOContext.GetAllOmapValuesOrdered",
+        "comment": "GetAllOmapValuesOrdered fetches all the keys and their values from an omap and\nreturns them as an ordered slice of OmapKeyValue. Unlike GetAllOmapValues,\nwhich returns an unordered map, the returned slice preserves the key ordering\nprovided by RADOS.\n\n`startAfter`: retrieve only the keys after this specified one\n`filterPrefix`: retrieve only the keys beginning with this prefix\n`iteratorSize`: internal number of keys to fetch during a read operation\n",
+        "added_in_version": "$NEXT_RELEASE",
+        "expected_stable_version": "$NEXT_RELEASE_STABLE"
       }
     ]
   },

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -22,6 +22,8 @@ FSAdmin.PinSubVolumeInGroup | v0.41.0 | v0.43.0 |
 Name | Added in Version | Expected Stable Version | 
 ---- | ---------------- | ----------------------- | 
 IOContext.Checksum | v0.40.0 | v0.42.0 | 
+IOContext.GetOmapValuesOrdered | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
+IOContext.GetAllOmapValuesOrdered | $NEXT_RELEASE | $NEXT_RELEASE_STABLE | 
 
 ## Package: rbd
 

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -152,6 +152,11 @@ func (ioctx *IOContext) ListOmapValues(oid string, startAfter string, filterPref
 // `startAfter`: retrieve only the keys after this specified one
 // `filterPrefix`: retrieve only the keys beginning with this prefix
 // `maxReturn`: retrieve no more than `maxReturn` key/value pairs
+//
+// Note: the returned map is unordered, so the last key needed for `startAfter`
+// based pagination cannot be reliably derived from it. For ordered results
+// suitable for pagination, use ListOmapValues, the GetOmapStep iterator, or
+// GetOmapValuesOrdered.
 func (ioctx *IOContext) GetOmapValues(oid string, startAfter string, filterPrefix string, maxReturn int64) (map[string][]byte, error) {
 	omap := map[string][]byte{}
 
@@ -169,6 +174,9 @@ func (ioctx *IOContext) GetOmapValues(oid string, startAfter string, filterPrefi
 // `startAfter`: retrieve only the keys after this specified one
 // `filterPrefix`: retrieve only the keys beginning with this prefix
 // `iteratorSize`: internal number of keys to fetch during a read operation
+//
+// Note: the returned map is unordered. For ordered results, use
+// GetAllOmapValuesOrdered.
 func (ioctx *IOContext) GetAllOmapValues(oid string, startAfter string, filterPrefix string, iteratorSize int64) (map[string][]byte, error) {
 	omap := map[string][]byte{}
 	omapSize := 0

--- a/rados/omap_ordered.go
+++ b/rados/omap_ordered.go
@@ -1,0 +1,63 @@
+//go:build ceph_preview
+
+package rados
+
+// GetOmapValuesOrdered fetches a set of keys and their values from an omap and
+// returns them as an ordered slice of OmapKeyValue. Unlike GetOmapValues, which
+// returns an unordered map, the returned slice preserves the key ordering
+// provided by RADOS. This makes it suitable for pagination: the Key of the last
+// element can be passed as `startAfter` in a subsequent call.
+//
+// `startAfter`: retrieve only the keys after this specified one
+// `filterPrefix`: retrieve only the keys beginning with this prefix
+// `maxReturn`: retrieve no more than `maxReturn` key/value pairs
+func (ioctx *IOContext) GetOmapValuesOrdered(
+	oid string, startAfter string, filterPrefix string, maxReturn int64,
+) ([]OmapKeyValue, error) {
+	omap := make([]OmapKeyValue, 0)
+
+	err := ioctx.ListOmapValues(
+		oid, startAfter, filterPrefix, maxReturn,
+		func(key string, value []byte) {
+			omap = append(omap, OmapKeyValue{Key: key, Value: value})
+		},
+	)
+
+	return omap, err
+}
+
+// GetAllOmapValuesOrdered fetches all the keys and their values from an omap and
+// returns them as an ordered slice of OmapKeyValue. Unlike GetAllOmapValues,
+// which returns an unordered map, the returned slice preserves the key ordering
+// provided by RADOS.
+//
+// `startAfter`: retrieve only the keys after this specified one
+// `filterPrefix`: retrieve only the keys beginning with this prefix
+// `iteratorSize`: internal number of keys to fetch during a read operation
+func (ioctx *IOContext) GetAllOmapValuesOrdered(
+	oid string, startAfter string, filterPrefix string, iteratorSize int64,
+) ([]OmapKeyValue, error) {
+	omap := make([]OmapKeyValue, 0)
+
+	for {
+		omapSize := len(omap)
+
+		err := ioctx.ListOmapValues(
+			oid, startAfter, filterPrefix, iteratorSize,
+			func(key string, value []byte) {
+				omap = append(omap, OmapKeyValue{Key: key, Value: value})
+				startAfter = key
+			},
+		)
+		if err != nil {
+			return omap, err
+		}
+
+		// End of omap: the last iteration returned no new key/value pairs.
+		if len(omap) == omapSize {
+			break
+		}
+	}
+
+	return omap, nil
+}

--- a/rados/omap_ordered_test.go
+++ b/rados/omap_ordered_test.go
@@ -1,0 +1,118 @@
+//go:build ceph_preview
+
+package rados
+
+import (
+	"sort"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *RadosTestSuite) TestGetOmapValuesOrdered() {
+	suite.SetupConnection()
+
+	orig := map[string][]byte{
+		"key1":          []byte("value1"),
+		"key2":          []byte("value2"),
+		"key3":          []byte("value3"),
+		"prefixed-key4": []byte("value4"),
+		"prefixed-key5": []byte("value5"),
+	}
+
+	oid := suite.GenObjectName()
+	err := suite.ioctx.SetOmap(oid, orig)
+	assert.NoError(suite.T(), err)
+
+	// full ordered fetch
+	fetched, err := suite.ioctx.GetOmapValuesOrdered(oid, "", "", 100)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), fetched, len(orig))
+
+	// results must be sorted by key and match the original values
+	assert.True(suite.T(), sort.SliceIsSorted(fetched, func(i, j int) bool {
+		return fetched[i].Key < fetched[j].Key
+	}), "returned slice must be ordered by key")
+	for _, kv := range fetched {
+		assert.Equal(suite.T(), orig[kv.Key], kv.Value)
+	}
+
+	// filter by prefix
+	fetched, err = suite.ioctx.GetOmapValuesOrdered(oid, "", "prefixed", 100)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []OmapKeyValue{
+		{Key: "prefixed-key4", Value: []byte("value4")},
+		{Key: "prefixed-key5", Value: []byte("value5")},
+	}, fetched)
+
+	// maxReturn caps the number of returned pairs, in order
+	fetched, err = suite.ioctx.GetOmapValuesOrdered(oid, "", "", 2)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []OmapKeyValue{
+		{Key: "key1", Value: []byte("value1")},
+		{Key: "key2", Value: []byte("value2")},
+	}, fetched)
+
+	// startAfter based pagination walks the omap in order without gaps or
+	// overlaps, using the last returned key as the next startAfter.
+	var paged []OmapKeyValue
+	startAfter := ""
+	for {
+		page, err := suite.ioctx.GetOmapValuesOrdered(oid, startAfter, "", 2)
+		assert.NoError(suite.T(), err)
+		if len(page) == 0 {
+			break
+		}
+		paged = append(paged, page...)
+		startAfter = page[len(page)-1].Key
+	}
+	assert.Equal(suite.T(), fetchAllExpected(orig), paged)
+}
+
+func (suite *RadosTestSuite) TestGetAllOmapValuesOrdered() {
+	suite.SetupConnection()
+
+	orig := map[string][]byte{
+		"key1":          []byte("value1"),
+		"key2":          []byte("value2"),
+		"key3":          []byte("value3"),
+		"prefixed-key4": []byte("value4"),
+		"prefixed-key5": []byte("value5"),
+	}
+
+	oid := suite.GenObjectName()
+	err := suite.ioctx.SetOmap(oid, orig)
+	assert.NoError(suite.T(), err)
+
+	expected := fetchAllExpected(orig)
+
+	// iterator size bigger than the map size
+	fetched, err := suite.ioctx.GetAllOmapValuesOrdered(oid, "", "", 100)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), expected, fetched)
+
+	// iterator size smaller than the map size (forces multiple iterations)
+	fetched, err = suite.ioctx.GetAllOmapValuesOrdered(oid, "", "", 2)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), expected, fetched)
+
+	// empty omap returns an empty (non-nil) slice
+	err = suite.ioctx.CleanOmap(oid)
+	assert.NoError(suite.T(), err)
+
+	fetched, err = suite.ioctx.GetAllOmapValuesOrdered(oid, "", "", 100)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), []OmapKeyValue{}, fetched)
+}
+
+// fetchAllExpected returns the given map as a slice of OmapKeyValue sorted by
+// key, matching the ordering that RADOS returns.
+func fetchAllExpected(m map[string][]byte) []OmapKeyValue {
+	out := make([]OmapKeyValue, 0, len(m))
+	for k, v := range m {
+		out = append(out, OmapKeyValue{Key: k, Value: v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Key < out[j].Key
+	})
+	return out
+}


### PR DESCRIPTION
Add _GetOmapValuesOrdered_ and _GetAllOmapValuesOrdered_ which return omap key/value pairs as an ordered `[]OmapKeyValue` slice instead of an unordered `map[string][]byte`.

Since Go maps are unordered, the last key needed for _startAfter_ based pagination cannot be reliably derived from the map returned by the existing _GetOmapValues_/_GetAllOmapValues_`. The new methods preserve the key ordering
provided by RADOS, making them suitable for pagination.

Fixes #1219 

## Checklist
- [x] Added tests for features and functional changes
- [x] Public functions and types are documented
- [x] Standard formatting is applied to Go code
- [x] Is this a new API? Added a new file that begins with `//go:build ceph_preview`
- [x] Ran `make api-update` to record new APIs