### PR TITLE
rados: Reject NUL bytes in `GetOmapValues` arguments

### DIFF
--- a/rados/errors.go
+++ b/rados/errors.go
@@ -26,6 +26,10 @@ var (
 	// ErrOperationIncomplete is returned from write op or read op steps for
 	// which the operation has not been performed yet.
 	ErrOperationIncomplete = errors.New("Operation has not been performed yet")
+	// ErrNulInString is returned when a string argument that is passed to a
+	// NUL-terminated C string contains a NUL byte, which would otherwise be
+	// silently truncated.
+	ErrNulInString = errors.New("string must not contain a NUL byte")
 
 	// ErrNotFound indicates a missing resource.
 	ErrNotFound = getError(-C.ENOENT)

--- a/rados/omap.go
+++ b/rados/omap.go
@@ -37,6 +37,11 @@ type GetOmapStep struct {
 	// canIterate is only set after the operation is performed and is
 	// intended to prevent premature fetching of data
 	canIterate bool
+
+	// err holds a validation error detected before the operation is
+	// performed. When set, it is surfaced from update() and the step
+	// will not iterate.
+	err error
 }
 
 func newGetOmapStep() *GetOmapStep {
@@ -61,6 +66,10 @@ func (gos *GetOmapStep) free() {
 }
 
 func (gos *GetOmapStep) update() error {
+	if gos.err != nil {
+		gos.canIterate = false
+		return gos.err
+	}
 	err := getError(*gos.rval)
 	gos.canIterate = (err == nil)
 	return err

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -924,10 +925,21 @@ func (suite *RadosTestSuite) TestReadWriteOmap() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), orig, fetched)
 
-	// Get All (with an iterator size smaller than the map size)
-	fetched, err = suite.ioctx.GetAllOmapValues(oid, "", "", 2)
+	// Get All (with an iterator size smaller than the map size) exercises
+	// pagination. Use only NUL-free keys so the last key of each page can be
+	// safely fed back as the startAfter cursor; NUL cursors are tested below.
+	nulFree := map[string][]byte{}
+	for k, v := range orig {
+		if !strings.ContainsRune(k, 0) {
+			nulFree[k] = v
+		}
+	}
+	nulFreeOid := suite.GenObjectName()
+	err = suite.ioctx.SetOmap(nulFreeOid, nulFree)
 	assert.NoError(suite.T(), err)
-	assert.Equal(suite.T(), orig, fetched)
+	fetched, err = suite.ioctx.GetAllOmapValues(nulFreeOid, "", "", 2)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), nulFree, fetched)
 
 	// Remove
 	err = suite.ioctx.RmOmapKeys(oid, []string{"key1", "prefixed-key3", "null\x00key4"})

--- a/rados/rados_test.go
+++ b/rados/rados_test.go
@@ -941,6 +941,11 @@ func (suite *RadosTestSuite) TestReadWriteOmap() {
 	assert.NoError(suite.T(), err)
 	assert.Equal(suite.T(), nulFree, fetched)
 
+	// Pagination that feeds a NUL-containing key back as the startAfter
+	// cursor must fail with ErrNulInString rather than truncate it (#1292).
+	_, err = suite.ioctx.GetAllOmapValues(oid, "", "", 2)
+	assert.ErrorIs(suite.T(), err, ErrNulInString)
+
 	// Remove
 	err = suite.ioctx.RmOmapKeys(oid, []string{"key1", "prefixed-key3", "null\x00key4"})
 	assert.NoError(suite.T(), err)

--- a/rados/read_op.go
+++ b/rados/read_op.go
@@ -8,6 +8,8 @@ package rados
 import "C"
 
 import (
+	"fmt"
+	"strings"
 	"unsafe"
 )
 
@@ -50,7 +52,13 @@ func (r *ReadOp) operateCompat(ioctx *IOContext, oid string) error {
 	case nil:
 		return nil
 	case OperationError:
-		return err.OpError
+		// If the op failed, return the bare OpError for backwards
+		// compatibility (e.g. ErrNotFound). Otherwise a step failed, so
+		// return the whole OperationError so it is detectable via errors.Is.
+		if err.OpError != nil {
+			return err.OpError
+		}
+		return err
 	default:
 		return err
 	}
@@ -69,9 +77,24 @@ func (r *ReadOp) AssertExists() {
 // as part of a read operation. An GetOmapStep is returned from this
 // function. The GetOmapStep may be used to iterate over the key-value
 // pairs after the Operate call has been performed.
+//
+// Note that startAfter and filterPrefix are passed to librados as
+// NUL-terminated C strings and therefore must not contain a NUL byte. If
+// either argument contains a NUL byte, the resulting Operate call will
+// return an error wrapping ErrNulInString instead of silently truncating
+// the argument.
 func (r *ReadOp) GetOmapValues(startAfter, filterPrefix string, maxReturn uint64) *GetOmapStep {
 	gos := newGetOmapStep()
 	r.steps = append(r.steps, gos)
+
+	if strings.IndexByte(startAfter, 0) >= 0 {
+		gos.err = fmt.Errorf("startAfter: %w", ErrNulInString)
+		return gos
+	}
+	if strings.IndexByte(filterPrefix, 0) >= 0 {
+		gos.err = fmt.Errorf("filterPrefix: %w", ErrNulInString)
+		return gos
+	}
 
 	cStartAfter := C.CString(startAfter)
 	cFilterPrefix := C.CString(filterPrefix)

--- a/rados/read_op_test.go
+++ b/rados/read_op_test.go
@@ -135,6 +135,32 @@ func (suite *RadosTestSuite) TestReadOpGetOmapValues() {
 		ta.Error(err)
 		ta.Equal(ErrOperationIncomplete, err)
 	})
+
+	suite.T().Run("nulInStartAfter", func(t *testing.T) {
+		// a NUL byte in startAfter must be rejected, not truncated (#1292)
+		ta := assert.New(t)
+		op := CreateReadOp()
+		defer op.Release()
+		op.AssertExists()
+		gos := op.GetOmapValues("tos.captain\x00extra", "", 16)
+		err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+		ta.ErrorIs(err, ErrNulInString)
+		_, nerr := gos.Next()
+		ta.Equal(ErrOperationIncomplete, nerr)
+	})
+
+	suite.T().Run("nulInFilterPrefix", func(t *testing.T) {
+		// a NUL byte in filterPrefix must be rejected, not truncated (#1292)
+		ta := assert.New(t)
+		op := CreateReadOp()
+		defer op.Release()
+		op.AssertExists()
+		gos := op.GetOmapValues("", "tos\x00", 16)
+		err := op.Operate(suite.ioctx, oid, OperationNoFlag)
+		ta.ErrorIs(err, ErrNulInString)
+		_, nerr := gos.Next()
+		ta.Equal(ErrOperationIncomplete, nerr)
+	})
 }
 
 func TestReadOpInvalid(t *testing.T) {

--- a/rados/write_op.go
+++ b/rados/write_op.go
@@ -78,7 +78,13 @@ func (w *WriteOp) operateCompat(ioctx *IOContext, oid string) error {
 	case nil:
 		return nil
 	case OperationError:
-		return err.OpError
+		// If the op failed, return the bare OpError for backwards
+		// compatibility (e.g. ErrNotFound). Otherwise a step failed, so
+		// return the whole OperationError so it is detectable via errors.Is.
+		if err.OpError != nil {
+			return err.OpError
+		}
+		return err
 	default:
 		return err
 	}


### PR DESCRIPTION
_GetOmapValues()_ silently truncated _startAfter_/_filterPrefix_ at NUL bytes, making omap pagination loop forever on binary keys. It now returns an explicit error (`ErrNulInString`) instead of hanging.

fixes #1292 