### PR TITLE
common/admin/osd: Parse new blocklist JSON format

### DIFF
--- a/common/admin/osd/osd_blocklist.go
+++ b/common/admin/osd/osd_blocklist.go
@@ -26,6 +26,11 @@ type networkList struct {
 	Until   expireTime `json:"until"`
 }
 
+type blocklistInfo struct {
+	Blocklist      []ipList      `json:"blocklist"`
+	RangeBlocklist []networkList `json:"range_blocklist"`
+}
+
 func (et *expireTime) UnmarshalText(data []byte) error {
 	t, err := time.Parse(layout, string(data))
 	if err != nil {
@@ -49,6 +54,25 @@ type Blocklist struct {
 
 func parseBlocklist(res response) (*[]Blocklist, error) {
 	var bl []Blocklist
+
+	// Newer monitors return proper JSON; fall back for older monitors.
+	var info blocklistInfo
+	if err := json.Unmarshal(res.Body(), &info); err == nil {
+		for _, i := range info.Blocklist {
+			bl = append(bl, Blocklist{
+				Addr:  i.IPAddr,
+				Until: i.Until.Time(),
+			})
+		}
+		for _, n := range info.RangeBlocklist {
+			bl = append(bl, Blocklist{
+				Addr:  n.Network,
+				Until: n.Until.Time(),
+			})
+		}
+
+		return &bl, nil
+	}
 
 	dec := json.NewDecoder(bytes.NewReader(res.Body()))
 

--- a/common/admin/osd/osd_blocklist_test.go
+++ b/common/admin/osd/osd_blocklist_test.go
@@ -9,7 +9,38 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ceph/go-ceph/internal/commands"
 )
+
+func TestParseBlocklist(t *testing.T) {
+	const (
+		ipUntil      = "2026-09-06T12:34:56.000000+0000"
+		rangeUntil   = "2026-09-07T12:34:56.000000+0000"
+		ipEntry      = `{"addr":"192.0.2.1:0/0","until":"` + ipUntil + `"}`
+		rangeEntry   = `{"range":"198.51.100.0/24","until":"` + rangeUntil + `"}`
+		legacyFormat = `[` + ipEntry + `][` + rangeEntry + `]`
+		newFormat    = `{"blocklist":[` + ipEntry + `],"range_blocklist":[` + rangeEntry + `]}`
+	)
+
+	ipTime, err := time.Parse(layout, ipUntil)
+	assert.NoError(t, err)
+	rangeTime, err := time.Parse(layout, rangeUntil)
+	assert.NoError(t, err)
+
+	want := []Blocklist{
+		{Addr: "192.0.2.1:0/0", Until: ipTime},
+		{Addr: "198.51.100.0/24", Until: rangeTime},
+	}
+
+	got, err := parseBlocklist(commands.NewResponse([]byte(legacyFormat), "", nil))
+	assert.NoError(t, err)
+	assert.Equal(t, &want, got)
+
+	got, err = parseBlocklist(commands.NewResponse([]byte(newFormat), "", nil))
+	assert.NoError(t, err)
+	assert.Equal(t, &want, got)
+}
 
 func (suite *OSDAdminSuite) TestOSDBlocklist() {
 	osda := NewFromConn(suite.vconn.Get(suite.T()))


### PR DESCRIPTION
With recently merged [changes](https://github.com/ceph/ceph/pull/65681), ceph monitors return both blocklist types in one JSON object. Decode that format while retaining the legacy response fallback.

fixes #1334 