### PR TITLE
Retry dynamically sized RADOS and RBD operations

### DIFF
--- a/rados/conn.go
+++ b/rados/conn.go
@@ -121,22 +121,22 @@ func (c *Conn) OpenIOContext(pool string) (*IOContext, error) {
 
 // ListPools returns the names of all existing pools.
 func (c *Conn) ListPools() (names []string, err error) {
-	buf := make([]byte, 4096)
-	for {
-		ret := C.rados_pool_list(c.cluster,
+	var (
+		buf []byte
+		ret C.int
+	)
+	retry.WithTries(4096, 16, func(size int) retry.Hint {
+		buf = make([]byte, size)
+		ret = C.rados_pool_list(c.cluster,
 			(*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
-		if ret < 0 {
-			return nil, getError(ret)
-		}
-
-		if int(ret) > len(buf) {
-			buf = make([]byte, ret)
-			continue
-		}
-
-		names = cutil.SplitSparseBuffer(buf[:ret])
-		return names, nil
+		err = getErrorIfNegative(ret)
+		return retry.Size(int(ret)).If(err == nil && int(ret) > size)
+	})
+	if err != nil {
+		return nil, err
 	}
+	names = cutil.SplitSparseBuffer(buf[:ret])
+	return names, nil
 }
 
 // SetConfigOption sets the value of the configuration option identified by

--- a/rados/conn.go
+++ b/rados/conn.go
@@ -310,14 +310,23 @@ func (c *Conn) GetPoolByName(name string) (int64, error) {
 
 // GetPoolByID returns the name of a pool by a given ID.
 func (c *Conn) GetPoolByID(id int64) (string, error) {
-	buf := make([]byte, 4096)
 	if err := c.ensureConnected(); err != nil {
 		return "", err
 	}
 	cid := C.int64_t(id)
-	ret := C.rados_pool_reverse_lookup(c.cluster, cid, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
-	if ret < 0 {
-		return "", getError(ret)
+	var (
+		buf []byte
+		err error
+	)
+	retry.WithSizes(4096, 1<<18, func(size int) retry.Hint {
+		buf = make([]byte, size)
+		ret := C.rados_pool_reverse_lookup(
+			c.cluster, cid, (*C.char)(unsafe.Pointer(&buf[0])), C.size_t(len(buf)))
+		err = getErrorIfNegative(ret)
+		return retry.DoubleSize.If(err == errRange)
+	})
+	if err != nil {
+		return "", err
 	}
 	return C.GoString((*C.char)(unsafe.Pointer(&buf[0]))), nil
 }

--- a/rbd/mirror_nautilus.go
+++ b/rbd/mirror_nautilus.go
@@ -12,6 +12,7 @@ import "C"
 import (
 	"unsafe"
 
+	"github.com/ceph/go-ceph/internal/retry"
 	"github.com/ceph/go-ceph/rados"
 )
 
@@ -130,24 +131,21 @@ type MirrorPeerInfo struct {
 //	 												 rbd_mirror_peer_list_t *peers,
 //											 			 int *max_peers);
 func MirrorPeerList(ioctx *rados.IOContext) ([]*MirrorPeerInfo, error) {
-	var mpi []*MirrorPeerInfo
-	cMaxPeers := C.int(5)
-
-	var cPeers []C.rbd_mirror_peer_t
-	for {
+	var (
+		mpi       []*MirrorPeerInfo
+		cMaxPeers C.int
+		cPeers    []C.rbd_mirror_peer_t
+		err       error
+	)
+	retry.WithTries(5, 16, func(maxPeers int) retry.Hint {
+		cMaxPeers = C.int(maxPeers)
 		cPeers = make([]C.rbd_mirror_peer_t, cMaxPeers)
 		ret := C.rbd_mirror_peer_list(cephIoctx(ioctx), &cPeers[0], &cMaxPeers)
-		if ret == -C.ERANGE {
-			// There are too many peers to fit in the list, and the number of peers has been
-			// returned in cMaxPeers. Try again with the returned value.
-			continue
-		}
-		if ret != 0 {
-			return nil, getError(ret)
-		}
-
-		// ret == 0
-		break
+		err = getError(ret)
+		return retry.Size(int(cMaxPeers)).If(err == errRange)
+	})
+	if err != nil {
+		return nil, err
 	}
 	defer C.rbd_mirror_peer_list_cleanup(&cPeers[0], cMaxPeers)
 	cPeers = cPeers[:cMaxPeers]

--- a/rbd/mirror_peer_site.go
+++ b/rbd/mirror_peer_site.go
@@ -165,25 +165,21 @@ type MirrorPeerSite struct {
 //
 //	int rbd_mirror_peer_site_list(rados_ioctx_t p, rbd_mirror_peer_site_t *peers, int *max_peers)
 func ListMirrorPeerSite(ioctx *rados.IOContext) ([]*MirrorPeerSite, error) {
-	var mps []*MirrorPeerSite
-	cMaxPeers := C.int(10)
-
-	var cSites []C.rbd_mirror_peer_site_t
-	for {
+	var (
+		mps       []*MirrorPeerSite
+		cMaxPeers C.int
+		cSites    []C.rbd_mirror_peer_site_t
+		err       error
+	)
+	retry.WithTries(10, 16, func(maxPeers int) retry.Hint {
+		cMaxPeers = C.int(maxPeers)
 		cSites = make([]C.rbd_mirror_peer_site_t, cMaxPeers)
 		ret := C.rbd_mirror_peer_site_list(cephIoctx(ioctx), &cSites[0], &cMaxPeers)
-		err := getError(ret)
-		if err == errRange {
-			// There are too many peer sites to fit in the list, and the number of peer sites has been
-			// returned in cMaxPeers. Try again with the returned value.
-			continue
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		// ret == 0
-		break
+		err = getError(ret)
+		return retry.Size(int(cMaxPeers)).If(err == errRange)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	defer C.rbd_mirror_peer_site_list_cleanup(&cSites[0], cMaxPeers)

--- a/rbd/options.go
+++ b/rbd/options.go
@@ -1,6 +1,7 @@
 package rbd
 
 // #cgo LDFLAGS: -lrbd
+// #include <errno.h>
 // #include <stdlib.h>
 // #include <rbd/librbd.h>
 import "C"
@@ -8,6 +9,8 @@ import "C"
 import (
 	"fmt"
 	"unsafe"
+
+	"github.com/ceph/go-ceph/internal/retry"
 )
 
 const (
@@ -142,11 +145,17 @@ func (rio *ImageOptions) SetString(option ImageOption, value string) error {
 //	int rbd_image_options_get_string(rbd_image_options_t opts, int optname,
 //	        char* optval, size_t maxlen);
 func (rio *ImageOptions) GetString(option ImageOption) (string, error) {
-	value := make([]byte, 4096)
-
-	ret := C.rbd_image_options_get_string(rio.options, C.int(option),
-		(*C.char)(unsafe.Pointer(&value[0])),
-		C.size_t(len(value)))
+	var (
+		value []byte
+		ret   C.int
+	)
+	retry.WithSizes(4096, 1<<18, func(size int) retry.Hint {
+		value = make([]byte, size)
+		ret = C.rbd_image_options_get_string(rio.options, C.int(option),
+			(*C.char)(unsafe.Pointer(&value[0])),
+			C.size_t(len(value)))
+		return retry.DoubleSize.If(ret == -C.E2BIG)
+	})
 	if ret != 0 {
 		return "", fmt.Errorf("%v, could not get option %v", getError(ret), option)
 	}

--- a/rbd/options_test.go
+++ b/rbd/options_test.go
@@ -1,8 +1,10 @@
 package rbd
 
 import (
-	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRbdOptions(t *testing.T) {
@@ -165,13 +167,14 @@ func TestRbdOptions(t *testing.T) {
 
 	err = options.SetUint64(ImageOptionDataPool, 1)
 	assert.Error(t, err)
-	err = options.SetString(ImageOptionDataPool, "data")
+	dataPool := strings.Repeat("data", 1025)
+	err = options.SetString(ImageOptionDataPool, dataPool)
 	assert.NoError(t, err)
 	_, err = options.GetUint64(ImageOptionDataPool)
 	assert.Error(t, err)
 	s, err = options.GetString(ImageOptionDataPool)
 	assert.NoError(t, err)
-	assert.True(t, s == "data")
+	assert.Equal(t, dataPool, s)
 	set, err = options.IsSet(ImageOptionDataPool)
 	assert.NoError(t, err)
 	assert.True(t, set)

--- a/rbd/rbd.go
+++ b/rbd/rbd.go
@@ -942,30 +942,30 @@ func (image *Image) GetSnapshotNames() (snaps []SnapInfo, err error) {
 		return nil, err
 	}
 
-	var cMaxSnaps C.int
-
-	ret := C.rbd_snap_list(image.image, nil, &cMaxSnaps)
-	// bugfix index out of range(&cSnaps[0])
-	if cMaxSnaps < 1 {
-		return nil, getError(ret)
+	var (
+		cMaxSnaps C.int
+		cSnaps    []C.rbd_snap_info_t
+		ret       C.int
+	)
+	retry.WithTries(1, 16, func(size int) retry.Hint {
+		cMaxSnaps = C.int(size)
+		cSnaps = make([]C.rbd_snap_info_t, cMaxSnaps)
+		ret = C.rbd_snap_list(image.image, &cSnaps[0], &cMaxSnaps)
+		err = getErrorIfNegative(ret)
+		return retry.Size(int(cMaxSnaps)).If(err == errRange)
+	})
+	if err != nil {
+		return nil, err
 	}
-	cSnaps := make([]C.rbd_snap_info_t, cMaxSnaps)
-	snaps = make([]SnapInfo, cMaxSnaps)
+	defer C.rbd_snap_list_end(&cSnaps[0])
 
-	ret = C.rbd_snap_list(image.image,
-		&cSnaps[0], &cMaxSnaps)
-	if ret < 0 {
-		return nil, getError(ret)
-	}
-
-	for i, s := range cSnaps {
+	snaps = make([]SnapInfo, ret)
+	for i, s := range cSnaps[:ret] {
 		snaps[i] = SnapInfo{Id: uint64(s.id),
 			Size: uint64(s.size),
 			Name: C.GoString(s.name)}
 	}
-
-	C.rbd_snap_list_end(&cSnaps[0])
-	return snaps[:len(snaps)-1], nil
+	return snaps, nil
 }
 
 // GetId returns the internal image ID string.

--- a/rbd/rbd_nautilus.go
+++ b/rbd/rbd_nautilus.go
@@ -13,28 +13,30 @@ import "C"
 import (
 	"unsafe"
 
+	"github.com/ceph/go-ceph/internal/retry"
 	ts "github.com/ceph/go-ceph/internal/timespec"
 	"github.com/ceph/go-ceph/rados"
 )
 
 // GetImageNames returns the list of current RBD images.
 func GetImageNames(ioctx *rados.IOContext) ([]string, error) {
-	var images []C.rbd_image_spec_t
-	size := C.size_t(4096)
-	for {
+	var (
+		images []C.rbd_image_spec_t
+		size   C.size_t
+		err    error
+	)
+	retry.WithTries(4096, 16, func(maxImages int) retry.Hint {
+		size = C.size_t(maxImages)
 		images = make([]C.rbd_image_spec_t, size)
 		ret := C.rbd_list2(
 			cephIoctx(ioctx),
 			(*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])),
 			&size)
-		err := getErrorIfNegative(ret)
-		if err != nil {
-			if err == errRange {
-				continue
-			}
-			return nil, err
-		}
-		break
+		err = getErrorIfNegative(ret)
+		return retry.Size(int(size)).If(err == errRange)
+	})
+	if err != nil {
+		return nil, err
 	}
 	defer C.rbd_image_spec_list_cleanup((*C.rbd_image_spec_t)(unsafe.Pointer(&images[0])), size)
 


### PR DESCRIPTION
Apply the common retry helpers to dynamically sized image options, pool name lookups, snapshot listings, pool and image listings, and mirror peer listings. This prevents fixed-buffer failures, handles concurrent list growth, and replaces unbounded manual resize loops with bounded retries.


depends on #1335 
fixes #185 